### PR TITLE
Fix jornada asistencia search without results

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/JornadaAsistenciaController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/JornadaAsistenciaController.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 
 import edu.ecep.base_app.dtos.JornadaAsistenciaCreateDTO;
 import edu.ecep.base_app.dtos.JornadaAsistenciaDTO;
+import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -40,12 +41,12 @@ public class JornadaAsistenciaController {
     }
 
     @GetMapping(params = {"seccionId","fecha"})
-    public ResponseEntity<JornadaAsistenciaDTO> bySeccionFecha(
+    public List<JornadaAsistenciaDTO> bySeccionFecha(
             @RequestParam Long seccionId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha) {
         return service.findBySeccionAndFecha(seccionId, fecha)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+                .map(List::of)
+                .orElseGet(Collections::emptyList);
     }
 
 


### PR DESCRIPTION
## Summary
- return an empty list when searching jornadas de asistencia by sección y fecha so the endpoint no longer returns 404
- add the necessary Collections import for the empty list response

## Testing
- mvn test *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cd697598808327b3efa9ee9aec797e