### PR TITLE
Fix section options memo reference

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -87,6 +87,24 @@ export default function AlumnoPerfilPage() {
 
   const { periodoEscolarId: activePeriodId } = useActivePeriod();
 
+  // helpers
+  const toNombre = (p?: PersonaDTO | null) =>
+    p
+      ? `${p.apellido ?? ""}, ${p.nombre ?? ""}`.trim().replace(/^, /, "") ||
+        "—"
+      : "—";
+
+  const seccionLabel = (sid?: number | null, mapOverride?: Map<number, SeccionDTO>) => {
+    if (!sid) return "—";
+    const sourceMap = mapOverride ?? seccionesMap;
+    const s = sourceMap.get(sid);
+    if (!s) return `Sección #${sid}`;
+    const grado = (s as any).gradoSala ?? (s as any).grado ?? "";
+    const div = (s as any).division ?? "";
+    const turno = (s as any).turno ?? "";
+    return `${grado} ${div} ${turno}`.trim();
+  };
+
   const sectionOptions = useMemo(() => {
     if (!seccionesList.length) return [] as { id: string; label: string }[];
     return seccionesList
@@ -150,24 +168,6 @@ export default function AlumnoPerfilPage() {
   const [addEsTutor, setAddEsTutor] = useState(false);
   const [savingFamily, setSavingFamily] = useState(false);
   const [familiaresCatalog, setFamiliaresCatalog] = useState<FamiliarDTO[]>([]);
-
-  // helpers
-  const toNombre = (p?: PersonaDTO | null) =>
-    p
-      ? `${p.apellido ?? ""}, ${p.nombre ?? ""}`.trim().replace(/^, /, "") ||
-        "—"
-      : "—";
-
-  const seccionLabel = (sid?: number | null, mapOverride?: Map<number, SeccionDTO>) => {
-    if (!sid) return "—";
-    const sourceMap = mapOverride ?? seccionesMap;
-    const s = sourceMap.get(sid);
-    if (!s) return `Sección #${sid}`;
-    const grado = (s as any).gradoSala ?? (s as any).grado ?? "";
-    const div = (s as any).division ?? "";
-    const turno = (s as any).turno ?? "";
-    return `${grado} ${div} ${turno}`.trim();
-  };
 
   // carga
   useEffect(() => {


### PR DESCRIPTION
## Summary
- move helper helpers before the section options memo to avoid referencing them before initialization

## Testing
- npm install *(fails: registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6ef4bd948327b8ae5ef9a93eba13