### PR TITLE
Enable alumno profile editing and user linking

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/dtos/PersonaDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/dtos/PersonaDTO.java
@@ -26,4 +26,5 @@ public class PersonaDTO {
     String telefono;
     String celular;
     String email;
+    Long usuarioId;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/dtos/PersonaUsuarioLinkDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/dtos/PersonaUsuarioLinkDTO.java
@@ -1,0 +1,6 @@
+package edu.ecep.base_app.dtos;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PersonaUsuarioLinkDTO(@NotNull Long usuarioId) {}
+

--- a/backend-ecep/src/main/java/edu/ecep/base_app/mappers/MatriculaSeccionHistorialMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/mappers/MatriculaSeccionHistorialMapper.java
@@ -3,8 +3,7 @@ package edu.ecep.base_app.mappers;
 import edu.ecep.base_app.domain.MatriculaSeccionHistorial;
 import edu.ecep.base_app.dtos.MatriculaSeccionHistorialCreateDTO;
 import edu.ecep.base_app.dtos.MatriculaSeccionHistorialDTO;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.*;
 
 @Mapper(config = ModelMapperConfig.class, uses = RefMapper.class)
 public interface MatriculaSeccionHistorialMapper {
@@ -15,4 +14,10 @@ public interface MatriculaSeccionHistorialMapper {
     @Mapping(target = "matricula", source = "matriculaId")
     @Mapping(target = "seccion", source = "seccionId")
     MatriculaSeccionHistorial toEntity(MatriculaSeccionHistorialCreateDTO dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "matricula", source = "matriculaId")
+    @Mapping(target = "seccion", source = "seccionId")
+    void update(@MappingTarget MatriculaSeccionHistorial entity, MatriculaSeccionHistorialDTO dto);
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/mappers/PersonaMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/mappers/PersonaMapper.java
@@ -16,6 +16,7 @@ import edu.ecep.base_app.dtos.PersonaUpdateDTO;
 public interface PersonaMapper {
 
     // Entity → DTO
+    @Mapping(target = "usuarioId", source = "usuario.id")
     PersonaDTO toDto(Persona e);
 
     // CreateDTO → Entity

--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/MatriculaSeccionHistorialController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/MatriculaSeccionHistorialController.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import java.util.*;
+
+import java.util.List;
 
 @RestController @RequestMapping("/api/matriculas/historial")
 @RequiredArgsConstructor @Validated
@@ -17,4 +18,10 @@ public class MatriculaSeccionHistorialController {
     private final MatriculaSeccionHistorialService service;
     @GetMapping public List<MatriculaSeccionHistorialDTO> list(){ return service.findAll(); }
     @PostMapping public ResponseEntity<Long> asignar(@RequestBody @Valid MatriculaSeccionHistorialCreateDTO dto){ return new ResponseEntity<>(service.asignar(dto), HttpStatus.CREATED); }
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable Long id,
+                                       @RequestBody @Valid MatriculaSeccionHistorialDTO dto) {
+        service.update(id, dto);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/AlumnoService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/AlumnoService.java
@@ -47,7 +47,11 @@ public class AlumnoService {
 
     public AlumnoDTO get(Long id) {
         return alumnoRepository.findWithPersonaById(id)
-                .map(alumnoMapper::toDto)
+                .map(entity -> {
+                    AlumnoDTO dto = alumnoMapper.toDto(entity);
+                    applySeccionActual(dto, entity.getId());
+                    return dto;
+                })
                 .orElseThrow(() -> new NotFoundException("Alumno no encontrado"));
     }
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/MatriculaSeccionHistorialService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/MatriculaSeccionHistorialService.java
@@ -4,6 +4,8 @@ import edu.ecep.base_app.dtos.MatriculaSeccionHistorialCreateDTO;
 import edu.ecep.base_app.dtos.MatriculaSeccionHistorialDTO;
 import edu.ecep.base_app.mappers.MatriculaSeccionHistorialMapper;
 import edu.ecep.base_app.repos.MatriculaSeccionHistorialRepository;
+import edu.ecep.base_app.util.NotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -13,11 +15,37 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MatriculaSeccionHistorialService {
-    private final MatriculaSeccionHistorialRepository repo; private final MatriculaSeccionHistorialMapper mapper;
-    public List<MatriculaSeccionHistorialDTO> findAll(){ return repo.findAll(Sort.by("matricula.id","desde").descending()).stream().map(mapper::toDto).toList(); }
-    public Long asignar(MatriculaSeccionHistorialCreateDTO dto){
-        if(dto.getHasta()!=null && dto.getHasta().isBefore(dto.getDesde())) throw new IllegalArgumentException("Rango inválido");
+
+    private final MatriculaSeccionHistorialRepository repo;
+    private final MatriculaSeccionHistorialMapper mapper;
+
+    public List<MatriculaSeccionHistorialDTO> findAll() {
+        return repo.findAll(Sort.by("matricula.id", "desde").descending())
+                .stream()
+                .map(mapper::toDto)
+                .toList();
+    }
+
+    public Long asignar(MatriculaSeccionHistorialCreateDTO dto) {
+        if (dto.getHasta() != null && dto.getHasta().isBefore(dto.getDesde())) {
+            throw new IllegalArgumentException("Rango inválido");
+        }
         // NOTA: acá podrías validar solapamientos con una consulta adicional
         return repo.save(mapper.toEntity(dto)).getId();
+    }
+
+    @Transactional
+    public void update(Long id, MatriculaSeccionHistorialDTO dto) {
+        var entity = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Historial de sección no encontrado"));
+
+        mapper.update(entity, dto);
+
+        if (entity.getHasta() != null && entity.getDesde() != null
+                && entity.getHasta().isBefore(entity.getDesde())) {
+            throw new IllegalArgumentException("Rango inválido");
+        }
+
+        repo.save(entity);
     }
 }

--- a/frontend-ecep/src/services/api/modules/matriculas.ts
+++ b/frontend-ecep/src/services/api/modules/matriculas.ts
@@ -12,6 +12,8 @@ export const matriculas = {
 export const matriculaSeccionHistorial = {
   list: () => http.get<DTO.MatriculaSeccionHistorialDTO[]>('/api/matriculas/historial'),
   create: (body: DTO.MatriculaSeccionHistorialCreateDTO) => http.post<number>('/api/matriculas/historial', body),
+  update: (id: number, body: DTO.MatriculaSeccionHistorialDTO) =>
+    http.put<void>(`/api/matriculas/historial/${id}`, body),
 };
 
 export const solicitudesBaja = {

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -597,6 +597,7 @@ export interface PersonaDTO {
   celular?: string;
   email?: string;
   observacionesGenerales?: string;
+  usuarioId?: number;
 }
 
 export interface PersonaCreateDTO {


### PR DESCRIPTION
## Summary
- expose alumno detail with seccion actual information and extend persona payloads with linked user id
- add persona<->usuario link management endpoints and matricula historial update support in the backend
- update alumno dashboard view to edit profile, switch current seccion and link or unlink system access using the new APIs

## Testing
- mvn -q test *(fails: unable to download dependencies from Maven Central due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6376bc0883279757d696fc41c3e1