### PR TITLE
Fix jornada creation permissions and improve date validation

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/JornadaAsistenciaController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/JornadaAsistenciaController.java
@@ -62,7 +62,7 @@ public class JornadaAsistenciaController {
     }
 
     // Abrir jornada
-    @PreAuthorize("hasAnyRole('ADMIN','DIRECTOR','TEACHER')")
+    @PreAuthorize("hasAnyRole('ADMIN','DIRECTOR','TEACHER','SECRETARY','COORDINATOR')")
     @PostMapping
     public ResponseEntity<Long> abrir(@RequestBody @Valid JornadaAsistenciaCreateDTO dto) {
         return new ResponseEntity<>(service.abrir(dto), HttpStatus.CREATED);


### PR DESCRIPTION
## Summary
- allow SECRETARY and COORDINATOR roles to abrir jornadas de asistencia
- restrict jornada creation UI to the active trimester, blocking weekends and invalid dates

## Testing
- npm install *(fails: 403 Forbidden fetching packages)*
- bun install *(fails: 403 Forbidden fetching packages)*
- ./mvnw test *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd62a9273c8327a142331ca2fa9554