### PR TITLE
fix: stabilize active trimestre badge rendering

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ActiveTrimestreBadge.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ActiveTrimestreBadge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { ComponentProps } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
+import { cn } from "@/lib/utils";
+import { formatTrimestreRange, getTrimestreEstado } from "@/lib/trimestres";
+
+interface ActiveTrimestreBadgeProps {
+  className?: string;
+}
+
+export function ActiveTrimestreBadge({ className }: ActiveTrimestreBadgeProps) {
+  const { trimestreActivo, loading } = useActivePeriod();
+
+  let label = "Sin trimestre activo";
+  let description = "";
+  let variant: ComponentProps<typeof Badge>["variant"] = "secondary";
+
+  if (trimestreActivo) {
+    const estado = getTrimestreEstado(trimestreActivo);
+    const range = formatTrimestreRange(trimestreActivo);
+    const numero = trimestreActivo.orden;
+    const numeroLabel = numero ? ` ${numero}` : "";
+
+    description = range ?? "";
+
+    switch (estado) {
+      case "activo":
+        label = `Trimestre${numeroLabel} activo`;
+        variant = "outline";
+        break;
+      case "cerrado":
+        label = `Trimestre${numeroLabel} cerrado`;
+        variant = "secondary";
+        break;
+      default:
+        label = `Trimestre${numeroLabel} sin estado`;
+        variant = "secondary";
+        break;
+    }
+  }
+
+  if (loading || (!label && !description)) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      <Badge variant={variant} className="whitespace-nowrap">
+        {label}
+      </Badge>
+      {description ? <span>{description}</span> : null}
+    </div>
+  );
+}

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/NuevaAsistenciaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/NuevaAsistenciaDialog.tsx
@@ -29,6 +29,11 @@ import type {
   TrimestreDTO,
   DetalleAsistenciaCreateDTO,
 } from "@/types/api-generated";
+import {
+  getTrimestreFin,
+  getTrimestreInicio,
+  isFechaDentroDeTrimestre,
+} from "@/lib/trimestres";
 
 function fmt(d?: string | null) {
   if (!d) return "";
@@ -126,10 +131,7 @@ export default function NuevaAsistenciaDialog({
     setDateError(computeDateError(fecha));
   }, [open, fecha, busyDates, computeDateError]);
 
-  const dentro =
-    !!trimestre &&
-    fecha >= fmt(trimestre?.fechaInicio ?? undefined) &&
-    fecha <= fmt(trimestre?.fechaFin ?? undefined);
+  const dentro = isFechaDentroDeTrimestre(fecha, trimestre);
   const marcar = (matriculaId: number, estado: EstadoAsistencia) =>
     setMarcas((m) => ({ ...m, [matriculaId]: estado }));
 
@@ -208,8 +210,8 @@ export default function NuevaAsistenciaDialog({
             <Input
               type="date"
               value={fecha}
-              min={fmt(trimestre?.fechaInicio ?? undefined)}
-              max={fmt(trimestre?.fechaFin ?? undefined)}
+              min={getTrimestreInicio(trimestre) || undefined}
+              max={getTrimestreFin(trimestre) || undefined}
               onChange={(e) => {
                 const value = e.target.value;
                 setFecha(value);

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDocente.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDocente.tsx
@@ -24,6 +24,10 @@ import {
   DialogDescription,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  getTrimestreEstado,
+  isFechaDentroDeTrimestre,
+} from "@/lib/trimestres";
 
 const DBG = !!process.env.NEXT_PUBLIC_DEBUG;
 const dlog = (...a: any[]) => DBG && console.log("[VistaDocente]", ...a);
@@ -90,9 +94,8 @@ export default function VistaDocente() {
     const t =
       trimestres.find(
         (tr) =>
-          !tr.cerrado &&
-          nowKey >= fmt(tr.fechaInicio ?? undefined) &&
-          nowKey <= fmt(tr.fechaFin ?? undefined),
+          getTrimestreEstado(tr) !== "cerrado" &&
+          isFechaDentroDeTrimestre(nowKey, tr),
       ) ?? null;
 
     dgrp("calculo trimestreHoy");

--- a/frontend-ecep/src/app/dashboard/asistencia/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { NewJornadaDialog } from "@/app/dashboard/asistencia/_components/NewJornadaDialog";
+import { ActiveTrimestreBadge } from "@/app/dashboard/_components/ActiveTrimestreBadge";
 
 /* =========================
    PAGE
@@ -44,6 +45,7 @@ export default function AsistenciaPage() {
                   ? "Dirección — Seguimiento integral por secciones y alumnos"
                   : "Consulta"}
             </p>
+            <ActiveTrimestreBadge className="mt-2" />
           </div>
         </header>
 

--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -22,6 +22,7 @@ import type {
   AsistenciaAlumnoResumenDTO,
 } from "@/types/api-generated";
 import { toast } from "sonner";
+import { ActiveTrimestreBadge } from "@/app/dashboard/_components/ActiveTrimestreBadge";
 
 function fmt(iso?: string) {
   if (!iso) return "—";
@@ -157,6 +158,7 @@ export default function SeccionHistorialPage() {
               Turno: {seccion?.turno ?? "—"}
             </p>
             {secErr && <p className="text-sm text-red-600">{secErr}</p>}
+            <ActiveTrimestreBadge className="mt-2" />
           </div>
 
           <div className="flex items-center gap-2">

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
@@ -20,6 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { getTrimestreEstado, isFechaDentroDeTrimestre } from "@/lib/trimestres";
 
 type Row = {
   matriculaId: number;
@@ -51,18 +52,14 @@ export default function NotasExamenDialog({
     const triId = (evaluacion as any)?.trimestreId as number | undefined;
     if (triId) return triId;
     if (!fecha) return undefined;
-    const tri = trimestres.find(
-      (t) =>
-        fecha >= ((t as any).fechaInicio ?? "0000-00-00") &&
-        fecha <= ((t as any).fechaFin ?? "9999-12-31"),
-    );
+    const tri = trimestres.find((t) => isFechaDentroDeTrimestre(fecha, t));
     return tri?.id;
   }, [evaluacion, trimestres, fecha]);
 
   const trimestreCerrado = useMemo(() => {
     if (!trimestreId) return false;
     const tri = trimestres.find((t) => t.id === trimestreId);
-    return !!tri?.cerrado;
+    return getTrimestreEstado(tri) === "cerrado";
   }, [trimestres, trimestreId]);
 
   const fetchSeccionIdFromEval = async (): Promise<number> => {

--- a/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
@@ -24,6 +24,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { ActiveTrimestreBadge } from "@/app/dashboard/_components/ActiveTrimestreBadge";
 
 function isPrimario(s: SeccionDTO): boolean {
   const n = (s as any)?.nivel as NivelAcademico | undefined;
@@ -173,6 +174,7 @@ export default function EvaluacionesIndexPage() {
               <Badge variant="outline">Primario</Badge>
               <Badge variant="outline">Período {periodoEscolarId ?? "—"}</Badge>
             </div>
+            <ActiveTrimestreBadge className="mt-2" />
           </div>
         </div>
 

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -12,6 +12,8 @@ import type {
   EvaluacionDTO,
 } from "@/types/api-generated";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
+import { ActiveTrimestreBadge } from "@/app/dashboard/_components/ActiveTrimestreBadge";
+import { getTrimestreEstado } from "@/lib/trimestres";
 
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -50,7 +52,7 @@ export default function SeccionEvaluacionesPage() {
   const { id } = useParams<{ id: string }>();
   const seccionId = Number(id);
   const router = useRouter();
-  const { trimestres } = useActivePeriod();
+  const { getTrimestreByDate } = useActivePeriod();
 
   // Data
   const [loading, setLoading] = useState(true);
@@ -178,13 +180,13 @@ export default function SeccionEvaluacionesPage() {
       setCreating(true);
 
       // Resolver trimestre por fecha
-      const tri = trimestres.find(
-        (t) =>
-          fecha >= ((t as any).fechaInicio ?? "0000-00-00") &&
-          fecha <= ((t as any).fechaFin ?? "9999-12-31"),
-      );
-      if (!tri || (tri as any).cerrado) {
-        alert("La fecha seleccionada no cae en un trimestre activo.");
+      const tri = getTrimestreByDate(fecha);
+      if (!tri) {
+        alert("La fecha seleccionada no coincide con un trimestre configurado.");
+        return;
+      }
+      if (getTrimestreEstado(tri) === "cerrado") {
+        alert("La fecha seleccionada cae en un trimestre cerrado.");
         return;
       }
 
@@ -265,6 +267,7 @@ export default function SeccionEvaluacionesPage() {
                 {evaluaciones.length === 1 ? "examen" : "exámenes"}
               </Badge>
             </div>
+            <ActiveTrimestreBadge className="mt-2" />
           </div>
           <div className="flex items-center gap-2">
             {/* Filtro materia */}

--- a/frontend-ecep/src/lib/trimestres.ts
+++ b/frontend-ecep/src/lib/trimestres.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import type { TrimestreDTO } from "@/types/api-generated";
+
+const toDateInput = (value?: string | null) => {
+  if (!value) return "";
+  const str = String(value);
+  return str.length > 10 ? str.slice(0, 10) : str;
+};
+
+type MaybeTrimestre = Partial<TrimestreDTO> & Record<string, unknown>;
+
+const getRawInicio = (t?: MaybeTrimestre | null) =>
+  (t?.inicio as string | undefined) ??
+  (t?.fechaInicio as string | undefined) ??
+  (t?.fecha_inicio as string | undefined) ??
+  null;
+
+const getRawFin = (t?: MaybeTrimestre | null) =>
+  (t?.fin as string | undefined) ??
+  (t?.fechaFin as string | undefined) ??
+  (t?.fecha_fin as string | undefined) ??
+  null;
+
+export const getTrimestreInicio = (
+  t?: MaybeTrimestre | TrimestreDTO | null,
+): string => toDateInput(getRawInicio(t as MaybeTrimestre));
+
+export const getTrimestreFin = (
+  t?: MaybeTrimestre | TrimestreDTO | null,
+): string => toDateInput(getRawFin(t as MaybeTrimestre));
+
+export const resolveTrimestrePeriodoId = (
+  t: MaybeTrimestre | TrimestreDTO,
+  fallback?: number | null,
+): number | undefined =>
+  (t?.periodoEscolarId as number | undefined) ??
+  (t?.periodoId as number | undefined) ??
+  (t as any)?.periodoEscolar?.id ??
+  (fallback ?? undefined);
+
+export type TrimestreEstado = "cerrado" | "activo" | "sin-estado";
+
+export const getTrimestreEstado = (
+  t?: MaybeTrimestre | TrimestreDTO | null,
+): TrimestreEstado => {
+  if (!t) return "sin-estado";
+  if (t.cerrado === true) return "cerrado";
+  if (t.cerrado === false) return "activo";
+  return "sin-estado";
+};
+
+const formatSimpleDate = (iso?: string) => {
+  if (!iso) return null;
+  const [year, month, day] = iso.split("-");
+  if (!year || !month || !day) return null;
+  const dd = day.padStart(2, "0");
+  const mm = month.padStart(2, "0");
+  return `${dd}/${mm}/${year}`;
+};
+
+export const formatTrimestreRange = (
+  t?: MaybeTrimestre | TrimestreDTO | null,
+): string | null => {
+  const inicio = getTrimestreInicio(t);
+  const fin = getTrimestreFin(t);
+  if (!inicio && !fin) return null;
+  const inicioFmt = formatSimpleDate(inicio) ?? inicio;
+  const finFmt = formatSimpleDate(fin) ?? fin;
+  if (inicio && fin) {
+    return `Del ${inicioFmt} al ${finFmt}`;
+  }
+  if (inicio) {
+    return `Desde ${inicioFmt}`;
+  }
+  if (fin) {
+    return `Hasta ${finFmt}`;
+  }
+  return null;
+};
+
+export const isFechaDentroDeTrimestre = (
+  fechaISO: string,
+  trimestre?: MaybeTrimestre | TrimestreDTO | null,
+): boolean => {
+  if (!trimestre) return false;
+  const inicio = getTrimestreInicio(trimestre);
+  const fin = getTrimestreFin(trimestre);
+  const afterStart = !inicio || fechaISO >= inicio;
+  const beforeEnd = !fin || fechaISO <= fin;
+  return afterStart && beforeEnd;
+};


### PR DESCRIPTION
## Summary
- compute the active trimester badge label without conditional hooks to prevent runtime errors
- handle closed and missing trimester cases explicitly while keeping existing badge styling

## Testing
- npm run lint *(fails: `next` executable missing because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd528d1a588327817435cef59048fb