### PR TITLE
Add direction configuration dialog in dashboard

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/PeriodoEscolarController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/PeriodoEscolarController.java
@@ -28,4 +28,16 @@ public class PeriodoEscolarController {
         Long id = service.create(dto);
         return new ResponseEntity<>(id, HttpStatus.CREATED);
     }
+
+    @PostMapping("/{id}/cerrar")
+    public ResponseEntity<Void> cerrar(@PathVariable Long id) {
+        service.cerrar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/abrir")
+    public ResponseEntity<Void> abrir(@PathVariable Long id) {
+        service.abrir(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/PeriodoEscolarService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/PeriodoEscolarService.java
@@ -8,6 +8,7 @@ import edu.ecep.base_app.util.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,6 +19,20 @@ public class PeriodoEscolarService {
     public List<PeriodoEscolarDTO> findAll(){ return repo.findAll(Sort.by("anio")).stream().map(mapper::toDto).toList(); }
     public PeriodoEscolarDTO get(Long id){ return repo.findById(id).map(mapper::toDto).orElseThrow(() -> new NotFoundException("No encontrado")); }
     public Long create(PeriodoEscolarCreateDTO dto){ if(repo.existsByAnio(dto.getAnio())) throw new IllegalArgumentException("Ya existe periodo para ese año"); return repo.save(mapper.toEntity(dto)).getId(); }
+
+    @Transactional
+    public void cerrar(Long id){
+        var periodo = repo.findById(id).orElseThrow(() -> new NotFoundException("No encontrado"));
+        periodo.setActivo(false);
+        repo.save(periodo);
+    }
+
+    @Transactional
+    public void abrir(Long id){
+        var periodo = repo.findById(id).orElseThrow(() -> new NotFoundException("No encontrado"));
+        periodo.setActivo(true);
+        repo.save(periodo);
+    }
 }
 
 

--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -1,0 +1,557 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { api } from "@/services/api";
+import type { PeriodoEscolarDTO, TrimestreDTO } from "@/types/api-generated";
+import { UserRole } from "@/types/api-generated";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+
+interface ConfiguracionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentRole: UserRole | null;
+  roles: UserRole[];
+}
+
+const toDateInput = (value?: string | null) => {
+  if (!value) return "";
+  return value.slice(0, 10);
+};
+
+const resolvePeriodoId = (t: TrimestreDTO, fallback?: number | null) =>
+  t.periodoEscolarId ??
+  (t as any).periodoId ??
+  (t as any).periodoEscolar?.id ??
+  fallback ??
+  undefined;
+
+const getTriInicio = (t: TrimestreDTO) =>
+  toDateInput(
+    t.inicio ??
+      (t as any).fechaInicio ??
+      (t as any).inicio ??
+      (t as any).fecha_inicio ??
+      null,
+  );
+
+const getTriFin = (t: TrimestreDTO) =>
+  toDateInput(
+    t.fin ??
+      (t as any).fechaFin ??
+      (t as any).fin ??
+      (t as any).fecha_fin ??
+      null,
+  );
+
+const resolveErrorMessage = (error: unknown, fallback: string) => {
+  if (!error) return fallback;
+  if (typeof error === "string") return error;
+  if (error instanceof Error && error.message) return error.message;
+  if (
+    typeof error === "object" &&
+    "response" in error &&
+    error.response &&
+    typeof (error as any).response === "object"
+  ) {
+    const data = (error as any).response?.data;
+    if (typeof data === "string") return data;
+    if (data && typeof data.message === "string") return data.message;
+  }
+  return fallback;
+};
+
+export function ConfiguracionDialog({
+  open,
+  onOpenChange,
+  currentRole,
+  roles,
+}: ConfiguracionDialogProps) {
+  const tieneDireccion = roles.includes(UserRole.DIRECTOR);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Configuración</DialogTitle>
+          <DialogDescription>
+            Administrá las preferencias disponibles para tu rol actual.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {tieneDireccion ? (
+            currentRole === UserRole.DIRECTOR ? (
+              <DireccionConfig open={open} />
+            ) : (
+              <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+                Seleccioná el rol <strong>Dirección</strong> para acceder a la
+                configuración institucional.
+              </div>
+            )
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No hay configuraciones disponibles para tu rol actual.
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface DireccionConfigProps {
+  open: boolean;
+}
+
+type TrimestreDraft = {
+  inicio: string;
+  fin: string;
+};
+
+function DireccionConfig({ open }: DireccionConfigProps) {
+  const [loading, setLoading] = useState(false);
+  const [periodos, setPeriodos] = useState<PeriodoEscolarDTO[]>([]);
+  const [trimestres, setTrimestres] = useState<TrimestreDTO[]>([]);
+  const [drafts, setDrafts] = useState<Record<number, TrimestreDraft>>({});
+  const [savingTrimestreId, setSavingTrimestreId] = useState<number | null>(null);
+  const [togglingTrimestreId, setTogglingTrimestreId] =
+    useState<number | null>(null);
+  const [closingPeriodo, setClosingPeriodo] = useState(false);
+  const [openingPeriodo, setOpeningPeriodo] = useState(false);
+  const [creatingPeriodo, setCreatingPeriodo] = useState(false);
+  const [nuevoPeriodo, setNuevoPeriodo] = useState<{ anio: string }>({
+    anio: "",
+  });
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [perRes, triRes] = await Promise.all([
+        api.periodos.list(),
+        api.trimestres.list(),
+      ]);
+      const per = (perRes.data ?? []) as PeriodoEscolarDTO[];
+      const tri = (triRes.data ?? []) as TrimestreDTO[];
+      setPeriodos(per);
+      setTrimestres(tri);
+
+      const maxYear = per.reduce(
+        (max, p) => Math.max(max, p.anio ?? 0),
+        0,
+      );
+      const currentYear = new Date().getFullYear();
+      const suggestedYear = per.length
+        ? Math.max(maxYear + 1, currentYear)
+        : currentYear;
+      setNuevoPeriodo((prev) => ({
+        ...prev,
+        anio: prev.anio || String(suggestedYear),
+      }));
+    } catch (error) {
+      toast.error(
+        resolveErrorMessage(
+          error,
+          "No se pudo cargar el calendario escolar",
+        ),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      loadData();
+    }
+  }, [open, loadData]);
+
+  const periodoActual = useMemo(() => {
+    if (!periodos.length) return null;
+    const activo = periodos.find((p) => p.activo !== false);
+    if (activo) return activo;
+    return [...periodos]
+      .sort((a, b) => (b.anio ?? 0) - (a.anio ?? 0))
+      .at(0) ?? null;
+  }, [periodos]);
+
+  const trimestresPeriodo = useMemo(() => {
+    if (!periodoActual?.id) return [];
+    return trimestres.filter((t) => {
+      const periodoId = resolvePeriodoId(t);
+      return periodoId === periodoActual.id;
+    });
+  }, [periodoActual, trimestres]);
+
+  useEffect(() => {
+    const next: Record<number, TrimestreDraft> = {};
+    for (const t of trimestresPeriodo) {
+      next[t.id] = {
+        inicio: getTriInicio(t),
+        fin: getTriFin(t),
+      };
+    }
+    setDrafts(next);
+  }, [trimestresPeriodo]);
+
+  const handleDraftChange = (
+    id: number,
+    field: keyof TrimestreDraft,
+    value: string,
+  ) => {
+    setDrafts((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        [field]: value,
+      },
+    }));
+  };
+
+  const handleResetTrimestre = (tri: TrimestreDTO) => {
+    setDrafts((prev) => ({
+      ...prev,
+      [tri.id]: {
+        inicio: getTriInicio(tri),
+        fin: getTriFin(tri),
+      },
+    }));
+  };
+
+  const hasChanges = (tri: TrimestreDTO) => {
+    const draft = drafts[tri.id];
+    if (!draft) return false;
+    return (
+      draft.inicio !== getTriInicio(tri) || draft.fin !== getTriFin(tri)
+    );
+  };
+
+  const handleSaveTrimestre = async (tri: TrimestreDTO) => {
+    const draft = drafts[tri.id];
+    if (!draft) return;
+    if (!draft.inicio || !draft.fin) {
+      toast.error("Completá las fechas desde y hasta del trimestre");
+      return;
+    }
+    if (draft.inicio > draft.fin) {
+      toast.error("La fecha de inicio no puede ser posterior a la de fin");
+      return;
+    }
+
+    try {
+      setSavingTrimestreId(tri.id);
+      await api.trimestres.update(tri.id, {
+        periodoEscolarId: resolvePeriodoId(tri, periodoActual?.id),
+        orden: tri.orden,
+        inicio: draft.inicio,
+        fin: draft.fin,
+      });
+      toast.success("Fechas del trimestre actualizadas");
+      await loadData();
+    } catch (error) {
+      toast.error(
+        resolveErrorMessage(error, "No se pudieron guardar los cambios"),
+      );
+    } finally {
+      setSavingTrimestreId(null);
+    }
+  };
+
+  const handleToggleTrimestre = async (tri: TrimestreDTO) => {
+    try {
+      setTogglingTrimestreId(tri.id);
+      if (tri.cerrado) {
+        await api.trimestres.reabrir(tri.id);
+        toast.success("Trimestre reabierto");
+      } else {
+        await api.trimestres.cerrar(tri.id);
+        toast.success("Trimestre cerrado");
+      }
+      await loadData();
+    } catch (error) {
+      toast.error(
+        resolveErrorMessage(
+          error,
+          "No se pudo actualizar el estado del trimestre",
+        ),
+      );
+    } finally {
+      setTogglingTrimestreId(null);
+    }
+  };
+
+  const handleCerrarPeriodo = async () => {
+    if (!periodoActual?.id) return;
+    try {
+      setClosingPeriodo(true);
+      await api.periodos.cerrar(periodoActual.id);
+      toast.success("Período cerrado");
+      await loadData();
+    } catch (error) {
+      toast.error(
+        resolveErrorMessage(error, "No se pudo cerrar el período actual"),
+      );
+    } finally {
+      setClosingPeriodo(false);
+    }
+  };
+
+  const handleAbrirPeriodo = async () => {
+    if (!periodoActual?.id) return;
+    try {
+      setOpeningPeriodo(true);
+      await api.periodos.abrir(periodoActual.id);
+      toast.success("Período reabierto");
+      await loadData();
+    } catch (error) {
+      toast.error(
+        resolveErrorMessage(error, "No se pudo reabrir el período"),
+      );
+    } finally {
+      setOpeningPeriodo(false);
+    }
+  };
+
+  const handleCrearPeriodo = async () => {
+    const year = Number.parseInt(nuevoPeriodo.anio, 10);
+    if (!Number.isFinite(year) || year < 2000) {
+      toast.error("Ingresá un año válido para el período");
+      return;
+    }
+
+    try {
+      setCreatingPeriodo(true);
+      await api.periodos.create({ anio: year });
+      toast.success("Nuevo período creado");
+      setNuevoPeriodo((prev) => ({
+        ...prev,
+        anio: String(year + 1),
+      }));
+      await loadData();
+    } catch (error) {
+      toast.error(
+        resolveErrorMessage(error, "No se pudo crear el nuevo período"),
+      );
+    } finally {
+      setCreatingPeriodo(false);
+    }
+  };
+
+  const periodoAbierto = periodoActual?.activo !== false;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Gestión de trimestres</CardTitle>
+          <CardDescription>
+            Ajustá las fechas y el estado de los trimestres del período en curso.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Cargando datos...
+            </div>
+          ) : trimestresPeriodo.length ? (
+            trimestresPeriodo.map((tri) => {
+              const draft = drafts[tri.id] ?? { inicio: "", fin: "" };
+              return (
+                <div
+                  key={tri.id}
+                  className="space-y-4 rounded-lg border bg-muted/30 p-4"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium">
+                        Trimestre {tri.orden ?? ""}
+                      </p>
+                      <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>
+                          Período {resolvePeriodoId(tri, periodoActual?.id) ?? "—"}
+                        </span>
+                        <Badge variant={tri.cerrado ? "destructive" : "outline"}>
+                          {tri.cerrado ? "Cerrado" : "Abierto"}
+                        </Badge>
+                      </div>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleToggleTrimestre(tri)}
+                      disabled={togglingTrimestreId === tri.id || loading}
+                    >
+                      {tri.cerrado ? "Reabrir" : "Cerrar"}
+                    </Button>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1">
+                      <Label>Desde</Label>
+                      <Input
+                        type="date"
+                        value={draft.inicio}
+                        onChange={(e) =>
+                          handleDraftChange(tri.id, "inicio", e.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label>Hasta</Label>
+                      <Input
+                        type="date"
+                        value={draft.fin}
+                        onChange={(e) =>
+                          handleDraftChange(tri.id, "fin", e.target.value)
+                        }
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleResetTrimestre(tri)}
+                      disabled={!hasChanges(tri)}
+                    >
+                      Restaurar
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={() => handleSaveTrimestre(tri)}
+                      disabled={
+                        savingTrimestreId === tri.id || !hasChanges(tri)
+                      }
+                    >
+                      {savingTrimestreId === tri.id ? (
+                        <span className="flex items-center gap-2">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Guardando
+                        </span>
+                      ) : (
+                        "Guardar cambios"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No hay trimestres cargados para el período seleccionado.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Período escolar</CardTitle>
+          <CardDescription>
+            Cerrá el período en curso o abrí uno nuevo para el siguiente ciclo.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {periodoActual ? (
+            <div className="space-y-3">
+              <div>
+                <p className="text-sm font-medium">
+                  Período actual: {periodoActual.anio ?? "—"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Estado: {periodoAbierto ? "Abierto" : "Cerrado"}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  onClick={handleCerrarPeriodo}
+                  disabled={closingPeriodo || !periodoAbierto}
+                >
+                  {closingPeriodo ? (
+                    <span className="flex items-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Cerrando
+                    </span>
+                  ) : (
+                    "Cerrar período"
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={handleAbrirPeriodo}
+                  disabled={openingPeriodo || periodoAbierto}
+                >
+                  {openingPeriodo ? (
+                    <span className="flex items-center gap-2">
+                      <Loader2 className="h-4 w-4 animate-spin" /> Reabriendo
+                    </span>
+                  ) : (
+                    "Reabrir período"
+                  )}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Aún no hay períodos creados.
+            </p>
+          )}
+
+          <Separator />
+
+          <div className="space-y-3">
+            <p className="text-sm font-medium">Abrir nuevo período</p>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div className="sm:w-40">
+                <Label htmlFor="nuevo-periodo-anio">Año</Label>
+                <Input
+                  id="nuevo-periodo-anio"
+                  type="number"
+                  min={2000}
+                  value={nuevoPeriodo.anio}
+                  onChange={(e) =>
+                    setNuevoPeriodo({ anio: e.target.value.slice(0, 4) })
+                  }
+                />
+              </div>
+              <Button
+                onClick={handleCrearPeriodo}
+                disabled={creatingPeriodo || !nuevoPeriodo.anio}
+              >
+                {creatingPeriodo ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" /> Creando
+                  </span>
+                ) : (
+                  "Crear período"
+                )}
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export { DireccionConfig };

--- a/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
+++ b/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { UserRole } from "@/types/api-generated";
 import { useRouter, usePathname } from "next/navigation";
-import { ChevronsUpDown, LogOut, School, X, Menu } from "lucide-react";
+import { ChevronsUpDown, LogOut, School, X, Menu, Settings } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,6 +21,8 @@ import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import { MENU, type MenuItem } from "@/lib/menu";
 
+import { ConfiguracionDialog } from "./_components/ConfiguracionDialog";
+
 import { isItemActive } from "@/lib/nav";
 
 import { useVisibleMenu } from "@/hooks/useVisibleMenu";
@@ -35,6 +37,7 @@ const getInitials = (name: string | undefined | null) => {
 
 export function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
   const { logout, user, selectedRole, setSelectedRole, loading } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
@@ -215,6 +218,13 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
 
                 <DropdownMenuSeparator className="bg-gray-200 mx-1" />
 
+                <DropdownMenuItem onClick={() => setConfigOpen(true)}>
+                  <Settings className="h-4 w-4 mr-2" />
+                  Configuración
+                </DropdownMenuItem>
+
+                <DropdownMenuSeparator className="bg-gray-200 mx-1" />
+
                 <DropdownMenuItem
                   onClick={() => handleLogout()}
                   className="text-red-600 focus:text-red-700"
@@ -259,6 +269,13 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           onClick={toggleSidebar}
         />
       )}
+
+      <ConfiguracionDialog
+        open={configOpen}
+        onOpenChange={setConfigOpen}
+        currentRole={role}
+        roles={rolesNormalized}
+      />
     </div>
   );
 }

--- a/frontend-ecep/src/services/api/modules/calendario.ts
+++ b/frontend-ecep/src/services/api/modules/calendario.ts
@@ -4,11 +4,15 @@ import type * as DTO from '@/types/api-generated';
 export const periodos = {
   list: () => http.get<DTO.PeriodoEscolarDTO[]>('/api/periodos'),
   create: (body: DTO.PeriodoEscolarCreateDTO) => http.post<number>('/api/periodos', body),
+  cerrar: (id: number) => http.post<void>(`/api/periodos/${id}/cerrar`, {}),
+  abrir: (id: number) => http.post<void>(`/api/periodos/${id}/abrir`, {}),
 };
 
 export const trimestres = {
   list: () => http.get<DTO.TrimestreDTO[]>('/api/trimestres'),
   create: (body: DTO.TrimestreCreateDTO) => http.post<number>('/api/trimestres', body),
+  update: (id: number, body: Partial<DTO.TrimestreDTO>) =>
+    http.put<void>(`/api/trimestres/${id}`, body),
   cerrar: (id: number) => http.post<void>('/api/trimestres/' + id + '/cerrar', {}),
   reabrir: (id: number) => http.post<void>('/api/trimestres/' + id + '/reabrir', {}),
 };


### PR DESCRIPTION
## Summary
- add a configuration dialog accessible from the profile menu with a gear option
- implement dirección settings to edit trimestre dates, toggle closures, and manage the active período escolar
- expose backend endpoints and API helpers to cerrar/abrir períodos and actualizar trimestres

## Testing
- ./mvnw test *(fails: unable to download maven distribution in container)*
- npm run lint *(fails: Next.js CLI missing because dependencies could not be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68cc475f0d188327a36030e9557c220d