### PR TITLE
Fix Pagos receipts tab closure

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/dtos/CuotaBulkCreateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/dtos/CuotaBulkCreateDTO.java
@@ -1,0 +1,32 @@
+package edu.ecep.base_app.dtos;
+
+import edu.ecep.base_app.domain.enums.ConceptoCuota;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class CuotaBulkCreateDTO {
+    @NotEmpty
+    private List<Long> seccionIds;
+
+    private ConceptoCuota concepto;
+    private String subconcepto;
+    private Integer anio;
+    private Integer mes;
+
+    @NotNull
+    private BigDecimal importe;
+
+    @NotNull
+    private LocalDate fechaVencimiento;
+
+    private BigDecimal porcentajeRecargo;
+    private String observaciones;
+
+    private boolean matricula;
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/repos/CuotaRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/repos/CuotaRepository.java
@@ -13,4 +13,5 @@ public interface CuotaRepository extends JpaRepository<Cuota, Long> {
     boolean existsByMatriculaIdAndAnioAndMesAndConcepto(Long matriculaId, Integer anio, Integer mes, ConceptoCuota concepto);
     boolean existsByMatriculaIdAndAnioAndConcepto(Long matriculaId, Integer anio, ConceptoCuota concepto);
     Optional<Cuota> findByCodigoPago(String codigoPago);
+    boolean existsByCodigoPago(String codigoPago);
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/CuotaController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/CuotaController.java
@@ -23,6 +23,7 @@ public class CuotaController {
     private final CuotaService service;
     @GetMapping public List<CuotaDTO> list(){ return service.findAll(); }
     @GetMapping("/{id}") public CuotaDTO get(@PathVariable Long id){ return service.get(id); }
+    @PostMapping("/bulk") public ResponseEntity<List<Long>> bulk(@RequestBody @Valid CuotaBulkCreateDTO dto){ return new ResponseEntity<>(service.bulkCreate(dto), HttpStatus.CREATED); }
     @PostMapping public ResponseEntity<Long> create(@RequestBody @Valid CuotaCreateDTO dto){ return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED); }
     @PutMapping("/{id}") public ResponseEntity<Void> update(@PathVariable Long id, @RequestBody @Valid CuotaDTO dto){ service.update(id, dto); return ResponseEntity.noContent().build(); }
     @DeleteMapping("/{id}") public ResponseEntity<Void> delete(@PathVariable Long id){ service.delete(id); return ResponseEntity.noContent().build(); }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/CuotaService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/CuotaService.java
@@ -1,34 +1,137 @@
 package edu.ecep.base_app.service;
 
 import edu.ecep.base_app.domain.Cuota;
+import edu.ecep.base_app.domain.Matricula;
+import edu.ecep.base_app.domain.MatriculaSeccionHistorial;
 import edu.ecep.base_app.domain.enums.ConceptoCuota;
+import edu.ecep.base_app.dtos.CuotaBulkCreateDTO;
 import edu.ecep.base_app.dtos.CuotaCreateDTO;
 import edu.ecep.base_app.dtos.CuotaDTO;
 import edu.ecep.base_app.mappers.CuotaMapper;
 import edu.ecep.base_app.repos.CuotaRepository;
+import edu.ecep.base_app.repos.MatriculaRepository;
+import edu.ecep.base_app.repos.MatriculaSeccionHistorialRepository;
 import edu.ecep.base_app.util.NotFoundException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Service @RequiredArgsConstructor
+@Service
+@RequiredArgsConstructor
 public class CuotaService {
-    private final CuotaRepository repo; private final CuotaMapper mapper;
-    public List<CuotaDTO> findAll(){ return repo.findAll(Sort.by("anio","mes")).stream().map(mapper::toDto).toList(); }
+    private final CuotaRepository repo;
+    private final CuotaMapper mapper;
+    private final MatriculaSeccionHistorialRepository historialRepository;
+    private final MatriculaRepository matriculaRepository;
+
+    public List<CuotaDTO> findAll(){
+        return repo.findAll(Sort.by("anio","mes"))
+                .stream()
+                .map(mapper::toDto)
+                .toList();
+    }
+
     public CuotaDTO get(Long id){
         return repo.findById(id)
                 .map(mapper::toDto)
                 .orElseThrow(NotFoundException::new);
     }
+
     public Long create(CuotaCreateDTO dto){
-        // reglas de unicidad por concepto
         if(dto.getConcepto()== ConceptoCuota.MENSUALIDAD && repo.existsByMatriculaIdAndAnioAndMesAndConcepto(dto.getMatriculaId(), dto.getAnio(), dto.getMes(), dto.getConcepto()))
             throw new IllegalArgumentException("Mensualidad duplicada");
         if(dto.getConcepto()==ConceptoCuota.MATRICULA && repo.existsByMatriculaIdAndAnioAndConcepto(dto.getMatriculaId(), dto.getAnio(), dto.getConcepto()))
             throw new IllegalArgumentException("Matrícula duplicada");
         return repo.save(mapper.toEntity(dto)).getId();
+    }
+
+    @Transactional
+    public List<Long> bulkCreate(CuotaBulkCreateDTO dto) {
+        if(dto.getSeccionIds()==null || dto.getSeccionIds().isEmpty()) return List.of();
+
+        ConceptoCuota concepto = dto.isMatricula() ? ConceptoCuota.MATRICULA : dto.getConcepto();
+        if(concepto == null) concepto = ConceptoCuota.MENSUALIDAD;
+
+        LocalDate fechaVencimiento = dto.getFechaVencimiento();
+        if(fechaVencimiento == null)
+            throw new IllegalArgumentException("La fecha de vencimiento es obligatoria");
+
+        int anio = dto.getAnio() != null ? dto.getAnio() : fechaVencimiento.getYear();
+        Integer mes = dto.getMes();
+        if(concepto == ConceptoCuota.MENSUALIDAD) {
+            if(mes == null) mes = fechaVencimiento.getMonthValue();
+        } else {
+            mes = null;
+        }
+
+        BigDecimal recargo = dto.getPorcentajeRecargo() != null ? dto.getPorcentajeRecargo() : BigDecimal.ZERO;
+
+        LocalDate fechaReferencia = fechaVencimiento;
+        Set<Long> matriculaIds = new HashSet<>();
+        for(Long seccionId : dto.getSeccionIds()){
+            List<MatriculaSeccionHistorial> activos = historialRepository.findActivosBySeccionOnDate(seccionId, fechaReferencia);
+            for(MatriculaSeccionHistorial historial : activos){
+                Matricula matricula = historial.getMatricula();
+                if(matricula != null && matricula.getId() != null)
+                    matriculaIds.add(matricula.getId());
+            }
+        }
+
+        if(matriculaIds.isEmpty()) return List.of();
+
+        List<Long> created = new ArrayList<>();
+        for(Long matriculaId : matriculaIds){
+            if(concepto == ConceptoCuota.MENSUALIDAD && repo.existsByMatriculaIdAndAnioAndMesAndConcepto(matriculaId, anio, mes, concepto))
+                continue;
+            if(concepto == ConceptoCuota.MATRICULA && repo.existsByMatriculaIdAndAnioAndConcepto(matriculaId, anio, concepto))
+                continue;
+
+            Cuota cuota = new Cuota();
+            cuota.setMatricula(matriculaRepository.getReferenceById(matriculaId));
+            cuota.setConcepto(concepto);
+            cuota.setSubconcepto(dto.getSubconcepto());
+            cuota.setAnio(anio);
+            cuota.setMes(mes);
+            cuota.setImporte(dto.getImporte());
+            cuota.setFechaVencimiento(fechaVencimiento);
+            cuota.setPorcentajeRecargo(recargo);
+            cuota.setCodigoPago(generarCodigo(concepto, anio, mes, matriculaId));
+            cuota.setObservaciones(dto.getObservaciones());
+
+            Cuota saved = repo.save(cuota);
+            created.add(saved.getId());
+        }
+
+        return created;
+    }
+
+    private String generarCodigo(ConceptoCuota concepto, int anio, Integer mes, Long matriculaId){
+        String prefix;
+        switch (concepto) {
+            case MATRICULA -> prefix = "MAT";
+            case MENSUALIDAD -> prefix = "MENS";
+            case MATERIALES -> prefix = "MATE";
+            case OTROS -> prefix = "OTRO";
+            default -> prefix = "CUO";
+        }
+
+        String periodo = mes != null ? String.format("%04d%02d", anio, mes) : String.format("%04d", anio);
+        String base = String.format("%s-%s-%05d", prefix, periodo, matriculaId);
+        String candidate = base;
+        int suffix = 1;
+        while (repo.existsByCodigoPago(candidate)) {
+            candidate = base + "-" + suffix;
+            suffix++;
+        }
+        return candidate;
     }
 
     public void update(Long id, CuotaDTO dto){

--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,17 +17,20 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
   Select,
@@ -30,488 +40,2103 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
-  CreditCard,
-  Plus,
-  FileText,
-  Calendar,
-  DollarSign,
-  Users,
-  Upload,
-  Download,
-  CheckCircle,
   AlertCircle,
+  Calendar,
+  CheckCircle,
+  DollarSign,
+  Download,
+  FileText,
+  Loader2,
+  Plus,
+  TrendingUp,
+  Upload,
+  Users,
+  Wallet,
 } from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/useAuth";
+import { useFamilyAlumnos } from "@/hooks/useFamilyAlumnos";
+import { api } from "@/services/api";
+import { normalizeRole } from "@/lib/auth-roles";
+import type {
+  AlumnoDTO,
+  AlumnoLiteDTO,
+  ConceptoCuota,
+  CuotaBulkCreateDTO,
+  CuotaDTO,
+  EmpleadoDTO,
+  EstadoCuota,
+  EstadoPago,
+  MatriculaDTO,
+  MedioPago,
+  PagoCuotaCreateDTO,
+  PagoCuotaDTO,
+  PersonaDTO,
+  ReciboSueldoCreateDTO,
+  ReciboSueldoDTO,
+  SeccionDTO,
+  UserRole,
+} from "@/types/api-generated";
+
+const MONTH_LABELS = [
+  "enero",
+  "febrero",
+  "marzo",
+  "abril",
+  "mayo",
+  "junio",
+  "julio",
+  "agosto",
+  "septiembre",
+  "octubre",
+  "noviembre",
+  "diciembre",
+];
+
+const CONCEPTO_LABELS: Record<string, string> = {
+  MATRICULA: "Matrícula",
+  MENSUALIDAD: "Cuota mensual",
+  MATERIALES: "Materiales",
+  OTROS: "Otros",
+};
+
+const ESTADO_PAGO_LABEL: Record<EstadoPago, { label: string; variant: string }> = {
+  EN_REVISION: { label: "En revisión", variant: "secondary" },
+  ACREDITADO: { label: "Acreditado", variant: "default" },
+  RECHAZADO: { label: "Rechazado", variant: "destructive" },
+};
+
+function formatCurrency(value?: number | null) {
+  if (value == null) return "—";
+  return new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: "ARS",
+    minimumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatMonthAndYear(mes?: number | null, anio?: number | null) {
+  if (!mes && !anio) return "—";
+  if (!mes) return `${anio ?? ""}`.trim();
+  const label = MONTH_LABELS[mes - 1] ?? "";
+  const capitalized = label.charAt(0).toUpperCase() + label.slice(1);
+  return anio ? `${capitalized} ${anio}` : capitalized;
+}
+
+function formatDate(iso?: string | null) {
+  if (!iso) return "—";
+  const date = new Date(`${iso}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("es-AR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(date);
+}
+
+function conceptoLabel(value?: string | null) {
+  if (!value) return "Sin concepto";
+  return CONCEPTO_LABELS[value] ?? value;
+}
+
+function cuotaEstadoInfo(cuota: CuotaDTO): {
+  label: string;
+  variant: "default" | "secondary" | "destructive" | "outline";
+} {
+  const estado = cuota.estado as EstadoCuota | undefined;
+  const dueDate = cuota.fechaVencimiento
+    ? new Date(`${cuota.fechaVencimiento}T00:00:00`)
+    : null;
+  const now = new Date();
+
+  if (estado === "PAGADA") return { label: "Pagada", variant: "default" };
+  if (estado === "PARCIAL") return { label: "Pago parcial", variant: "outline" };
+  if (
+    estado === "VENCIDA" ||
+    (dueDate && dueDate.getTime() < now.getTime() && estado !== "PAGADA")
+  ) {
+    return { label: "Vencida", variant: "destructive" };
+  }
+  return { label: "Vigente", variant: "secondary" };
+}
+
+const medioPagoOptions = Object.values(MedioPago);
 
 export default function PagosPage() {
+  const { user, selectedRole, loading: authLoading } = useAuth();
+  const normalizedRole = useMemo(() => {
+    if (selectedRole) return normalizeRole(selectedRole);
+    const first = user?.roles?.[0];
+    return first ? normalizeRole(first) : null;
+  }, [selectedRole, user]);
+
+  const isFamily = normalizedRole === UserRole.FAMILY;
+  const isTeacher =
+    normalizedRole === UserRole.TEACHER || normalizedRole === UserRole.ALTERNATE;
+  const isAdmin =
+    normalizedRole === UserRole.ADMIN ||
+    normalizedRole === UserRole.SECRETARY ||
+    normalizedRole === UserRole.DIRECTOR ||
+    normalizedRole === UserRole.COORDINATOR;
+
+  const shouldLoadCuotas = isFamily || isAdmin;
+  const shouldLoadPagos = isAdmin;
+  const shouldLoadSecciones = isAdmin;
+  const shouldLoadMatriculas = isAdmin;
+  const shouldLoadAlumnos = isAdmin;
+  const shouldLoadRecibos = isAdmin || isTeacher;
+  const shouldLoadEmpleados = isAdmin || isTeacher;
+
+  const { alumnos: hijos, loading: hijosLoading } = useFamilyAlumnos();
+
   const [selectedTab, setSelectedTab] = useState("cuotas");
-  const [userProfile] = useState("administracion"); // Simulando perfil de usuario
+  const [cuotas, setCuotas] = useState<CuotaDTO[]>([]);
+  const [cuotasLoading, setCuotasLoading] = useState(false);
+  const [cuotasError, setCuotasError] = useState<string | null>(null);
 
-  const [alumnos] = useState([
-    {
-      id: 1,
-      nombre: "Juan Pérez",
-      seccion: "4° A",
-      cuotas: [
-        {
-          id: 1,
-          mes: "Marzo 2025",
-          monto: 45000,
-          vencida: false,
-          codigo: "ECEP-2025-03-001",
-        },
-        {
-          id: 2,
-          mes: "Abril 2025",
-          monto: 45000,
-          vencida: true,
-          codigo: "ECEP-2025-04-001",
-        },
-        {
-          id: 3,
-          mes: "Mayo 2025",
-          monto: 47000,
-          vencida: false,
-          codigo: "ECEP-2025-05-001",
-        },
-      ],
-      matricula: { monto: 25000, pagada: true, codigo: "ECEP-MAT-2025-001" },
-    },
-    {
-      id: 2,
-      nombre: "María González",
-      seccion: "Sala 5",
-      cuotas: [
-        {
-          id: 1,
-          mes: "Marzo 2025",
-          monto: 42000,
-          vencida: false,
-          codigo: "ECEP-2025-03-002",
-        },
-        {
-          id: 2,
-          mes: "Abril 2025",
-          monto: 42000,
-          vencida: false,
-          codigo: "ECEP-2025-04-002",
-        },
-      ],
-      matricula: { monto: 22000, pagada: true, codigo: "ECEP-MAT-2025-002" },
-    },
-  ]);
+  const [pagos, setPagos] = useState<PagoCuotaDTO[]>([]);
+  const [pagosLoading, setPagosLoading] = useState(false);
+  const [pagosError, setPagosError] = useState<string | null>(null);
 
-  const [personal] = useState([
-    {
-      id: 1,
-      nombre: "Prof. Ana López",
-      cargo: "Docente",
-      sueldo: 180000,
-      recibido: true,
-      fecha: "2025-01-30",
-      archivo: "recibo_enero_2025.pdf",
-    },
-    {
-      id: 2,
-      nombre: "Maestra Clara",
-      cargo: "Maestra",
-      sueldo: 165000,
-      recibido: false,
-      fecha: "2025-01-30",
-      archivo: "recibo_enero_2025.pdf",
-    },
-  ]);
+  const [recibos, setRecibos] = useState<ReciboSueldoDTO[]>([]);
+  const [recibosLoading, setRecibosLoading] = useState(false);
+  const [recibosError, setRecibosError] = useState<string | null>(null);
 
-  const [secciones] = useState([
-    "3° A",
-    "3° B",
-    "4° A",
-    "4° B",
-    "5° A",
-    "5° B",
-    "6° A",
-    "6° B",
-    "Sala 3",
-    "Sala 4",
-    "Sala 5",
-  ]);
+  const [secciones, setSecciones] = useState<SeccionDTO[]>([]);
+  const [seccionesLoading, setSeccionesLoading] = useState(false);
 
-  const formatMonto = (monto: number) => {
-    return new Intl.NumberFormat("es-AR", {
-      style: "currency",
-      currency: "ARS",
-    }).format(monto);
+  const [matriculas, setMatriculas] = useState<MatriculaDTO[]>([]);
+  const [alumnos, setAlumnos] = useState<AlumnoDTO[]>([]);
+  const [empleados, setEmpleados] = useState<EmpleadoDTO[]>([]);
+
+  const personaCache = useRef(new Map<number, PersonaDTO | null>());
+  const [, forcePersonaRefresh] = useState(0);
+
+  const ensurePersona = useCallback(async (personaId?: number | null) => {
+    if (!personaId) return null;
+    if (personaCache.current.has(personaId)) {
+      return personaCache.current.get(personaId) ?? null;
+    }
+    try {
+      const res = await api.personasCore.getById(personaId);
+      personaCache.current.set(personaId, res.data ?? null);
+      forcePersonaRefresh((value) => value + 1);
+      return res.data ?? null;
+    } catch {
+      personaCache.current.set(personaId, null);
+      forcePersonaRefresh((value) => value + 1);
+      return null;
+    }
+  }, []);
+
+  const loadCuotas = useCallback(async () => {
+    setCuotasLoading(true);
+    try {
+      const res = await api.cuotas.list();
+      setCuotas(res.data ?? []);
+      setCuotasError(null);
+    } catch (error: any) {
+      setCuotasError(error?.message ?? "No se pudo obtener la información");
+    } finally {
+      setCuotasLoading(false);
+    }
+  }, []);
+
+  const loadPagos = useCallback(async () => {
+    setPagosLoading(true);
+    try {
+      const res = await api.pagosCuota.list();
+      setPagos(res.data ?? []);
+      setPagosError(null);
+    } catch (error: any) {
+      setPagosError(
+        error?.message ?? "No se pudo obtener los pagos registrados",
+      );
+    } finally {
+      setPagosLoading(false);
+    }
+  }, []);
+
+  const loadRecibos = useCallback(async () => {
+    setRecibosLoading(true);
+    try {
+      const res = await api.recibos.list();
+      setRecibos(res.data ?? []);
+      setRecibosError(null);
+    } catch (error: any) {
+      setRecibosError(error?.message ?? "No se pudieron cargar los recibos");
+    } finally {
+      setRecibosLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!shouldLoadCuotas) return;
+    loadCuotas();
+  }, [shouldLoadCuotas, loadCuotas]);
+
+  useEffect(() => {
+    if (!shouldLoadPagos) return;
+    loadPagos();
+  }, [shouldLoadPagos, loadPagos]);
+
+  useEffect(() => {
+    if (!shouldLoadRecibos) return;
+    loadRecibos();
+  }, [shouldLoadRecibos, loadRecibos]);
+
+  useEffect(() => {
+    if (!shouldLoadSecciones) return;
+    setSeccionesLoading(true);
+    api.secciones
+      .secciones.list()
+      .then((res) => setSecciones(res.data ?? []))
+      .catch(() => setSecciones([]))
+      .finally(() => setSeccionesLoading(false));
+  }, [shouldLoadSecciones]);
+
+  useEffect(() => {
+    if (!shouldLoadMatriculas) return;
+    api.matriculas
+      .matriculas.list()
+      .then((res) => setMatriculas(res.data ?? []))
+      .catch(() => setMatriculas([]));
+  }, [shouldLoadMatriculas]);
+
+  useEffect(() => {
+    if (!shouldLoadAlumnos) return;
+    api.alumnos
+      .list()
+      .then((res) => setAlumnos(res.data ?? []))
+      .catch(() => setAlumnos([]));
+  }, [shouldLoadAlumnos]);
+
+  useEffect(() => {
+    if (!shouldLoadEmpleados) return;
+    api.empleados
+      .empleados.list()
+      .then((res) => setEmpleados(res.data ?? []))
+      .catch(() => setEmpleados([]));
+  }, [shouldLoadEmpleados]);
+
+  useEffect(() => {
+    if (!shouldLoadEmpleados || empleados.length === 0) return;
+    empleados.forEach((empleado) => ensurePersona(empleado.personaId ?? null));
+  }, [empleados, ensurePersona, shouldLoadEmpleados]);
+
+  const matriculaInfo = useMemo(() => {
+    const map = new Map<
+      number,
+      { alumnoId?: number; alumnoNombre: string; seccionNombre?: string | null }
+    >();
+    if (!matriculas.length) return map;
+    const alumnoMap = new Map<number, AlumnoDTO>();
+    for (const alumno of alumnos) {
+      if (alumno.id != null) alumnoMap.set(alumno.id, alumno);
+    }
+    for (const matricula of matriculas) {
+      if (matricula.id == null) continue;
+      const alumno = matricula.alumnoId
+        ? alumnoMap.get(matricula.alumnoId)
+        : undefined;
+      const nombre = alumno
+        ? `${alumno.apellido ?? ""}, ${alumno.nombre ?? ""}`
+            .trim()
+            .replace(/^, /, "") || `Alumno #${alumno.id}`
+        : `Matrícula #${matricula.id}`;
+      map.set(matricula.id, {
+        alumnoId: alumno?.id ?? undefined,
+        alumnoNombre: nombre,
+        seccionNombre: alumno?.seccionActualNombre ?? null,
+      });
+    }
+    return map;
+  }, [matriculas, alumnos]);
+
+  const cuotasPorMatricula = useMemo(() => {
+    const map = new Map<number, CuotaDTO[]>();
+    for (const cuota of cuotas) {
+      const matriculaId = cuota.matriculaId;
+      if (!matriculaId) continue;
+      if (!map.has(matriculaId)) map.set(matriculaId, []);
+      map.get(matriculaId)!.push(cuota);
+    }
+    for (const [, lista] of map.entries()) {
+      lista.sort((a, b) => {
+        const anioA = a.anio ?? 0;
+        const anioB = b.anio ?? 0;
+        if (anioA !== anioB) return anioA - anioB;
+        const mesA = a.mes ?? 0;
+        const mesB = b.mes ?? 0;
+        if (mesA !== mesB) return mesA - mesB;
+        return (a.fechaVencimiento ?? "").localeCompare(b.fechaVencimiento ?? "");
+      });
+    }
+    return map;
+  }, [cuotas]);
+
+  const cuotasOrdenadasAdmin = useMemo(() => {
+    return [...cuotas].sort((a, b) => {
+      const fechaA = a.fechaVencimiento ?? "";
+      const fechaB = b.fechaVencimiento ?? "";
+      return fechaA.localeCompare(fechaB);
+    });
+  }, [cuotas]);
+
+  const pagosOrdenados = useMemo(() => {
+    return [...pagos].sort((a, b) => {
+      const fechaA = a.fechaPago ?? "";
+      const fechaB = b.fechaPago ?? "";
+      return fechaB.localeCompare(fechaA);
+    });
+  }, [pagos]);
+
+  const recibosOrdenados = useMemo(() => {
+    return [...recibos].sort((a, b) => {
+      const anioDiff = (b.anio ?? 0) - (a.anio ?? 0);
+      if (anioDiff !== 0) return anioDiff;
+      return (b.mes ?? 0) - (a.mes ?? 0);
+    });
+  }, [recibos]);
+
+  const myEmpleado = useMemo(() => {
+    if (!shouldLoadEmpleados) return null;
+    if (!user?.personaId) return null;
+    return empleados.find((empleado) => empleado.personaId === user.personaId) ?? null;
+  }, [empleados, shouldLoadEmpleados, user]);
+
+  const misRecibos = useMemo(() => {
+    if (!myEmpleado) return [];
+    return recibosOrdenados.filter((recibo) => recibo.empleadoId === myEmpleado.id);
+  }, [myEmpleado, recibosOrdenados]);
+
+  const getAlumnoNombre = useCallback(
+    (matriculaId?: number | null) => {
+      if (!matriculaId) return "—";
+      const info = matriculaInfo.get(matriculaId);
+      if (!info) return `Matrícula #${matriculaId}`;
+      return info.alumnoNombre;
+    },
+    [matriculaInfo],
+  );
+
+  const getAlumnoSeccion = useCallback(
+    (matriculaId?: number | null) => {
+      if (!matriculaId) return "—";
+      const info = matriculaInfo.get(matriculaId);
+      if (!info) return "—";
+      return info.seccionNombre ?? "—";
+    },
+    [matriculaInfo],
+  );
+
+  const getEmpleadoNombre = useCallback(
+    (empleadoId?: number | null) => {
+      if (!empleadoId) return "—";
+      const empleado = empleados.find((item) => item.id === empleadoId);
+      if (!empleado) return `Empleado #${empleadoId}`;
+      const persona = personaCache.current.get(empleado.personaId ?? 0);
+      if (persona) {
+        return (
+          `${persona.apellido ?? ""}, ${persona.nombre ?? ""}`
+            .trim()
+            .replace(/^, /, "") || `Empleado #${empleadoId}`
+        );
+      }
+      return `Empleado #${empleadoId}`;
+    },
+    [empleados],
+  );
+
+  const [detalleCuota, setDetalleCuota] = useState<CuotaDTO | null>(null);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [creatingCuota, setCreatingCuota] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    seccionIds: [] as number[],
+    concepto: "MENSUALIDAD" as ConceptoCuota,
+    titulo: "",
+    anio: new Date().getFullYear().toString(),
+    mes: (new Date().getMonth() + 1).toString(),
+    importe: "",
+    fechaVencimiento: "",
+    porcentajeRecargo: "10",
+    matricula: false,
+  });
+
+  const [pagoDialogOpen, setPagoDialogOpen] = useState(false);
+  const [registrandoPago, setRegistrandoPago] = useState(false);
+  const [pagoForm, setPagoForm] = useState({
+    tipo: "cuota" as "cuota" | "matricula" | "sueldo",
+    cuotaId: "",
+    empleadoId: "",
+    fecha: "",
+    medioPago: "EFECTIVO" as MedioPago,
+    monto: "",
+    referencia: "",
+    comprobanteId: "",
+    anio: new Date().getFullYear().toString(),
+    mes: (new Date().getMonth() + 1).toString(),
+    bruto: "",
+    neto: "",
+  });
+
+  const cuotasParaPago = useMemo(() => {
+    const cuotasMensuales = cuotas.filter(
+      (cuota) => cuota.concepto !== "MATRICULA",
+    );
+    const cuotasMatricula = cuotas.filter(
+      (cuota) => cuota.concepto === "MATRICULA",
+    );
+    return { cuotasMensuales, cuotasMatricula };
+  }, [cuotas]);
+
+  const resumenCuotas = useMemo(() => {
+    const total = cuotas.length;
+    const vencidas = cuotas.filter(
+      (cuota) => cuotaEstadoInfo(cuota).label === "Vencida",
+    ).length;
+    const pagadas = cuotas.filter((cuota) => cuota.estado === "PAGADA").length;
+    const importeTotal = cuotas.reduce(
+      (acc, cuota) => acc + (cuota.importe ?? 0),
+      0,
+    );
+    return { total, vencidas, pagadas, importeTotal };
+  }, [cuotas]);
+
+  const toggleSeccion = (id: number, checked: boolean) => {
+    setCreateForm((prev) => {
+      const nextIds = new Set(prev.seccionIds);
+      if (checked) nextIds.add(id);
+      else nextIds.delete(id);
+      return { ...prev, seccionIds: Array.from(nextIds) };
+    });
   };
 
-  const renderFamiliaView = () => (
-    <div className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-2">
-        {alumnos.map((alumno) => (
-          <Card key={alumno.id} className="hover:shadow-md transition-shadow">
-            <CardHeader>
-              <CardTitle className="flex items-center justify-between">
-                {alumno.nombre}
-                <Badge variant="outline">{alumno.seccion}</Badge>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {/* Matrícula */}
-              <div className="border rounded-lg p-3">
-                <div className="flex items-center justify-between mb-2">
-                  <h4 className="font-medium">Matrícula 2025</h4>
-                  <Badge
-                    variant={
-                      alumno.matricula.pagada ? "default" : "destructive"
-                    }
-                  >
-                    {alumno.matricula.pagada ? "Pagada" : "Pendiente"}
-                  </Badge>
-                </div>
-                <p className="text-sm text-gray-600">
-                  Monto: {formatMonto(alumno.matricula.monto)}
-                </p>
-                <p className="text-xs text-gray-500">
-                  Código: {alumno.matricula.codigo}
-                </p>
-              </div>
+  const resetCreateForm = () => {
+    setCreateForm({
+      seccionIds: [],
+      concepto: "MENSUALIDAD",
+      titulo: "",
+      anio: new Date().getFullYear().toString(),
+      mes: (new Date().getMonth() + 1).toString(),
+      importe: "",
+      fechaVencimiento: "",
+      porcentajeRecargo: "10",
+      matricula: false,
+    });
+  };
 
-              {/* Cuotas */}
-              <div>
-                <h4 className="font-medium mb-3">Cuotas</h4>
-                <div className="space-y-2">
-                  {alumno.cuotas.map((cuota) => (
+  const resetPagoForm = () => {
+    setPagoForm({
+      tipo: "cuota",
+      cuotaId: "",
+      empleadoId: "",
+      fecha: "",
+      medioPago: "EFECTIVO",
+      monto: "",
+      referencia: "",
+      comprobanteId: "",
+      anio: new Date().getFullYear().toString(),
+      mes: (new Date().getMonth() + 1).toString(),
+      bruto: "",
+      neto: "",
+    });
+  };
+
+  const seccionesOrdenadas = useMemo(() => {
+    return [...secciones].sort((a, b) => {
+      const nivel = (a.nivel ?? "").localeCompare(b.nivel ?? "");
+      if (nivel !== 0) return nivel;
+      const grado = (a.gradoSala ?? "").localeCompare(b.gradoSala ?? "");
+      if (grado !== 0) return grado;
+      return (a.division ?? "").localeCompare(b.division ?? "");
+    });
+  }, [secciones]);
+
+  const availableTabs = useMemo(() => {
+    const tabs: { value: string; label: string }[] = [];
+    if (shouldLoadCuotas) {
+      tabs.push({
+        value: "cuotas",
+        label: isFamily ? "Cuotas y matrícula" : "Cuotas",
+      });
+    }
+    if (shouldLoadPagos) {
+      tabs.push({ value: "pagos", label: "Pagos registrados" });
+    }
+    if (shouldLoadRecibos) {
+      tabs.push({
+        value: "recibos",
+        label: isAdmin ? "Recibos de sueldo" : "Mis recibos",
+      });
+    }
+    return tabs;
+  }, [shouldLoadCuotas, shouldLoadPagos, shouldLoadRecibos, isFamily, isAdmin]);
+
+  useEffect(() => {
+    if (!availableTabs.length) return;
+    if (!availableTabs.some((tab) => tab.value === selectedTab)) {
+      setSelectedTab(availableTabs[0].value);
+    }
+  }, [availableTabs, selectedTab]);
+
+  const cuotaMap = useMemo(() => {
+    const map = new Map<number, CuotaDTO>();
+    for (const cuota of cuotas) {
+      if (cuota.id != null) {
+        map.set(cuota.id, cuota);
+      }
+    }
+    return map;
+  }, [cuotas]);
+
+  const copyToClipboard = useCallback(async (value: string, message: string) => {
+    if (!value) return;
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        await navigator.clipboard.writeText(value);
+        toast.success(message);
+      } else {
+        throw new Error("Clipboard no disponible");
+      }
+    } catch (error: any) {
+      toast.error(error?.message ?? "No se pudo copiar el texto");
+    }
+  }, []);
+
+  const handleSubmitNuevaCuota = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!createForm.seccionIds.length) {
+      toast.error("Seleccioná al menos una sección");
+      return;
+    }
+    const importe = Number.parseFloat(createForm.importe.replace(/,/g, "."));
+    if (!Number.isFinite(importe) || importe <= 0) {
+      toast.error("Ingresá un monto válido");
+      return;
+    }
+    if (!createForm.fechaVencimiento) {
+      toast.error("La fecha de vencimiento es obligatoria");
+      return;
+    }
+
+    const porcentaje = createForm.porcentajeRecargo
+      ? Number.parseFloat(createForm.porcentajeRecargo.replace(/,/g, "."))
+      : undefined;
+    const anioNumber = createForm.anio ? Number.parseInt(createForm.anio, 10) : undefined;
+    const mesNumber =
+      createForm.matricula || !createForm.mes
+        ? undefined
+        : Number.parseInt(createForm.mes, 10);
+
+    const payload: CuotaBulkCreateDTO = {
+      seccionIds: createForm.seccionIds,
+      concepto: createForm.matricula ? ConceptoCuota.MATRICULA : createForm.concepto,
+      subconcepto: createForm.titulo.trim() || undefined,
+      anio: anioNumber,
+      mes: mesNumber,
+      importe,
+      fechaVencimiento: createForm.fechaVencimiento,
+      porcentajeRecargo: porcentaje,
+      observaciones: undefined,
+      matricula: createForm.matricula,
+    };
+
+    setCreatingCuota(true);
+    try {
+      const res = await api.cuotas.bulkCreate(payload);
+      const creadas = res.data?.length ?? 0;
+      if (creadas > 0) {
+        toast.success(`Se generaron ${creadas} cuotas`);
+      } else {
+        toast.success("No se generaron nuevas cuotas (posibles duplicados)");
+      }
+      setCreateDialogOpen(false);
+      resetCreateForm();
+      await loadCuotas();
+    } catch (error: any) {
+      toast.error(error?.response?.data ?? error?.message ?? "No se pudo crear la cuota");
+    } finally {
+      setCreatingCuota(false);
+    }
+  };
+
+  const handleSubmitPago = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setRegistrandoPago(true);
+    try {
+      if (pagoForm.tipo === "sueldo") {
+        if (!pagoForm.empleadoId) {
+          toast.error("Seleccioná un empleado");
+          return;
+        }
+        const anio = Number.parseInt(pagoForm.anio, 10);
+        const mes = Number.parseInt(pagoForm.mes, 10);
+        const bruto = Number.parseFloat(pagoForm.bruto.replace(/,/g, "."));
+        const neto = Number.parseFloat(pagoForm.neto.replace(/,/g, "."));
+        if (!Number.isFinite(anio) || !Number.isFinite(mes)) {
+          toast.error("Indicá el período del recibo");
+          return;
+        }
+        if (!Number.isFinite(bruto) || !Number.isFinite(neto)) {
+          toast.error("Ingresá montos válidos para bruto y neto");
+          return;
+        }
+        const payload: ReciboSueldoCreateDTO = {
+          empleadoId: Number.parseInt(pagoForm.empleadoId, 10),
+          anio,
+          mes,
+          bruto,
+          neto,
+          recibiConforme: false,
+          comprobanteArchivoId: pagoForm.comprobanteId || undefined,
+        };
+        await api.recibos.create(payload);
+        toast.success("Recibo de sueldo registrado");
+        await loadRecibos();
+      } else {
+        if (!pagoForm.cuotaId) {
+          toast.error("Seleccioná una cuota");
+          return;
+        }
+        const monto = Number.parseFloat(pagoForm.monto.replace(/,/g, "."));
+        if (!Number.isFinite(monto) || monto <= 0) {
+          toast.error("Ingresá un monto válido");
+          return;
+        }
+        const payload: PagoCuotaCreateDTO = {
+          cuotaId: Number.parseInt(pagoForm.cuotaId, 10),
+          medioPago: pagoForm.medioPago,
+          montoPagado: monto,
+          fechaPago: pagoForm.fecha ? `${pagoForm.fecha}T00:00:00Z` : undefined,
+          referenciaExterna: pagoForm.referencia || undefined,
+          comprobanteArchivoId: pagoForm.comprobanteId || undefined,
+        };
+        await api.pagosCuota.create(payload);
+        toast.success("Pago registrado correctamente");
+        await Promise.all([loadPagos(), loadCuotas()]);
+      }
+      setPagoDialogOpen(false);
+      resetPagoForm();
+    } catch (error: any) {
+      toast.error(error?.response?.data ?? error?.message ?? "No se pudo registrar el pago");
+    } finally {
+      setRegistrandoPago(false);
+    }
+  };
+
+  const actualizarEstadoPago = useCallback(
+    async (pagoId: number, estado: EstadoPago) => {
+      try {
+        await api.pagosCuota.updateEstado(pagoId, {
+          estadoPago: estado,
+          fechaAcreditacion:
+            estado === EstadoPago.ACREDITADO ? new Date().toISOString() : undefined,
+        });
+        toast.success("Estado de pago actualizado");
+        await loadPagos();
+      } catch (error: any) {
+        toast.error(error?.response?.data ?? error?.message ?? "No se pudo actualizar el pago");
+      }
+    },
+    [loadPagos],
+  );
+
+  const handleConfirmarRecibo = useCallback(
+    async (recibo: ReciboSueldoDTO, value: boolean) => {
+      if (!recibo.id) return;
+      if (
+        recibo.empleadoId == null ||
+        recibo.anio == null ||
+        recibo.mes == null ||
+        recibo.bruto == null ||
+        recibo.neto == null
+      ) {
+        toast.error("El recibo no tiene información suficiente para actualizarse");
+        return;
+      }
+      try {
+        await api.recibos.update(recibo.id, {
+          ...recibo,
+          recibiConforme: value,
+          fechaConfirmacion: value ? new Date().toISOString() : (null as any),
+        });
+        toast.success(value ? "Recibo confirmado" : "Confirmación eliminada");
+        await loadRecibos();
+      } catch (error: any) {
+        toast.error(error?.response?.data ?? error?.message ?? "No se pudo actualizar el recibo");
+      }
+    },
+    [loadRecibos],
+  );
+
+  const renderEstadoPago = (estado?: EstadoPago | null) => {
+    if (!estado) return null;
+    const info = ESTADO_PAGO_LABEL[estado];
+    if (!info) return null;
+    return <Badge variant={info.variant as any}>{info.label}</Badge>;
+  };
+
+  const conceptoTexto = (cuota: CuotaDTO) => {
+    if (cuota.subconcepto) return cuota.subconcepto;
+    return conceptoLabel(cuota.concepto ?? "MENSUALIDAD");
+  };
+
+  const renderCuotasTab = () => {
+    if (authLoading) {
+      return (
+        <div className="flex items-center justify-center py-16 text-muted-foreground">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando información...
+        </div>
+      );
+    }
+
+    if (isFamily) {
+      if (hijosLoading || cuotasLoading) {
+        return (
+          <div className="flex items-center justify-center py-16 text-muted-foreground">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Preparando tus cuotas...
+          </div>
+        );
+      }
+
+      if (!hijos.length) {
+        return (
+          <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+            <Users className="mx-auto mb-3 h-10 w-10" />
+            Aún no hay alumnos asociados a tu cuenta.
+          </div>
+        );
+      }
+
+      return (
+        <div className="space-y-6">
+          {cuotasError && (
+            <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span>{cuotasError}</span>
+            </div>
+          )}
+          <div className="grid gap-4 lg:grid-cols-2">
+            {hijos.map((hijo) => {
+              const cuotasMatricula = cuotasPorMatricula.get(hijo.matriculaId) ?? [];
+              const cuotasMensuales = cuotasMatricula.filter(
+                (cuota) => cuota.concepto !== "MATRICULA",
+              );
+              const matriculas = cuotasMatricula.filter(
+                (cuota) => cuota.concepto === "MATRICULA",
+              );
+              return (
+                <Card key={hijo.matriculaId} className="flex h-full flex-col">
+                  <CardHeader>
+                    <CardTitle className="flex items-center justify-between gap-2">
+                      <span>{hijo.nombreCompleto}</span>
+                      <Badge variant="outline">
+                        {hijo.seccionNombre ?? "Sin sección"}
+                      </Badge>
+                    </CardTitle>
+                    <CardDescription>
+                      Visualizá el detalle de cuotas y matrícula correspondientes.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="flex flex-1 flex-col gap-4">
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2 text-sm font-semibold uppercase text-muted-foreground">
+                        <Calendar className="h-4 w-4" /> Cuotas mensuales
+                      </div>
+                      {!cuotasMensuales.length ? (
+                        <p className="text-sm text-muted-foreground">
+                          No hay cuotas registradas aún.
+                        </p>
+                      ) : (
+                        <div className="space-y-3">
+                          {cuotasMensuales.map((cuota) => {
+                            const estado = cuotaEstadoInfo(cuota);
+                            return (
+                              <div key={cuota.id} className="rounded-lg border bg-card/40 p-3">
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                  <div>
+                                    <p className="font-medium">
+                                      {formatMonthAndYear(cuota.mes ?? undefined, cuota.anio ?? undefined)}
+                                    </p>
+                                    <p className="text-sm text-muted-foreground">
+                                      Vence: {formatDate(cuota.fechaVencimiento)}
+                                    </p>
+                                  </div>
+                                  <div className="text-right">
+                                    <p className="font-semibold">{formatCurrency(cuota.importe)}</p>
+                                    <Badge variant={estado.variant}>{estado.label}</Badge>
+                                  </div>
+                                </div>
+                                <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+                                  <span>Código: {cuota.codigoPago ?? "—"}</span>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setDetalleCuota(cuota)}
+                                  >
+                                    <FileText className="mr-2 h-4 w-4" /> Ver detalle
+                                  </Button>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2 text-sm font-semibold uppercase text-muted-foreground">
+                        <Wallet className="h-4 w-4" /> Matrícula
+                      </div>
+                      {!matriculas.length ? (
+                        <p className="text-sm text-muted-foreground">
+                          No hay matrículas registradas todavía.
+                        </p>
+                      ) : (
+                        <div className="space-y-3">
+                          {matriculas.map((cuota) => {
+                            const estado = cuotaEstadoInfo(cuota);
+                            return (
+                              <div
+                                key={cuota.id}
+                                className="rounded-lg border border-dashed bg-background p-3"
+                              >
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                  <div>
+                                    <p className="font-medium">{cuota.subconcepto || "Matrícula"}</p>
+                                    <p className="text-sm text-muted-foreground">
+                                      Año: {cuota.anio ?? "—"}
+                                    </p>
+                                  </div>
+                                  <div className="text-right">
+                                    <p className="font-semibold">{formatCurrency(cuota.importe)}</p>
+                                    <Badge variant={estado.variant}>{estado.label}</Badge>
+                                  </div>
+                                </div>
+                                <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+                                  <span>Código: {cuota.codigoPago ?? "—"}</span>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setDetalleCuota(cuota)}
+                                  >
+                                    <FileText className="mr-2 h-4 w-4" /> Ver detalle
+                                  </Button>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      );
+    }
+
+    if (isAdmin) {
+      return (
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">Gestión de cuotas</h2>
+              <p className="text-sm text-muted-foreground">
+                Administrá cuotas, matrículas y visualizá el estado financiero por sección.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={() => setCreateDialogOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" /> Nueva cuota
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  resetPagoForm();
+                  setPagoDialogOpen(true);
+                }}
+              >
+                <DollarSign className="mr-2 h-4 w-4" /> Registrar pago
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Cuotas generadas</CardTitle>
+                <Users className="h-5 w-5 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{resumenCuotas.total}</div>
+                <p className="text-xs text-muted-foreground">Totales registradas en el sistema</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Importe emitido</CardTitle>
+                <TrendingUp className="h-5 w-5 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{formatCurrency(resumenCuotas.importeTotal)}</div>
+                <p className="text-xs text-muted-foreground">Suma de cuotas y matrículas</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Cuotas vencidas</CardTitle>
+                <AlertCircle className="h-5 w-5 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{resumenCuotas.vencidas}</div>
+                <p className="text-xs text-muted-foreground">Incluye vencimientos al día de hoy</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          {cuotasError && (
+            <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span>{cuotasError}</span>
+            </div>
+          )}
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Listado de cuotas</CardTitle>
+              <CardDescription>
+                Visualizá cada cuota generada y accedé rápidamente al código de pago.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {cuotasLoading ? (
+                <div className="flex items-center justify-center py-10 text-muted-foreground">
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando cuotas...
+                </div>
+              ) : !cuotasOrdenadasAdmin.length ? (
+                <p className="text-sm text-muted-foreground">
+                  Aún no se registraron cuotas. Creá la primera para comenzar.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {cuotasOrdenadasAdmin.map((cuota) => {
+                    const info = cuotaEstadoInfo(cuota);
+                    return (
+                      <div
+                        key={cuota.id}
+                        className="grid gap-3 rounded-lg border p-4 md:grid-cols-5 md:items-center"
+                      >
+                        <div className="md:col-span-2">
+                          <p className="font-medium">{conceptoTexto(cuota)}</p>
+                          <p className="text-sm text-muted-foreground">
+                            {getAlumnoNombre(cuota.matriculaId)} — {getAlumnoSeccion(cuota.matriculaId)}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium">Período</p>
+                          <p className="text-sm text-muted-foreground">
+                            {formatMonthAndYear(cuota.mes ?? undefined, cuota.anio ?? undefined)}
+                          </p>
+                        </div>
+                        <div className="text-right">
+                          <p className="font-semibold">{formatCurrency(cuota.importe)}</p>
+                          <Badge variant={info.variant}>{info.label}</Badge>
+                        </div>
+                        <div className="flex flex-col items-end gap-2 md:items-start">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              copyToClipboard(
+                                cuota.codigoPago ?? "",
+                                "Código de pago copiado",
+                              )
+                            }
+                          >
+                            <Download className="mr-2 h-4 w-4" /> Copiar código
+                          </Button>
+                          <Button variant="ghost" size="sm" onClick={() => setDetalleCuota(cuota)}>
+                            Detalle
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      );
+    }
+
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+        No tenés permisos para visualizar cuotas en este momento.
+      </div>
+    );
+  };
+
+  const renderPagosTab = () => {
+    if (!shouldLoadPagos) {
+      return (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+          No tenés acceso al registro de pagos.
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold">Pagos registrados</h2>
+            <p className="text-sm text-muted-foreground">
+              Validá los pagos recibidos y gestioná su estado de acreditación.
+            </p>
+          </div>
+          <Button onClick={() => setPagoDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" /> Nuevo pago
+          </Button>
+        </div>
+        {pagosError && (
+          <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+            <AlertCircle className="h-4 w-4" />
+            <span>{pagosError}</span>
+          </div>
+        )}
+        <Card>
+          <CardHeader>
+            <CardTitle>Historial</CardTitle>
+            <CardDescription>Pagos ordenados por fecha de registro.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {pagosLoading ? (
+              <div className="flex items-center justify-center py-10 text-muted-foreground">
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando pagos...
+              </div>
+            ) : !pagosOrdenados.length ? (
+              <p className="text-sm text-muted-foreground">Aún no hay pagos registrados.</p>
+            ) : (
+              <div className="space-y-3">
+                {pagosOrdenados.map((pago) => {
+                  const cuota = pago.cuotaId ? cuotaMap.get(pago.cuotaId) ?? null : null;
+                  return (
                     <div
-                      key={cuota.id}
-                      className="flex items-center justify-between p-2 border rounded"
+                      key={pago.id}
+                      className="grid gap-3 rounded-lg border p-4 md:grid-cols-5 md:items-center"
                     >
+                      <div className="md:col-span-2">
+                        <p className="font-medium">{cuota ? conceptoTexto(cuota) : "Pago sin cuota"}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {cuota
+                            ? `${getAlumnoNombre(cuota.matriculaId)} — ${formatMonthAndYear(
+                                cuota.mes ?? undefined,
+                                cuota.anio ?? undefined,
+                              )}`
+                            : ""}
+                        </p>
+                        {pago.referenciaExterna && (
+                          <p className="text-xs text-muted-foreground">
+                            Ref.: {pago.referenciaExterna}
+                          </p>
+                        )}
+                      </div>
                       <div>
-                        <p className="font-medium">{cuota.mes}</p>
-                        <p className="text-sm text-gray-600">
-                          {formatMonto(cuota.monto)}
+                        <p className="text-sm font-medium">Fecha</p>
+                        <p className="text-sm text-muted-foreground">
+                          {pago.fechaPago
+                            ? formatDate(pago.fechaPago.slice(0, 10))
+                            : "Sin registrar"}
                         </p>
                       </div>
                       <div className="text-right">
-                        <Badge
-                          variant={cuota.vencida ? "destructive" : "secondary"}
-                        >
-                          {cuota.vencida ? "Vencida" : "Vigente"}
-                        </Badge>
-                        <p className="text-xs text-gray-500 mt-1">
-                          {cuota.codigo}
-                        </p>
+                        <p className="font-semibold">{formatCurrency(pago.montoPagado)}</p>
+                        <p className="text-xs text-muted-foreground">{pago.medioPago}</p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2 md:items-start">
+                        {renderEstadoPago(pago.estadoPago)}
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => actualizarEstadoPago(pago.id, EstadoPago.ACREDITADO)}
+                          >
+                            <CheckCircle className="mr-2 h-4 w-4" /> Acreditar
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => actualizarEstadoPago(pago.id, EstadoPago.EN_REVISION)}
+                          >
+                            Revisar
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => actualizarEstadoPago(pago.id, EstadoPago.RECHAZADO)}
+                          >
+                            Rechazar
+                          </Button>
+                        </div>
                       </div>
                     </div>
-                  ))}
-                </div>
+                  );
+                })}
               </div>
-            </CardContent>
-          </Card>
-        ))}
+            )}
+          </CardContent>
+        </Card>
       </div>
-    </div>
-  );
+    );
+  };
 
-  const renderAdministracionView = () => (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-medium">Gestión de Cuotas y Pagos</h3>
-        <div className="flex space-x-2">
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button>
-                <Plus className="h-4 w-4 mr-2" />
-                Nueva Cuota
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Crear Nueva Cuota</DialogTitle>
-                <DialogDescription>
-                  Complete la información para crear una nueva cuota
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4">
-                <div>
-                  <Label>Secciones</Label>
-                  <Select>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Seleccione secciones" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {secciones.map((seccion) => (
-                        <SelectItem key={seccion} value={seccion}>
-                          {seccion}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div>
-                  <Label>Título de la Cuota</Label>
-                  <Input placeholder="Ej: Cuota Abril 2025" />
-                </div>
-
-                <div>
-                  <Label>Monto</Label>
-                  <Input type="number" placeholder="45000" />
-                </div>
-
-                <div>
-                  <Label>Fecha de Vencimiento</Label>
-                  <Input type="date" />
-                </div>
-
-                <div>
-                  <Label>Recargo por Vencimiento (%)</Label>
-                  <Input type="number" placeholder="10" defaultValue="10" />
-                </div>
-
-                <div className="flex items-center space-x-2">
-                  <Checkbox id="matricula" />
-                  <Label htmlFor="matricula">Es matrícula</Label>
-                </div>
-
-                <div className="flex space-x-2">
-                  <Button variant="outline" className="flex-1">
-                    Cancelar
-                  </Button>
-                  <Button className="flex-1">Crear Cuota</Button>
-                </div>
-              </div>
-            </DialogContent>
-          </Dialog>
-
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="outline">
-                <DollarSign className="h-4 w-4 mr-2" />
-                Nuevo Pago
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Registrar Nuevo Pago</DialogTitle>
-                <DialogDescription>
-                  Registre un pago realizado por personal o familia
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4">
-                <div>
-                  <Label>Tipo de Pago</Label>
-                  <Select>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Seleccione tipo" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="sueldo">Sueldo Personal</SelectItem>
-                      <SelectItem value="cuota">Cuota Alumno</SelectItem>
-                      <SelectItem value="matricula">Matrícula</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div>
-                  <Label>Persona/Alumno</Label>
-                  <Select>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Seleccione persona" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="ana">Prof. Ana López</SelectItem>
-                      <SelectItem value="clara">Maestra Clara</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div>
-                  <Label>Fecha del Pago</Label>
-                  <Input type="date" />
-                </div>
-
-                <div>
-                  <Label>Archivo del Recibo</Label>
-                  <div className="border-2 border-dashed border-gray-300 rounded-lg p-4 text-center">
-                    <Upload className="h-8 w-8 mx-auto mb-2 text-gray-400" />
-                    <p className="text-sm text-gray-600">
-                      Haga clic para subir archivo
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex space-x-2">
-                  <Button variant="outline" className="flex-1">
-                    Cancelar
-                  </Button>
-                  <Button className="flex-1">Registrar Pago</Button>
-                </div>
-              </div>
-            </DialogContent>
-          </Dialog>
+  const renderRecibosTab = () => {
+    if (!shouldLoadRecibos) {
+      return (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+          No tenés acceso a los recibos de sueldo.
         </div>
+      );
+    }
+
+    const listado = isAdmin ? recibosOrdenados : misRecibos;
+
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold">
+              {isAdmin ? "Recibos del personal" : "Mis recibos"}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {isAdmin
+                ? "Consulta los recibos emitidos y verifica su confirmación."
+                : "Descargá y confirmá la recepción de tus recibos de sueldo."}
+            </p>
+          </div>
+          {isAdmin && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                resetPagoForm();
+                setPagoForm((prev) => ({ ...prev, tipo: "sueldo" }));
+                setPagoDialogOpen(true);
+              }}
+            >
+              <Upload className="mr-2 h-4 w-4" /> Nuevo recibo
+            </Button>
+          )}
+        </div>
+
+        {recibosError && (
+          <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+            <AlertCircle className="h-4 w-4" />
+            <span>{recibosError}</span>
+          </div>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Recibos</CardTitle>
+            <CardDescription>
+              {isAdmin
+                ? "Listado cronológico de recibos emitidos al personal."
+                : "Recibos disponibles para descargar y confirmar."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {recibosLoading ? (
+              <div className="flex items-center justify-center py-10 text-muted-foreground">
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando recibos...
+              </div>
+            ) : !listado.length ? (
+              <p className="text-sm text-muted-foreground">
+                {isAdmin
+                  ? "Aún no se registraron recibos."
+                  : "Todavía no tenés recibos disponibles."}
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {listado.map((recibo) => {
+                  const empleadoNombre = getEmpleadoNombre(recibo.empleadoId);
+                  const periodo = formatMonthAndYear(
+                    recibo.mes ?? undefined,
+                    recibo.anio ?? undefined,
+                  );
+                  return (
+                    <div
+                      key={recibo.id}
+                      className="grid gap-3 rounded-lg border p-4 md:grid-cols-5 md:items-center"
+                    >
+                      <div className="md:col-span-2">
+                        <p className="font-medium">{empleadoNombre}</p>
+                        <p className="text-sm text-muted-foreground">Período {periodo}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Bruto: {formatCurrency(recibo.bruto)} — Neto: {formatCurrency(recibo.neto)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">Estado</p>
+                        <p className="text-sm text-muted-foreground">
+                          {recibo.recibiConforme ? "Recibí conforme" : "Pendiente de confirmación"}
+                        </p>
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {recibo.comprobanteArchivoId ? (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() =>
+                              copyToClipboard(
+                                recibo.comprobanteArchivoId ?? "",
+                                "Identificador de archivo copiado",
+                              )
+                            }
+                          >
+                            <Download className="mr-2 h-4 w-4" /> Copiar comprobante
+                          </Button>
+                        ) : (
+                          <span>Sin comprobante adjunto</span>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap justify-end gap-2 md:justify-start">
+                        {isTeacher && (
+                          <Button
+                            size="sm"
+                            variant={recibo.recibiConforme ? "secondary" : "outline"}
+                            onClick={() => handleConfirmarRecibo(recibo, !recibo.recibiConforme)}
+                          >
+                            {recibo.recibiConforme ? "Quitar confirmación" : "Recibí conforme"}
+                          </Button>
+                        )}
+                        {isAdmin && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => {
+                              resetPagoForm();
+                              setPagoForm((prev) => ({
+                                ...prev,
+                                tipo: "sueldo",
+                                empleadoId:
+                                  recibo.empleadoId != null ? String(recibo.empleadoId) : "",
+                                anio:
+                                  recibo.anio != null ? String(recibo.anio) : prev.anio,
+                                mes:
+                                  recibo.mes != null ? String(recibo.mes) : prev.mes,
+                                bruto:
+                                  recibo.bruto != null ? String(recibo.bruto) : prev.bruto,
+                                neto:
+                                  recibo.neto != null ? String(recibo.neto) : prev.neto,
+                                comprobanteId: recibo.comprobanteArchivoId ?? "",
+                              }));
+                              setPagoDialogOpen(true);
+                            }}
+                          >
+                            Gestionar
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
+    );
+  };
 
-      {/* Lista de cuotas creadas */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Cuotas Activas</CardTitle>
-          <CardDescription>
-            Gestión de cuotas por sección y período
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            <div className="flex items-center justify-between p-3 border rounded-lg">
-              <div>
-                <p className="font-medium">Cuota Marzo 2025</p>
-                <p className="text-sm text-gray-600">
-                  Todas las secciones - Vence: 10/03/2025
-                </p>
-              </div>
-              <div className="text-right">
-                <p className="font-medium">{formatMonto(45000)}</p>
-                <Badge variant="default">Activa</Badge>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between p-3 border rounded-lg">
-              <div>
-                <p className="font-medium">Matrícula 2025</p>
-                <p className="text-sm text-gray-600">
-                  Todas las secciones - Vence: 15/02/2025
-                </p>
-              </div>
-              <div className="text-right">
-                <p className="font-medium">{formatMonto(25000)}</p>
-                <Badge variant="secondary">Vencida</Badge>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
-
-  const renderPersonalView = () => (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center">
-            <FileText className="h-5 w-5 mr-2" />
-            Mi Recibo de Sueldo
-          </CardTitle>
-          <CardDescription>Enero 2025</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <p className="text-sm font-medium">Sueldo Bruto</p>
-              <p className="text-2xl font-bold">{formatMonto(180000)}</p>
-            </div>
-            <div>
-              <p className="text-sm font-medium">Fecha de Pago</p>
-              <p className="text-lg">30/01/2025</p>
-            </div>
-          </div>
-
-          <div className="border-t pt-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2">
-                <Checkbox id="recibido" defaultChecked />
-                <Label htmlFor="recibido">Recibí conforme</Label>
-              </div>
-              <Button variant="outline" size="sm">
-                <Download className="h-4 w-4 mr-2" />
-                Descargar PDF
-              </Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  const detalleRecargo = detallesRecargo(detalleCuota);
+  const cuotasDisponiblesParaPago =
+    pagoForm.tipo === "matricula"
+      ? cuotasParaPago.cuotasMatricula
+      : pagoForm.tipo === "cuota"
+        ? cuotasParaPago.cuotasMensuales
+        : [];
+  const pagoDialogTitle =
+    pagoForm.tipo === "sueldo"
+      ? "Registrar recibo de sueldo"
+      : pagoForm.tipo === "matricula"
+        ? "Registrar pago de matrícula"
+        : "Registrar pago de cuota";
+  const pagoDialogDescription =
+    pagoForm.tipo === "sueldo"
+      ? "Cargá el recibo correspondiente y dejá constancia para el personal."
+      : pagoForm.tipo === "matricula"
+        ? "Registrá un pago asociado a la matrícula seleccionada."
+        : "Registrá un pago asociado a la cuota seleccionada.";
 
   return (
     <DashboardLayout>
-      <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
+      <div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h2 className="text-3xl font-bold tracking-tight">Pagos</h2>
-            <p className="text-muted-foreground">
-              Gestión de cuotas, matrículas y pagos del personal
+            <h2 className="text-3xl font-bold tracking-tight">Pagos y cuotas</h2>
+            <p className="text-sm text-muted-foreground">
+              {isAdmin
+                ? "Generá cuotas, registrá pagos y administrá los recibos del personal."
+                : isTeacher
+                  ? "Consultá tus recibos de sueldo y confirmá la recepción."
+                  : "Accedé al estado de cuotas y matrículas de tu familia."}
             </p>
           </div>
         </div>
 
-        {/* Contenido según perfil */}
-        {userProfile === "familia" && renderFamiliaView()}
-        {userProfile === "administracion" && (
+        {!availableTabs.length ? (
+          <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+            No tenés acceso a la información de pagos en este momento.
+          </div>
+        ) : (
           <Tabs
             value={selectedTab}
-            onValueChange={setSelectedTab}
-            className="space-y-4"
+            onValueChange={(value) => setSelectedTab(value)}
+            className="space-y-6"
           >
-            <TabsList>
-              <TabsTrigger value="cuotas">Cuotas y Matrículas</TabsTrigger>
-              <TabsTrigger value="personal">Pagos Personal</TabsTrigger>
+            <TabsList className="w-full justify-start overflow-x-auto sm:w-auto">
+              {availableTabs.map((tab) => (
+                <TabsTrigger key={tab.value} value={tab.value}>
+                  {tab.label}
+                </TabsTrigger>
+              ))}
             </TabsList>
 
-            <TabsContent value="cuotas">
-              {renderAdministracionView()}
-            </TabsContent>
+            {availableTabs.some((tab) => tab.value === "cuotas") && (
+              <TabsContent
+                value="cuotas"
+                className="space-y-6 focus-visible:outline-none"
+              >
+                {renderCuotasTab()}
+              </TabsContent>
+            )}
 
-            <TabsContent value="personal" className="space-y-4">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Pagos del Personal</CardTitle>
-                  <CardDescription>
-                    Gestión de sueldos y pagos al personal docente
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-3">
-                    {personal.map((persona) => (
-                      <div
-                        key={persona.id}
-                        className="flex items-center justify-between p-3 border rounded-lg"
-                      >
-                        <div>
-                          <p className="font-medium">{persona.nombre}</p>
-                          <p className="text-sm text-gray-600">
-                            {persona.cargo}
-                          </p>
-                        </div>
-                        <div className="flex items-center space-x-4">
-                          <div className="text-right">
-                            <p className="font-medium">
-                              {formatMonto(persona.sueldo)}
-                            </p>
-                            <p className="text-sm text-gray-600">
-                              {persona.fecha}
-                            </p>
-                          </div>
-                          <Badge
-                            variant={persona.recibido ? "default" : "secondary"}
-                          >
-                            {persona.recibido ? (
-                              <CheckCircle className="h-3 w-3 mr-1" />
-                            ) : (
-                              <AlertCircle className="h-3 w-3 mr-1" />
-                            )}
-                            {persona.recibido ? "Recibido" : "Pendiente"}
-                          </Badge>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            </TabsContent>
+            {availableTabs.some((tab) => tab.value === "pagos") && (
+              <TabsContent
+                value="pagos"
+                className="space-y-6 focus-visible:outline-none"
+              >
+                {renderPagosTab()}
+              </TabsContent>
+            )}
+
+            {availableTabs.some((tab) => tab.value === "recibos") && (
+              <TabsContent
+                value="recibos"
+                className="space-y-6 focus-visible:outline-none"
+              >
+                {renderRecibosTab()}
+              </TabsContent>
+            )}
           </Tabs>
         )}
-        {userProfile === "personal" && renderPersonalView()}
+
+        <Dialog
+          open={!!detalleCuota}
+          onOpenChange={(open) => {
+            if (!open) setDetalleCuota(null);
+          }}
+        >
+          <DialogContent className="max-w-xl">
+            {detalleCuota && (
+              <div className="space-y-6">
+                <DialogHeader>
+                  <DialogTitle>Detalle de cuota</DialogTitle>
+                  <DialogDescription>
+                    Información completa de la cuota seleccionada.
+                  </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold">
+                      {conceptoTexto(detalleCuota)}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {formatMonthAndYear(
+                        detalleCuota.mes ?? undefined,
+                        detalleCuota.anio ?? undefined,
+                      )}
+                    </p>
+                  </div>
+                  {(() => {
+                    const info = cuotaEstadoInfo(detalleCuota);
+                    return <Badge variant={info.variant}>{info.label}</Badge>;
+                  })()}
+                </div>
+
+                <div className="grid gap-3 text-sm md:grid-cols-2">
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase text-muted-foreground">Alumno</p>
+                    <p className="font-medium">
+                      {getAlumnoNombre(detalleCuota.matriculaId)}
+                    </p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase text-muted-foreground">Sección</p>
+                    <p className="font-medium">
+                      {getAlumnoSeccion(detalleCuota.matriculaId)}
+                    </p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase text-muted-foreground">Vencimiento</p>
+                    <p className="font-medium">
+                      {formatDate(detalleCuota.fechaVencimiento)}
+                    </p>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase text-muted-foreground">Código de pago</p>
+                    <p className="font-mono text-sm">
+                      {detalleCuota.codigoPago ?? "—"}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-2 rounded-md border p-3 text-sm">
+                  <p className="font-semibold">Importe y recargo</p>
+                  <div className="flex items-center justify-between">
+                    <span>Importe base</span>
+                    <span>{formatCurrency(detalleCuota.importe)}</span>
+                  </div>
+                  {detalleRecargo.porcentaje > 0 ? (
+                    <>
+                      <div className="flex items-center justify-between text-muted-foreground">
+                        <span>Recargo ({detalleRecargo.porcentaje}%)</span>
+                        <span>{formatCurrency(detalleRecargo.recargo)}</span>
+                      </div>
+                      <div className="flex items-center justify-between font-semibold">
+                        <span>Total con recargo</span>
+                        <span>{formatCurrency(detalleRecargo.total)}</span>
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-muted-foreground">
+                      Sin recargo configurado para esta cuota.
+                    </p>
+                  )}
+                </div>
+
+                {detalleCuota.observaciones && (
+                  <div className="space-y-1 text-sm">
+                    <p className="font-semibold">Observaciones</p>
+                    <p className="whitespace-pre-wrap text-muted-foreground">
+                      {detalleCuota.observaciones}
+                    </p>
+                  </div>
+                )}
+
+                <DialogFooter className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-sm text-muted-foreground">
+                    Código:
+                    <span className="ml-1 font-mono">
+                      {detalleCuota.codigoPago ?? "—"}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() =>
+                        copyToClipboard(
+                          detalleCuota.codigoPago ?? "",
+                          "Código de pago copiado",
+                        )
+                      }
+                    >
+                      <Download className="mr-2 h-4 w-4" /> Copiar código
+                    </Button>
+                    <Button type="button" onClick={() => setDetalleCuota(null)}>
+                      Cerrar
+                    </Button>
+                  </div>
+                </DialogFooter>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+
+        <Dialog
+          open={createDialogOpen}
+          onOpenChange={(open) => {
+            setCreateDialogOpen(open);
+            if (!open) {
+              resetCreateForm();
+            }
+          }}
+        >
+          <DialogContent className="max-w-3xl">
+            <form onSubmit={handleSubmitNuevaCuota} className="space-y-6">
+              <DialogHeader>
+                <DialogTitle>Nueva cuota</DialogTitle>
+                <DialogDescription>
+                  Definí el período, concepto e importe que se aplicará a las secciones
+                  seleccionadas.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-3">
+                  <Label>Secciones</Label>
+                  <div className="max-h-60 space-y-2 overflow-auto rounded-md border p-3 text-sm">
+                    {seccionesLoading ? (
+                      <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin" /> Cargando secciones...
+                      </div>
+                    ) : !seccionesOrdenadas.length ? (
+                      <p className="text-muted-foreground">
+                        No hay secciones disponibles para generar cuotas.
+                      </p>
+                    ) : (
+                      seccionesOrdenadas.map((seccion) => {
+                        if (seccion.id == null) return null;
+                        const checked = createForm.seccionIds.includes(seccion.id);
+                        const nombreSeccion = [
+                          seccion.nivel,
+                          seccion.gradoSala,
+                          seccion.division,
+                        ]
+                          .filter(Boolean)
+                          .join(" ")
+                          .trim();
+                        return (
+                          <div key={seccion.id} className="flex items-center gap-2">
+                            <Checkbox
+                              id={`seccion-${seccion.id}`}
+                              checked={checked}
+                              onCheckedChange={(value) =>
+                                toggleSeccion(seccion.id!, Boolean(value))
+                              }
+                            />
+                            <Label
+                              htmlFor={`seccion-${seccion.id}`}
+                              className="flex-1 cursor-pointer text-sm"
+                            >
+                              {nombreSeccion || `Sección #${seccion.id}`}
+                            </Label>
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 text-sm">
+                    <Checkbox
+                      id="matricula"
+                      checked={createForm.matricula}
+                      onCheckedChange={(value) =>
+                        setCreateForm((prev) => ({
+                          ...prev,
+                          matricula: Boolean(value),
+                        }))
+                      }
+                    />
+                    <Label htmlFor="matricula" className="cursor-pointer">
+                      Marcar como matrícula
+                    </Label>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Las cuotas de matrícula no requieren selección de mes y se generan una única
+                    vez por ciclo lectivo.
+                  </p>
+                </div>
+
+                <div className="space-y-4">
+                  <div className="grid gap-2">
+                    <Label htmlFor="concepto">Concepto</Label>
+                    <Select
+                      value={createForm.concepto}
+                      onValueChange={(value) =>
+                        setCreateForm((prev) => ({
+                          ...prev,
+                          concepto: value as ConceptoCuota,
+                        }))
+                      }
+                      disabled={createForm.matricula}
+                    >
+                      <SelectTrigger id="concepto">
+                        <SelectValue placeholder="Seleccioná un concepto" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(CONCEPTO_LABELS).map(([value, label]) => (
+                          <SelectItem key={value} value={value}>
+                            {label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="grid gap-2">
+                    <Label htmlFor="titulo">Título o descripción</Label>
+                    <Input
+                      id="titulo"
+                      value={createForm.titulo}
+                      onChange={(event) =>
+                        setCreateForm((prev) => ({
+                          ...prev,
+                          titulo: event.target.value,
+                        }))
+                      }
+                      placeholder="Ej. Marzo 2025"
+                    />
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="grid gap-2">
+                      <Label htmlFor="anio">Año</Label>
+                      <Input
+                        id="anio"
+                        type="number"
+                        value={createForm.anio}
+                        onChange={(event) =>
+                          setCreateForm((prev) => ({
+                            ...prev,
+                            anio: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="mes">Mes</Label>
+                      <Select
+                        value={createForm.mes}
+                        onValueChange={(value) =>
+                          setCreateForm((prev) => ({
+                            ...prev,
+                            mes: value,
+                          }))
+                        }
+                        disabled={createForm.matricula}
+                      >
+                        <SelectTrigger id="mes">
+                          <SelectValue placeholder="Seleccioná el mes" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {MONTH_LABELS.map((label, index) => {
+                            const value = String(index + 1);
+                            return (
+                              <SelectItem key={value} value={value}>
+                                {label.charAt(0).toUpperCase() + label.slice(1)}
+                              </SelectItem>
+                            );
+                          })}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-2">
+                    <Label htmlFor="importe">Importe</Label>
+                    <Input
+                      id="importe"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={createForm.importe}
+                      onChange={(event) =>
+                        setCreateForm((prev) => ({
+                          ...prev,
+                          importe: event.target.value,
+                        }))
+                      }
+                      placeholder="0,00"
+                    />
+                  </div>
+
+                  <div className="grid gap-2">
+                    <Label htmlFor="fechaVencimiento">Fecha de vencimiento</Label>
+                    <Input
+                      id="fechaVencimiento"
+                      type="date"
+                      value={createForm.fechaVencimiento}
+                      onChange={(event) =>
+                        setCreateForm((prev) => ({
+                          ...prev,
+                          fechaVencimiento: event.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+
+                  <div className="grid gap-2">
+                    <Label htmlFor="porcentajeRecargo">Recargo por mora (%)</Label>
+                    <Input
+                      id="porcentajeRecargo"
+                      type="number"
+                      step="0.1"
+                      min="0"
+                      value={createForm.porcentajeRecargo}
+                      onChange={(event) =>
+                        setCreateForm((prev) => ({
+                          ...prev,
+                          porcentajeRecargo: event.target.value,
+                        }))
+                      }
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Este porcentaje se aplicará automáticamente a los pagos fuera de término.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setCreateDialogOpen(false)}
+                >
+                  Cancelar
+                </Button>
+                <Button type="submit" disabled={creatingCuota}>
+                  {creatingCuota && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Crear cuota
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog
+          open={pagoDialogOpen}
+          onOpenChange={(open) => {
+            setPagoDialogOpen(open);
+            if (!open) {
+              resetPagoForm();
+            }
+          }}
+        >
+          <DialogContent className="max-w-2xl">
+            <form onSubmit={handleSubmitPago} className="space-y-6">
+              <DialogHeader>
+                <DialogTitle>{pagoDialogTitle}</DialogTitle>
+                <DialogDescription>{pagoDialogDescription}</DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="tipoRegistro">Tipo de registro</Label>
+                  <Select
+                    value={pagoForm.tipo}
+                    onValueChange={(value) =>
+                      setPagoForm((prev) => ({
+                        ...prev,
+                        tipo: value as typeof pagoForm.tipo,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="tipoRegistro">
+                      <SelectValue placeholder="Seleccioná el tipo" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="cuota">Pago de cuota</SelectItem>
+                      <SelectItem value="matricula">Pago de matrícula</SelectItem>
+                      <SelectItem value="sueldo">Recibo de sueldo</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {pagoForm.tipo === "sueldo" ? (
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="grid gap-2 md:col-span-2">
+                      <Label htmlFor="empleado">Empleado</Label>
+                      <Select
+                        value={pagoForm.empleadoId}
+                        onValueChange={(value) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            empleadoId: value,
+                          }))
+                        }
+                      >
+                        <SelectTrigger id="empleado">
+                          <SelectValue placeholder="Seleccioná un empleado" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {!empleados.length ? (
+                            <SelectItem value="" disabled>
+                              No hay empleados disponibles
+                            </SelectItem>
+                          ) : (
+                            empleados.map((empleado) => (
+                              <SelectItem
+                                key={empleado.id}
+                                value={empleado.id != null ? String(empleado.id) : ""}
+                                disabled={empleado.id == null}
+                              >
+                                {getEmpleadoNombre(empleado.id)}
+                              </SelectItem>
+                            ))
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="anioRecibo">Año</Label>
+                      <Input
+                        id="anioRecibo"
+                        type="number"
+                        value={pagoForm.anio}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            anio: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="mesRecibo">Mes</Label>
+                      <Select
+                        value={pagoForm.mes}
+                        onValueChange={(value) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            mes: value,
+                          }))
+                        }
+                      >
+                        <SelectTrigger id="mesRecibo">
+                          <SelectValue placeholder="Seleccioná el mes" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {MONTH_LABELS.map((label, index) => {
+                            const value = String(index + 1);
+                            return (
+                              <SelectItem key={value} value={value}>
+                                {label.charAt(0).toUpperCase() + label.slice(1)}
+                              </SelectItem>
+                            );
+                          })}
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="bruto">Monto bruto</Label>
+                      <Input
+                        id="bruto"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={pagoForm.bruto}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            bruto: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="neto">Monto neto</Label>
+                      <Input
+                        id="neto"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={pagoForm.neto}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            neto: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+
+                    <div className="grid gap-2 md:col-span-2">
+                      <Label htmlFor="comprobanteRecibo">Identificador de comprobante</Label>
+                      <Input
+                        id="comprobanteRecibo"
+                        value={pagoForm.comprobanteId}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            comprobanteId: event.target.value,
+                          }))
+                        }
+                        placeholder="ID del archivo o referencia"
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="grid gap-2 md:col-span-2">
+                      <Label htmlFor="cuotaId">Cuota</Label>
+                      <Select
+                        value={pagoForm.cuotaId}
+                        onValueChange={(value) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            cuotaId: value,
+                          }))
+                        }
+                      >
+                        <SelectTrigger id="cuotaId">
+                          <SelectValue placeholder="Seleccioná una cuota" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {!cuotasDisponiblesParaPago.length ? (
+                            <SelectItem value="" disabled>
+                              No hay cuotas disponibles
+                            </SelectItem>
+                          ) : (
+                            cuotasDisponiblesParaPago.map((cuota) => (
+                              <SelectItem
+                                key={cuota.id}
+                                value={cuota.id != null ? String(cuota.id) : ""}
+                                disabled={cuota.id == null}
+                              >
+                                {`${conceptoTexto(cuota)} · ${getAlumnoNombre(
+                                  cuota.matriculaId,
+                                )} · ${formatMonthAndYear(
+                                  cuota.mes ?? undefined,
+                                  cuota.anio ?? undefined,
+                                )}`}
+                              </SelectItem>
+                            ))
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="fechaPago">Fecha de pago</Label>
+                      <Input
+                        id="fechaPago"
+                        type="date"
+                        value={pagoForm.fecha}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            fecha: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="montoPago">Monto abonado</Label>
+                      <Input
+                        id="montoPago"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={pagoForm.monto}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            monto: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="medioPago">Medio de pago</Label>
+                      <Select
+                        value={pagoForm.medioPago}
+                        onValueChange={(value) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            medioPago: value as MedioPago,
+                          }))
+                        }
+                      >
+                        <SelectTrigger id="medioPago">
+                          <SelectValue placeholder="Seleccioná un medio" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {medioPagoOptions.map((medio) => (
+                            <SelectItem key={medio} value={medio}>
+                              {formatMedioPagoLabel(medio)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="referencia">Referencia externa</Label>
+                      <Input
+                        id="referencia"
+                        value={pagoForm.referencia}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            referencia: event.target.value,
+                          }))
+                        }
+                        placeholder="Número de comprobante, transacción, etc."
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <Label htmlFor="comprobante">Identificador de comprobante</Label>
+                      <Input
+                        id="comprobante"
+                        value={pagoForm.comprobanteId}
+                        onChange={(event) =>
+                          setPagoForm((prev) => ({
+                            ...prev,
+                            comprobanteId: event.target.value,
+                          }))
+                        }
+                        placeholder="ID del archivo o referencia"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setPagoDialogOpen(false)}
+                >
+                  Cancelar
+                </Button>
+                <Button type="submit" disabled={registrandoPago}>
+                  {registrandoPago && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Guardar
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   );
+}
+
+function detallesRecargo(cuota?: CuotaDTO | null) {
+  const importe = Number(cuota?.importe ?? 0);
+  const porcentaje = Number(cuota?.porcentajeRecargo ?? 0);
+  const safeImporte = Number.isFinite(importe) ? importe : 0;
+  const safePorcentaje = Number.isFinite(porcentaje) ? porcentaje : 0;
+  const recargo = safeImporte * (safePorcentaje / 100);
+  return {
+    porcentaje: Math.round(safePorcentaje * 100) / 100,
+    recargo,
+    total: safeImporte + recargo,
+  };
+}
+
+function formatMedioPagoLabel(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
 }

--- a/frontend-ecep/src/services/api/modules/finanzas.ts
+++ b/frontend-ecep/src/services/api/modules/finanzas.ts
@@ -14,6 +14,8 @@ export const cuotas = {
   list: () => http.get<DTO.CuotaDTO[]>('/api/cuotas'),
   byId: (id: number) => http.get<DTO.CuotaDTO>('/api/cuotas/' + id),
   create: (body: DTO.CuotaCreateDTO) => http.post<number>('/api/cuotas', body),
+  bulkCreate: (body: DTO.CuotaBulkCreateDTO) =>
+    http.post<number[]>('/api/cuotas/bulk', body),
   update: (id: number, body: DTO.CuotaDTO) => http.put<void>('/api/cuotas/' + id, body),
   delete: (id: number) => http.delete<void>('/api/cuotas/' + id),
 };

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -359,6 +359,19 @@ export interface CuotaCreateDTO {
   observaciones?: string;
 }
 
+export interface CuotaBulkCreateDTO {
+  seccionIds: number[];
+  concepto?: ConceptoCuota;
+  subconcepto?: string;
+  anio?: number;
+  mes?: number;
+  importe: number;
+  fechaVencimiento: ISODate;
+  porcentajeRecargo?: number;
+  observaciones?: string;
+  matricula?: boolean;
+}
+
 export interface CuotaDTO {
   id: number;
   matriculaId?: number;


### PR DESCRIPTION
## Summary
- move the recibos tab renderer inside `PagosPage` so it can access role-aware state, payment handlers and dialog toggles
- drop the stray duplicate implementation that lived after the component to prevent scope errors when rendering tabs

## Testing
- `npm install` *(fails: registry returns 403 when fetching @hookform/resolvers)*
- `npm run lint` *(fails: `next` binary missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc64476480832796e30b9cdcebc4dc