### PR TITLE
Fix alumno profile role formatting helper

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -123,6 +123,11 @@ export default function AlumnoPerfilPage() {
       }));
   }, [seccionesList, seccionesMap, activePeriodId]);
   const rolOptions = useMemo(() => Object.values(RolVinculo), []);
+  const formatRol = (value?: RolVinculo | string | null) => {
+    if (!value) return "Sin vínculo";
+    const formatted = String(value).replace(/_/g, " ").toLowerCase();
+    return formatted.replace(/\b\w/g, (char) => char.toUpperCase());
+  };
 
   const [editOpen, setEditOpen] = useState(false);
   const [savingProfile, setSavingProfile] = useState(false);


### PR DESCRIPTION
## Summary
- add the missing `formatRol` helper in the alumno profile page so familiar roles render correctly

## Testing
- bun install *(fails: npm registry responds 403, so lint/tests could not be executed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc70b96f4c832790843021689893fc