### PR TITLE
Enforce date validations and birthdate rules

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -509,13 +509,25 @@ export default function AccidentesIndexPage() {
             <Input
               type="date"
               value={fromDate}
-              onChange={(e) => setFromDate(e.target.value)}
+              onChange={(e) => {
+                const value = e.target.value;
+                setFromDate(value);
+                if (value && toDate && value > toDate) {
+                  setToDate(value);
+                }
+              }}
             />
             <span className="text-xs text-muted-foreground">a</span>
             <Input
               type="date"
               value={toDate}
-              onChange={(e) => setToDate(e.target.value)}
+              onChange={(e) => {
+                const value = e.target.value;
+                setToDate(value);
+                if (value && fromDate && value < fromDate) {
+                  setFromDate(value);
+                }
+              }}
             />
           </div>
 

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -37,6 +37,7 @@ import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { api } from "@/services/api";
+import { isBirthDateValid, maxBirthDate } from "@/lib/form-utils";
 import type {
   AlumnoDTO,
   FamiliarDTO,
@@ -461,6 +462,16 @@ export default function AlumnoPerfilPage() {
       return;
     }
 
+    if (
+      personaDraft.fechaNacimiento &&
+      !isBirthDateValid(personaDraft.fechaNacimiento)
+    ) {
+      toast.error(
+        "La fecha de nacimiento debe ser al menos dos años anterior a hoy.",
+      );
+      return;
+    }
+
     setSavingProfile(true);
     const todayIso = new Date().toISOString().slice(0, 10);
 
@@ -818,6 +829,7 @@ export default function AlumnoPerfilPage() {
                         <Label>Fecha de nacimiento</Label>
                         <Input
                           type="date"
+                          max={maxBirthDate}
                           value={personaDraft.fechaNacimiento}
                           onChange={(e) =>
                             setPersonaDraft((prev) => ({

--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { api } from "@/services/api";
+import { isBirthDateValid, maxBirthDate } from "@/lib/form-utils";
 import type * as DTO from "@/types/api-generated";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
@@ -182,6 +183,15 @@ export default function AltaAlumnoPage() {
   const handleCrearAlumno = async () => {
     if (!alumnoForm.seccionId) {
       toast.error("Seleccioná una sección para matricular al alumno");
+      return;
+    }
+    if (
+      personaForm.fechaNacimiento &&
+      !isBirthDateValid(personaForm.fechaNacimiento)
+    ) {
+      toast.error(
+        "La fecha de nacimiento debe ser al menos dos años anterior a hoy.",
+      );
       return;
     }
     setCreatingAlumno(true);
@@ -388,6 +398,7 @@ function PersonaFormFields({ values, onChange }: PersonaFormFieldsProps) {
         <label className="text-sm font-medium text-muted-foreground">Fecha de nacimiento</label>
         <Input
           type="date"
+          max={maxBirthDate}
           value={values.fechaNacimiento}
           onChange={(e) => onChange("fechaNacimiento", e.target.value)}
         />

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
@@ -83,6 +83,10 @@ export default function VistaDireccion() {
         toast.error("Completá fechas");
         return;
       }
+      if (nuevoTrimestre.inicio > nuevoTrimestre.fin) {
+        toast.error("La fecha de inicio no puede ser posterior a la de fin");
+        return;
+      }
       await api.trimestres.create({
         periodoEscolarId: 1,
         orden: (trimestres.length % 3) + 1,

--- a/frontend-ecep/src/app/dashboard/materias/_components/AsignarDocenteMateriaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/AsignarDocenteMateriaDialog.tsx
@@ -83,6 +83,10 @@ export default function AsignarDocenteMateriaDialog({
 
   const guardar = async () => {
     if (!canSubmit || saving) return;
+    if (hasta && desde && hasta < desde) {
+      alert("La fecha hasta no puede ser anterior a la fecha desde.");
+      return;
+    }
     try {
       setSaving(true);
       const hastaValue = hasta ? hasta : "9999-12-31";

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -38,6 +38,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
 import { api } from "@/services/api";
+import { isBirthDateValid, maxBirthDate } from "@/lib/form-utils";
 import {
   RolEmpleado,
   UserRole,
@@ -846,6 +847,34 @@ export default function PersonalPage() {
         });
         return;
       }
+      if (
+        newPersona.fechaNacimiento &&
+        !isBirthDateValid(newPersona.fechaNacimiento)
+      ) {
+        toast({
+          title: "Fecha de nacimiento inválida",
+          description:
+            "La fecha de nacimiento debe ser al menos dos años anterior a hoy.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const fechaInicioFormacion = newFormacion.fechaInicio.trim();
+      const fechaFinFormacion = newFormacion.fechaFin.trim();
+      if (
+        fechaInicioFormacion &&
+        fechaFinFormacion &&
+        fechaFinFormacion < fechaInicioFormacion
+      ) {
+        toast({
+          title: "Fechas de formación inválidas",
+          description:
+            "La fecha de finalización no puede ser anterior a la de inicio.",
+          variant: "destructive",
+        });
+        return;
+      }
       setCreatingPersonal(true);
       try {
         const personaPayload = {
@@ -979,6 +1008,19 @@ export default function PersonalPage() {
         toast({
           title: "Motivo requerido",
           description: "Detalle el motivo de la licencia.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      if (
+        newLicense.fechaFin &&
+        newLicense.fechaInicio &&
+        newLicense.fechaFin < newLicense.fechaInicio
+      ) {
+        toast({
+          title: "Fechas de licencia inválidas",
+          description: "La fecha de fin no puede ser anterior a la de inicio.",
           variant: "destructive",
         });
         return;
@@ -1759,6 +1801,7 @@ export default function PersonalPage() {
                     <Input
                       id="nuevo-fecha-nac"
                       type="date"
+                      max={maxBirthDate}
                       value={newPersona.fechaNacimiento}
                       onChange={(event) =>
                         setNewPersona((prev) => ({ ...prev, fechaNacimiento: event.target.value }))
@@ -2015,9 +2058,19 @@ export default function PersonalPage() {
                       id="nuevo-fecha-inicio-formacion"
                       type="date"
                       value={newFormacion.fechaInicio}
-                      onChange={(event) =>
-                        setNewFormacion((prev) => ({ ...prev, fechaInicio: event.target.value }))
-                      }
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setNewFormacion((prev) => {
+                          if (!value) {
+                            return { ...prev, fechaInicio: value };
+                          }
+                          const next = { ...prev, fechaInicio: value };
+                          if (prev.fechaFin && prev.fechaFin < value) {
+                            next.fechaFin = value;
+                          }
+                          return next;
+                        });
+                      }}
                     />
                   </div>
                   <div className="space-y-2">
@@ -2026,9 +2079,18 @@ export default function PersonalPage() {
                       id="nuevo-fecha-fin-formacion"
                       type="date"
                       value={newFormacion.fechaFin}
-                      onChange={(event) =>
-                        setNewFormacion((prev) => ({ ...prev, fechaFin: event.target.value }))
-                      }
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setNewFormacion((prev) => {
+                          if (!value) {
+                            return { ...prev, fechaFin: value };
+                          }
+                          if (prev.fechaInicio && value < prev.fechaInicio) {
+                            return { ...prev, fechaFin: prev.fechaInicio };
+                          }
+                          return { ...prev, fechaFin: value };
+                        });
+                      }}
                     />
                   </div>
                 </div>
@@ -2158,9 +2220,19 @@ export default function PersonalPage() {
                     id="licencia-inicio"
                     type="date"
                     value={newLicense.fechaInicio}
-                    onChange={(event) =>
-                      setNewLicense((prev) => ({ ...prev, fechaInicio: event.target.value }))
-                    }
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setNewLicense((prev) => {
+                        if (!value) {
+                          return { ...prev, fechaInicio: value };
+                        }
+                        const next = { ...prev, fechaInicio: value };
+                        if (prev.fechaFin && prev.fechaFin < value) {
+                          next.fechaFin = value;
+                        }
+                        return next;
+                      });
+                    }}
                     required
                   />
                 </div>
@@ -2170,9 +2242,18 @@ export default function PersonalPage() {
                     id="licencia-fin"
                     type="date"
                     value={newLicense.fechaFin}
-                    onChange={(event) =>
-                      setNewLicense((prev) => ({ ...prev, fechaFin: event.target.value }))
-                    }
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setNewLicense((prev) => {
+                        if (!value) {
+                          return { ...prev, fechaFin: value };
+                        }
+                        if (prev.fechaInicio && value < prev.fechaInicio) {
+                          return { ...prev, fechaFin: prev.fechaInicio };
+                        }
+                        return { ...prev, fechaFin: value };
+                      });
+                    }}
                   />
                 </div>
               </div>

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -1730,7 +1730,13 @@ export default function ReportesPage() {
                     <Input
                       type="date"
                       value={attendanceFrom}
-                      onChange={(e) => setAttendanceFrom(e.target.value)}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setAttendanceFrom(value);
+                        if (value && attendanceTo && value > attendanceTo) {
+                          setAttendanceTo(value);
+                        }
+                      }}
                     />
                   </div>
                   <div>
@@ -1738,7 +1744,13 @@ export default function ReportesPage() {
                     <Input
                       type="date"
                       value={attendanceTo}
-                      onChange={(e) => setAttendanceTo(e.target.value)}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setAttendanceTo(value);
+                        if (value && attendanceFrom && value < attendanceFrom) {
+                          setAttendanceFrom(value);
+                        }
+                      }}
                     />
                   </div>
                   <div className="md:col-span-2">
@@ -1992,7 +2004,13 @@ export default function ReportesPage() {
                     <Input
                       type="date"
                       value={teacherFrom}
-                      onChange={(e) => setTeacherFrom(e.target.value)}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setTeacherFrom(value);
+                        if (value && teacherTo && value > teacherTo) {
+                          setTeacherTo(value);
+                        }
+                      }}
                     />
                   </div>
                   <div>
@@ -2000,7 +2018,13 @@ export default function ReportesPage() {
                     <Input
                       type="date"
                       value={teacherTo}
-                      onChange={(e) => setTeacherTo(e.target.value)}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setTeacherTo(value);
+                        if (value && teacherFrom && value < teacherFrom) {
+                          setTeacherFrom(value);
+                        }
+                      }}
                     />
                   </div>
                   <div className="md:col-span-2">
@@ -2118,11 +2142,31 @@ export default function ReportesPage() {
                     <CardContent className="space-y-4 text-sm">
                       <div className="space-y-2">
                         <Label>Desde</Label>
-                        <Input type="date" value={actaFrom} onChange={(e) => setActaFrom(e.target.value)} />
+                        <Input
+                          type="date"
+                          value={actaFrom}
+                          onChange={(e) => {
+                            const value = e.target.value;
+                            setActaFrom(value);
+                            if (value && actaTo && value > actaTo) {
+                              setActaTo(value);
+                            }
+                          }}
+                        />
                       </div>
                       <div className="space-y-2">
                         <Label>Hasta</Label>
-                        <Input type="date" value={actaTo} onChange={(e) => setActaTo(e.target.value)} />
+                        <Input
+                          type="date"
+                          value={actaTo}
+                          onChange={(e) => {
+                            const value = e.target.value;
+                            setActaTo(value);
+                            if (value && actaFrom && value < actaFrom) {
+                              setActaFrom(value);
+                            }
+                          }}
+                        />
                       </div>
                       <div className="space-y-2">
                         <Label>Nivel</Label>

--- a/frontend-ecep/src/app/postulacion/Step1.tsx
+++ b/frontend-ecep/src/app/postulacion/Step1.tsx
@@ -14,6 +14,7 @@ import {
 import { Curso, Turno } from "@/types/api-generated";
 import type { PostulacionFormData } from "./types";
 import { cn } from "@/lib/utils";
+import { maxBirthDate } from "@/lib/form-utils";
 
 interface Props {
   formData: PostulacionFormData;
@@ -98,9 +99,7 @@ export function Step1({
           <Input
             id="fechaNacimiento"
             type="date"
-            max={new Date(new Date().setFullYear(new Date().getFullYear() - 1))
-              .toISOString()
-              .slice(0, 10)}
+            max={maxBirthDate}
             value={formData.fechaNacimiento || ""}
             onChange={(e) =>
               handleInputChange("fechaNacimiento", e.target.value)

--- a/frontend-ecep/src/app/postulacion/Step2.tsx
+++ b/frontend-ecep/src/app/postulacion/Step2.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
+import { maxBirthDate } from "@/lib/form-utils";
 import { RolVinculo } from "@/types/api-generated";
 import type { PostulacionFormData } from "./types";
 
@@ -219,6 +220,7 @@ export function Step2({
                 <Input
                   id={`familiar-fecha-${i}`}
                   type="date"
+                  max={maxBirthDate}
                   value={f.familiar?.fechaNacimiento ?? ""}
                   onChange={(e) =>
                     handleInputChange(

--- a/frontend-ecep/src/app/postulacion/page.tsx
+++ b/frontend-ecep/src/app/postulacion/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/useToast";
 import { api } from "@/services/api"; // ← import del cliente API
 import * as DTO from "@/types/api-generated";
+import { isBirthDateValid } from "@/lib/form-utils";
 
 import { Step1 } from "./Step1";
 import { Step2 } from "./Step2";
@@ -317,16 +318,36 @@ export default function PostulacionPage() {
     ];
     const newErrors: Record<string, boolean> = {};
     let ok = true;
+    let missingRequired = false;
+    let invalidBirthDate = false;
     for (const f of fields) {
       if (!formData[f as keyof typeof formData]) {
         newErrors[f] = true;
         ok = false;
+        missingRequired = true;
       }
     }
+
+    const birthDate = formData.fechaNacimiento;
+    if (birthDate && !isBirthDateValid(birthDate)) {
+      newErrors.fechaNacimiento = true;
+      ok = false;
+      invalidBirthDate = true;
+    }
+
     setErrors(newErrors);
     if (!ok) {
+      const details = [
+        missingRequired ? "Completá los campos obligatorios." : null,
+        invalidBirthDate
+          ? "La fecha de nacimiento debe ser al menos dos años anterior a hoy."
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" ");
       toast({
-        title: "Completa los campos obligatorios.",
+        title: "Revisá los datos del aspirante.",
+        description: details || undefined,
         variant: "destructive",
       });
     }
@@ -337,6 +358,7 @@ export default function PostulacionPage() {
     const familiares = formData.familiares ?? [];
     const newErrors: Record<string, boolean> = {};
     let ok = true;
+    let invalidBirthDate = false;
 
     if (!familiares.length) {
       newErrors.familiares = true;
@@ -364,6 +386,12 @@ export default function PostulacionPage() {
         newErrors[`familiares.${index}.familiar.dni`] = true;
         ok = false;
       }
+      const fechaNacimiento = familiarPersona?.fechaNacimiento?.trim();
+      if (fechaNacimiento && !isBirthDateValid(fechaNacimiento)) {
+        newErrors[`familiares.${index}.familiar.fechaNacimiento`] = true;
+        ok = false;
+        invalidBirthDate = true;
+      }
       const email = familiarPersona?.emailContacto?.trim();
       if (!email) {
         newErrors[`familiares.${index}.familiar.emailContacto`] = true;
@@ -373,10 +401,17 @@ export default function PostulacionPage() {
 
     setErrors(newErrors);
     if (!ok) {
+      const descriptions = [
+        "Ingresá nombre, apellido, DNI y un email de contacto para continuar.",
+        invalidBirthDate
+          ? "Revisá también la fecha de nacimiento: debe ser al menos dos años anterior a hoy."
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" ");
       toast({
         title: "Completá los datos de al menos un familiar.",
-        description:
-          "Ingresá nombre, apellido, DNI y un email de contacto para continuar.",
+        description: descriptions,
         variant: "destructive",
       });
     }
@@ -433,6 +468,30 @@ export default function PostulacionPage() {
     if (!communicationsAuthorized) {
       toast({
         title: "Debes autorizar comunicaciones por email.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (formData.fechaNacimiento && !isBirthDateValid(formData.fechaNacimiento)) {
+      toast({
+        title: "Fecha de nacimiento inválida",
+        description:
+          "La fecha de nacimiento del aspirante debe ser al menos dos años anterior a hoy.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const familiaresInvalidos = (formData.familiares ?? []).some((familiar) => {
+      const fecha = familiar.familiar?.fechaNacimiento?.trim();
+      return fecha ? !isBirthDateValid(fecha) : false;
+    });
+    if (familiaresInvalidos) {
+      toast({
+        title: "Fecha de nacimiento inválida",
+        description:
+          "Verificá las fechas de nacimiento de los familiares: deben ser al menos dos años anteriores a hoy.",
         variant: "destructive",
       });
       return;

--- a/frontend-ecep/src/lib/form-utils.ts
+++ b/frontend-ecep/src/lib/form-utils.ts
@@ -12,10 +12,24 @@ export function formatDni(s: string) {
   return s.replace(/\D/g, "").slice(0, 9);
 }
 
-// Fecha máxima: personas de al menos 1 año
-const today = new Date();
-today.setFullYear(today.getFullYear() - 1);
-export const maxBirthDate = today.toISOString().slice(0, 10);
+const MIN_BIRTH_AGE_YEARS = 2;
+
+export function getBirthDateLimitIso(reference: Date = new Date()) {
+  const limit = new Date(reference);
+  limit.setFullYear(limit.getFullYear() - MIN_BIRTH_AGE_YEARS);
+  return limit.toISOString().slice(0, 10);
+}
+
+// Fecha máxima: personas de al menos 2 años
+export const maxBirthDate = getBirthDateLimitIso();
+
+export function isBirthDateValid(
+  value?: string | null,
+  reference: Date = new Date(),
+) {
+  if (!value) return true;
+  return value <= getBirthDateLimitIso(reference);
+}
 
 // Tipado parcial de los datos del Step 1
 export interface Step1Data {


### PR DESCRIPTION
## Summary
- add shared birth-date helpers and apply the two-year minimum age rule across student, staff, and postulant forms
- guard every desde/hasta selector so start dates cannot exceed end dates, including report filters, acta listings, and license creation

## Testing
- pnpm lint *(fails: dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd536afef48327b0144cc525c693fe