### PR TITLE
Fix chat websocket authentication handshake

### DIFF
--- a/frontend-ecep/src/hooks/useChatSocket.ts
+++ b/frontend-ecep/src/hooks/useChatSocket.ts
@@ -52,7 +52,13 @@ export default function useChatSocket() {
     setConnectionStatus("connecting");
     console.log("🔌 Intentando conectar WebSocket...");
 
-    const socketUrl = `${API_BASE}/ws`;
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
+    const socketUrl =
+      token && token.trim()
+        ? `${API_BASE}/ws?token=${encodeURIComponent(token)}`
+        : `${API_BASE}/ws`;
 
     const socket = new SockJS(socketUrl, undefined, {
       transports: ["websocket", "xhr-streaming", "xhr-polling"],
@@ -60,10 +66,8 @@ export default function useChatSocket() {
         "xhr-streaming": { withCredentials: true },
         "xhr-polling": { withCredentials: true },
       },
+      withCredentials: true,
     } as any);
-
-    const token =
-      typeof window !== "undefined" ? localStorage.getItem("token") : null;
 
     const stompClient = new Client({
       webSocketFactory: () => socket,


### PR DESCRIPTION
## Summary
- include the JWT token when creating the SockJS client so the chat handshake works across subdomains and force credentials on the transport
- extend the WebSocket handshake interceptor to read the token from cookies, query parameters or the Authorization header without logging the raw value

## Testing
- npm run lint *(fails: `next` not found because dependencies cannot be installed in the execution environment)*
- ./mvnw -q test *(fails: Maven wrapper cannot download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cda52cb34c8327a878b1655787a7d0