### PR TITLE
Enable public solicitud flow

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/config/SecurityConfig.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/config/SecurityConfig.java
@@ -69,10 +69,27 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 
                         .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/personas/dni/**",
+                                "/api/personas/*",
+                                "/api/aspirantes/*",
+                                "/api/familiares/*"
+                        ).permitAll()
+
+                        .requestMatchers(
                                 HttpMethod.POST,
+                                "/api/personas",
+                                "/api/familiares",
                                 "/api/aspirantes",
-                                "/api/aspirant-familiar",
+                                "/api/aspirante-familiar",
                                 "/api/solicitudes-admision"
+                        ).permitAll()
+
+                        .requestMatchers(
+                                HttpMethod.PUT,
+                                "/api/personas/*",
+                                "/api/familiares/*",
+                                "/api/aspirantes/*"
                         ).permitAll()
 
                         .requestMatchers("/api/**").authenticated()

--- a/backend-ecep/src/main/java/edu/ecep/base_app/dtos/AspiranteFamiliarDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/dtos/AspiranteFamiliarDTO.java
@@ -12,4 +12,5 @@ public class AspiranteFamiliarDTO {
     Long aspiranteId;
     Long familiarId;
     String parentesco;
+    Boolean convive;
 }

--- a/frontend-ecep/src/app/page.tsx
+++ b/frontend-ecep/src/app/page.tsx
@@ -241,7 +241,7 @@ export default function LoginPage() {
                   </div>
                 </div>
 
-                <Link href="/postulacion">
+                <Link href="/solicitud">
                   <Button variant="outline" className="w-full">
                     <Users className="h-4 w-4 mr-2" />
                     ¿Querés postularte como alumno? Ingresá acá

--- a/frontend-ecep/src/app/postulacion/Step1.tsx
+++ b/frontend-ecep/src/app/postulacion/Step1.tsx
@@ -17,7 +17,11 @@ import { cn } from "@/lib/utils";
 
 interface Props {
   formData: PostulacionFormData;
-  handleInputChange: (field: string, value: any) => void;
+  handleInputChange: (
+    field: string,
+    value: any,
+    options?: { errorKeys?: string | string[] },
+  ) => void;
   errors: Record<string, boolean>;
   personaDetectadaId?: number | null;
   dniLookupLoading?: boolean;

--- a/frontend-ecep/src/app/postulacion/Step2.tsx
+++ b/frontend-ecep/src/app/postulacion/Step2.tsx
@@ -15,11 +15,16 @@ import {
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
+import { RolVinculo } from "@/types/api-generated";
 import type { PostulacionFormData } from "./types";
 
 interface Step2Props {
   formData: PostulacionFormData;
-  handleInputChange: (field: string, value: any) => void;
+  handleInputChange: (
+    field: string,
+    value: any,
+    options?: { errorKeys?: string | string[] },
+  ) => void;
   addFamiliar: () => void;
   errors?: Record<string, boolean>;
 }
@@ -31,6 +36,12 @@ export function Step2({
   errors = {},
 }: Step2Props) {
   const familiares = formData.familiares ?? [];
+  const relationshipOptions: { value: RolVinculo; label: string }[] = [
+    { value: RolVinculo.PADRE, label: "Padre" },
+    { value: RolVinculo.MADRE, label: "Madre" },
+    { value: RolVinculo.TUTOR, label: "Tutor/a" },
+    { value: RolVinculo.OTRO, label: "Otro/a" },
+  ];
 
   return (
     <div className="space-y-4">
@@ -57,6 +68,12 @@ export function Step2({
         </p>
       )}
 
+      {errors.familiares && (
+        <p className="text-sm text-destructive">
+          Agregá al menos un familiar con sus datos completos.
+        </p>
+      )}
+
       {/* ——— Lista de Formularios de cada Familiar ——— */}
       <div className="space-y-6">
         {familiares.map((f, i) => (
@@ -75,6 +92,7 @@ export function Step2({
                       familiares.map((x, j) =>
                         j === i ? { ...x, tipoRelacion: v as string } : x,
                       ),
+                      { errorKeys: [`familiares.${i}.tipoRelacion`] },
                     )
                   }
                   className={cn(
@@ -86,11 +104,11 @@ export function Step2({
                     <SelectValue placeholder="Seleccione relación" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="PADRE">Padre</SelectItem>
-                    <SelectItem value="MADRE">Madre</SelectItem>
-                    <SelectItem value="TUTOR">Tutor</SelectItem>
-                    <SelectItem value="ABUELO">Abuelo</SelectItem>
-                    <SelectItem value="ABUELA">Abuela</SelectItem>
+                    {relationshipOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -115,6 +133,7 @@ export function Step2({
                             }
                           : x,
                       ),
+                      { errorKeys: [`familiares.${i}.familiar.nombre`] },
                     )
                   }
                   placeholder="Nombre"
@@ -145,6 +164,7 @@ export function Step2({
                             }
                           : x,
                       ),
+                      { errorKeys: [`familiares.${i}.familiar.apellido`] },
                     )
                   }
                   placeholder="Apellido"
@@ -180,6 +200,7 @@ export function Step2({
                             }
                           : x,
                       ),
+                      { errorKeys: [`familiares.${i}.familiar.dni`] },
                     )
                   }
                   placeholder="12345678"
@@ -213,6 +234,7 @@ export function Step2({
                             }
                           : x,
                       ),
+                      { errorKeys: [`familiares.${i}.familiar.fechaNacimiento`] },
                     )
                   }
                   className={cn(
@@ -243,6 +265,7 @@ export function Step2({
                             }
                           : x,
                       ),
+                      { errorKeys: [`familiares.${i}.familiar.emailContacto`] },
                     )
                   }
                   placeholder="email@dominio.com"

--- a/frontend-ecep/src/app/postulacion/Step3.tsx
+++ b/frontend-ecep/src/app/postulacion/Step3.tsx
@@ -13,6 +13,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import type { PostulacionFormData } from "./types";
 
 enum InternetConnectivity {
@@ -24,10 +25,15 @@ enum InternetConnectivity {
 
 interface Step3Props {
   formData: PostulacionFormData;
-  handleInputChange: (field: string, value: any) => void;
+  handleInputChange: (
+    field: string,
+    value: any,
+    options?: { errorKeys?: string | string[] },
+  ) => void;
+  errors?: Record<string, boolean>;
 }
 
-export function Step3({ formData, handleInputChange }: Step3Props) {
+export function Step3({ formData, handleInputChange, errors = {} }: Step3Props) {
   return (
     <div className="space-y-4">
       <div className="flex items-center mb-6">
@@ -45,7 +51,11 @@ export function Step3({ formData, handleInputChange }: Step3Props) {
             onValueChange={(v) => handleInputChange("conectividadInternet", v)}
             required
           >
-            <SelectTrigger>
+            <SelectTrigger
+              className={cn(
+                errors.conectividadInternet && "border-destructive",
+              )}
+            >
               <SelectValue placeholder="Seleccione conexión" />
             </SelectTrigger>
             <SelectContent>
@@ -71,6 +81,9 @@ export function Step3({ formData, handleInputChange }: Step3Props) {
             placeholder="Ej: PC, tablet, smartphone..."
             rows={3}
             required
+            className={cn(
+              errors.dispositivosDisponibles && "border-destructive",
+            )}
           />
         </div>
 
@@ -86,6 +99,9 @@ export function Step3({ formData, handleInputChange }: Step3Props) {
             }
             placeholder="Ej: Español, Inglés..."
             required
+            className={cn(
+              errors.idiomasHabladosHogar && "border-destructive",
+            )}
           />
         </div>
       </div>

--- a/frontend-ecep/src/app/postulacion/Step4.tsx
+++ b/frontend-ecep/src/app/postulacion/Step4.tsx
@@ -11,7 +11,11 @@ import type { PostulacionFormData } from "./types";
 
 interface Step4Props {
   formData: PostulacionFormData;
-  handleInputChange: (field: string, value: any) => void;
+  handleInputChange: (
+    field: string,
+    value: any,
+    options?: { errorKeys?: string | string[] },
+  ) => void;
 }
 
 export function Step4({ formData, handleInputChange }: Step4Props) {

--- a/frontend-ecep/src/app/solicitud/page.tsx
+++ b/frontend-ecep/src/app/solicitud/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../postulacion/page";


### PR DESCRIPTION
## Summary
- expose the postulacion flow at /solicitud so the public link matches the requested URL
- update the landing page CTA to point to the new /solicitud route
- expand backend security rules so personas, familiares, aspirantes and solicitud creation APIs are reachable from the public form (fixing the aspirante-familiar typo)

## Testing
- bun install *(fails: npm registry returned HTTP 403)*
- bun lint *(fails: `next` binary missing because dependencies could not be installed)*
- bash ./mvnw test -q *(fails: Maven wrapper download blocked by HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3a0b15788327a1c2e0172c7900b4