### PR TITLE
Normalize loading indicators

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import {
   Dialog,
   DialogContent,
@@ -435,9 +436,7 @@ function DireccionConfig({ open }: DireccionConfigProps) {
         </CardHeader>
         <CardContent className="space-y-4">
           {loading ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" /> Cargando datos...
-            </div>
+            <LoadingState label="Cargando datos…" />
           ) : trimestresOrdenados.length ? (
             trimestresOrdenados.map((tri) => {
               const idx = trimestresOrdenados.findIndex((t) => t.id === tri.id);

--- a/frontend-ecep/src/app/dashboard/actas/_components/EditActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/EditActaDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { api } from "@/services/api";
 import type {
   ActaAccidenteDTO,
@@ -160,7 +161,7 @@ export default function EditActaDialog({
         </DialogHeader>
 
         {loading ? (
-          <div className="text-sm">Cargando…</div>
+          <LoadingState label="Cargando acta…" />
         ) : (
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">

--- a/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { api } from "@/services/api";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import type {
@@ -330,7 +331,7 @@ export default function NewActaDialog({
         </DialogHeader>
 
         {loading ? (
-          <div className="text-sm">Cargando…</div>
+          <LoadingState label="Cargando información…" />
         ) : (
           <div className="space-y-4">
             {/* Alumno (autocomplete) */}

--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
@@ -597,7 +598,7 @@ export default function AccidentesIndexPage() {
             </CardHeader>
             <CardContent>
               <div className="space-y-3">
-                {loading && <div className="text-sm">Cargando…</div>}
+                {loading && <LoadingState label="Cargando actas…" />}
                 {!loading &&
                   filtered.map((a) => {
                     const isCerrada = a.estado.toUpperCase() === "CERRADA";

--- a/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
@@ -318,7 +319,7 @@ export default function AccidentesSeccionPage() {
   if (loading) {
     return (
       <DashboardLayout>
-        <div className="p-6 text-sm">Cargando…</div>
+        <LoadingState label="Cargando actas…" />
       </DashboardLayout>
     );
   }

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
@@ -962,7 +963,7 @@ export default function AlumnoPerfilPage() {
           </div>
         </div>
 
-        {loading && <div className="text-sm">Cargando…</div>}
+        {loading && <LoadingState label="Cargando información del alumno…" />}
         {error && <div className="text-sm text-red-600">{error}</div>}
 
         {!loading && !error && alumno && (

--- a/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { toast } from "sonner";
 import {
   Card,
@@ -208,11 +209,7 @@ export default function AspirantesTab({ searchTerm }: Props) {
   }, [detailOpen, selected]);
 
   if (loading) {
-    return (
-      <div className="text-sm text-muted-foreground py-8">
-        Cargando solicitudes…
-      </div>
-    );
+    return <LoadingState label="Cargando solicitudes…" />;
   }
 
   if (error) {

--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import type * as DTO from "@/types/api-generated";
@@ -152,7 +153,7 @@ export default function AlumnosIndexPage() {
           </div>
         )}
 
-        {loading && <div className="text-sm">Cargando…</div>}
+        {loading && <LoadingState label="Cargando información…" />}
         {error && <div className="text-sm text-red-600">{String(error)}</div>}
 
         {/* FAMILY: lista de hijos */}
@@ -205,7 +206,7 @@ export default function AlumnosIndexPage() {
                 </CardHeader>
                 <CardContent>
                   {loadingAlumnos ? (
-                    <div className="text-sm text-muted-foreground py-6">Cargando alumnos…</div>
+                    <LoadingState label="Cargando alumnos…" />
                   ) : errorAlumnos ? (
                     <div className="text-sm text-red-600 py-6">{errorAlumnos}</div>
                   ) : !alumnosFiltrados.length ? (

--- a/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -45,7 +46,7 @@ export default function SeccionAlumnosPage() {
 
         {/* Contenido: solo alumnos */}
         {loading ? (
-          <div className="text-sm">Cargando…</div>
+          <LoadingState label="Cargando alumnos…" />
         ) : error ? (
           <div className="text-sm text-red-600">
             Ocurrió un error al cargar los alumnos.

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/DetalleDiaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/DetalleDiaDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import {
   Dialog,
   DialogContent,
@@ -143,10 +144,7 @@ export default function DetalleDiaDialog({
         </DialogHeader>
 
         {loading ? (
-          <div className="flex items-center gap-2 text-sm">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Cargando…
-          </div>
+          <LoadingState label="Cargando asistencia…" />
         ) : (
           <div className="space-y-4">
             <div className="border rounded p-3 text-sm">

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaConsultaAlumno.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaConsultaAlumno.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import {
   Card,
   CardHeader,
@@ -71,7 +72,7 @@ export default function VistaConsultaAlumno() {
   const ausentes = detallesAlumno.filter((d) => d.estado === "AUSENTE").length;
   const pct = Math.round((presentes / total) * 100);
 
-  if (loading) return <p className="p-4">Cargando…</p>;
+  if (loading) return <LoadingState label="Cargando información…" />;
 
   return (
     <div className="grid gap-6 md:grid-cols-2">

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import {
   Card,
   CardHeader,
@@ -134,7 +135,7 @@ export default function VistaDireccion() {
     }
   };
 
-  if (loading) return <p className="p-4">Cargando…</p>;
+  if (loading) return <LoadingState label="Cargando información…" />;
 
   return (
     <div className="space-y-6">

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDocente.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDocente.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -138,7 +139,7 @@ export default function VistaDocente() {
     }
   };
 
-  if (loading) return <p className="p-4">Cargando…</p>;
+  if (loading) return <LoadingState label="Cargando información…" />;
 
   return (
     <>

--- a/frontend-ecep/src/app/dashboard/asistencia/jornada/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/jornada/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { api } from "@/services/api";
 import {
   JornadaAsistenciaDTO,
@@ -313,7 +314,7 @@ export default function JornadaPage() {
   if (loading) {
     return (
       <DashboardLayout>
-        <div className="p-6 text-sm">Cargando…</div>
+        <LoadingState label="Cargando jornada…" />
       </DashboardLayout>
     );
   }

--- a/frontend-ecep/src/app/dashboard/asistencia/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { useAuth } from "@/hooks/useAuth";
 import { UserRole, SeccionDTO, Turno } from "@/types/api-generated";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
@@ -156,7 +157,7 @@ function TeacherView() {
     error: countsError,
   } = useSectionStudentCounts(secciones);
 
-  if (loading) return <div className="text-sm">Cargando secciones…</div>;
+  if (loading) return <LoadingState label="Cargando secciones…" />;
   if (error) return <div className="text-sm text-red-600">{String(error)}</div>;
   if (!secciones.length)
     return <div className="text-sm">No tenés secciones asignadas.</div>;
@@ -277,7 +278,7 @@ function DirectivoView() {
 
   return (
     <div className="space-y-4">
-      {loading && <div className="text-sm">Cargando secciones…</div>}
+      {loading && <LoadingState label="Cargando secciones…" />}
       {err && <div className="text-sm text-red-600">{err}</div>}
       {countsError && <div className="text-sm text-red-600">{countsError}</div>}
 

--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { NewJornadaDialog } from "@/app/dashboard/asistencia/_components/NewJornadaDialog";
 import {
   Card,
@@ -224,7 +225,7 @@ export default function SeccionHistorialPage() {
         </div>
 
         {loadingPeriod ? (
-          <div className="text-sm">Cargando trimestres…</div>
+          <LoadingState label="Cargando trimestres…" />
         ) : !trimestresDelPeriodo.length ? (
           <div className="text-sm text-muted-foreground">
             No hay trimestres configurados para el período actual.
@@ -266,7 +267,7 @@ export default function SeccionHistorialPage() {
                     </div>
                   ) : (
                     <>
-                      {loading && <div className="text-sm">Cargando…</div>}
+                      {loading && <LoadingState label="Cargando asistencia…" />}
                       {err && (
                         <div className="text-sm text-red-600">{err}</div>
                       )}

--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { api } from "@/services/api";
 import {
   Card,
@@ -77,7 +78,7 @@ export default function CalificacionesIndexPage() {
             <Badge variant="outline">Inicial: {inicial.length}</Badge>
           </div>
         )}
-        {loading && <div className="text-sm">Cargando…</div>}
+        {loading && <LoadingState label="Cargando secciones…" />}
 
         {!loading && (
           <Tabs

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { api } from "@/services/api";
+import LoadingState from "@/components/common/LoadingState";
 import {
   Card,
   CardContent,
@@ -606,7 +607,9 @@ export default function CierrePrimarioView({
 
       {(loading || loadingRows) && (
         <Card>
-          <CardContent className="py-6 text-sm">Cargando…</CardContent>
+          <CardContent className="py-6">
+            <LoadingState label="Cargando calificaciones…" />
+          </CardContent>
         </Card>
       )}
 

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/InformeInicialView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/InformeInicialView.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { api } from "@/services/api";
+import LoadingState from "@/components/common/LoadingState";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
@@ -61,7 +62,7 @@ export default function InformeInicialView({
     return m;
   }, [informes]);
 
-  if (loading) return <div className="text-sm">Cargando…</div>;
+  if (loading) return <LoadingState label="Cargando informes…" />;
 
   return (
     <div className="space-y-4">

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { api } from "@/services/api";
 import { Badge } from "@/components/ui/badge";
 import CierrePrimarioView from "./_views/CierrePrimarioView";
@@ -70,7 +71,7 @@ export default function CalificacionesSeccionPage() {
           </div>
         </div>
 
-        {loading && <div className="text-sm">Cargando…</div>}
+        {loading && <LoadingState label="Cargando sección…" />}
         {error && <div className="text-sm text-red-600">{error}</div>}
 
         {!loading && !error && (

--- a/frontend-ecep/src/app/dashboard/comunicados/page.tsx
+++ b/frontend-ecep/src/app/dashboard/comunicados/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -318,8 +319,8 @@ export default function ComunicadosPage() {
         {/* Feed */}
         {loading ? (
           <Card>
-            <CardContent className="p-6 text-sm text-muted-foreground">
-              Cargando…
+            <CardContent className="p-6">
+              <LoadingState label="Cargando comunicados…" />
             </CardContent>
           </Card>
         ) : (

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
@@ -11,6 +11,7 @@ import type {
   TrimestreDTO,
   SeccionMateriaDTO,
 } from "@/types/api-generated";
+import LoadingState from "@/components/common/LoadingState";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -253,7 +254,7 @@ export default function NotasExamenDialog({
         </DialogHeader>
 
         {loading ? (
-          <div className="text-sm p-2">Cargando…</div>
+          <LoadingState label="Cargando notas…" />
         ) : errorMsg ? (
           <div className="text-sm text-red-600">{errorMsg}</div>
         ) : (

--- a/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { api } from "@/services/api";
@@ -347,7 +348,7 @@ export default function ExamenDetailPage() {
   if (loading) {
     return (
       <DashboardLayout>
-        <div className="p-6 text-sm">Cargando examen…</div>
+        <LoadingState label="Cargando examen…" />
       </DashboardLayout>
     );
   }

--- a/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { api } from "@/services/api";
@@ -178,7 +179,9 @@ export default function EvaluacionesIndexPage() {
           </div>
         </div>
 
-        {(loading || loadingScope) && <div className="text-sm">Cargando…</div>}
+        {(loading || loadingScope) && (
+          <LoadingState label="Cargando evaluaciones…" />
+        )}
         {(error || errorScope) && (
           <div className="text-sm text-red-600">
             {String(error ?? errorScope)}

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { api } from "@/services/api";
 import type {
   SeccionDTO,
@@ -250,7 +251,7 @@ export default function SeccionEvaluacionesPage() {
   if (loading) {
     return (
       <DashboardLayout>
-        <div className="p-6 text-sm">Cargando…</div>
+        <LoadingState label="Cargando evaluaciones…" />
       </DashboardLayout>
     );
   }

--- a/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
@@ -409,7 +410,7 @@ export default function FamiliarPerfilPage() {
           </div>
         </div>
 
-        {loading && <div className="text-sm">Cargando…</div>}
+        {loading && <LoadingState label="Cargando información del familiar…" />}
         {error && <div className="text-sm text-red-600">{error}</div>}
 
         {!loading && !error && (

--- a/frontend-ecep/src/app/dashboard/materias/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
@@ -123,7 +124,7 @@ export default function MateriasPage() {
         </div>
 
         {loading ? (
-          <div className="text-sm">Cargando…</div>
+          <LoadingState label="Cargando secciones…" />
         ) : (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {filtered.map((s) => (

--- a/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
@@ -262,7 +263,7 @@ export default function MateriasSeccionPage() {
         </div>
 
         {loading ? (
-          <div className="text-sm">Cargando…</div>
+          <LoadingState label="Cargando materias…" />
         ) : error ? (
           <div className="text-sm text-red-600">{error}</div>
         ) : (

--- a/frontend-ecep/src/app/dashboard/page.tsx
+++ b/frontend-ecep/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
+import LoadingState from "@/components/common/LoadingState";
 import {
   Card,
   CardContent,
@@ -191,7 +192,7 @@ export default function DashboardPage() {
             </CardHeader>
             <CardContent>
               {loadingMsgs ? (
-                <p className="text-sm text-muted-foreground">Cargando…</p>
+                <LoadingState label="Cargando mensajes…" />
               ) : recentMsgs.length === 0 ? (
                 <p className="text-sm text-muted-foreground">
                   No hay mensajes recientes

--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -9,6 +9,7 @@ import {
   type FormEvent,
 } from "react";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -818,22 +819,12 @@ export default function PagosPage() {
 
   const renderCuotasTab = () => {
     if (authLoading) {
-      return (
-        <div className="flex items-center justify-center py-16 text-muted-foreground">
-          <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando
-          información...
-        </div>
-      );
+      return <LoadingState label="Cargando información…" />;
     }
 
     if (isFamily) {
       if (hijosLoading || cuotasLoading) {
-        return (
-          <div className="flex items-center justify-center py-16 text-muted-foreground">
-            <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Preparando tus
-            cuotas...
-          </div>
-        );
+        return <LoadingState label="Preparando tus cuotas…" />;
       }
 
       if (!hijos.length) {
@@ -1089,10 +1080,7 @@ export default function PagosPage() {
             </CardHeader>
             <CardContent>
               {cuotasLoading ? (
-                <div className="flex items-center justify-center py-10 text-muted-foreground">
-                  <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando
-                  cuotas...
-                </div>
+                <LoadingState label="Cargando cuotas…" />
               ) : !cuotasOrdenadasAdmin.length ? (
                 <p className="text-sm text-muted-foreground">
                   Aún no se registraron cuotas. Creá la primera para comenzar.
@@ -1204,10 +1192,7 @@ export default function PagosPage() {
           </CardHeader>
           <CardContent>
             {pagosLoading ? (
-              <div className="flex items-center justify-center py-10 text-muted-foreground">
-                <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando
-                pagos...
-              </div>
+              <LoadingState label="Cargando pagos…" />
             ) : !pagosOrdenados.length ? (
               <p className="text-sm text-muted-foreground">
                 Aún no hay pagos registrados.
@@ -1365,10 +1350,7 @@ export default function PagosPage() {
           </CardHeader>
           <CardContent>
             {recibosLoading ? (
-              <div className="flex items-center justify-center py-10 text-muted-foreground">
-                <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Cargando
-                recibos...
-              </div>
+              <LoadingState label="Cargando recibos…" />
             ) : !listado.length ? (
               <p className="text-sm text-muted-foreground">
                 {isAdmin
@@ -1735,10 +1717,7 @@ export default function PagosPage() {
                   <Label>Secciones</Label>
                   <div className="max-h-60 space-y-2 overflow-auto rounded-md border p-3 text-sm">
                     {seccionesLoading ? (
-                      <div className="flex items-center justify-center gap-2 text-muted-foreground">
-                        <Loader2 className="h-4 w-4 animate-spin" /> Cargando
-                        secciones...
-                      </div>
+                      <LoadingState label="Cargando secciones…" className="h-48" iconClassName="h-4 w-4" />
                     ) : !seccionesOrdenadas.length ? (
                       <p className="text-muted-foreground">
                         No hay secciones disponibles para generar cuotas.

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter } from "next/navigation";
 
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -1050,14 +1051,7 @@ export default function PersonalPage() {
     [setLicenseDialogOpen, setNewLicense],
   );
 
-  const renderLoadingState = () => (
-    <div className="flex h-48 items-center justify-center">
-      <Loader2 className="h-6 w-6 animate-spin text-primary" />
-      <span className="ml-2 text-sm text-muted-foreground">
-        Cargando información…
-      </span>
-    </div>
-  );
+  const renderLoadingState = () => <LoadingState label="Cargando información…" />;
 
   const renderErrorState = () => (
     <Alert variant="destructive">

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
+import LoadingState from "@/components/common/LoadingState";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Card,
@@ -1368,8 +1369,8 @@ export default function ReportesPage() {
                 )}
 
                 {loadingBoletines && !boletinError ? (
-                  <div className="rounded-lg border border-dashed bg-muted/50 p-6 text-sm text-muted-foreground">
-                    Cargando información académica…
+                  <div className="rounded-lg border border-dashed bg-muted/50 p-6">
+                    <LoadingState label="Cargando información académica…" />
                   </div>
                 ) : !selectedSectionId ? (
                   <div className="rounded-lg border border-dashed bg-muted/50 p-6 text-sm text-muted-foreground">
@@ -1819,8 +1820,8 @@ export default function ReportesPage() {
                 )}
 
                 {loadingAttendance && !attendanceError && (
-                  <div className="rounded-lg border border-dashed bg-muted/60 p-6 text-sm text-muted-foreground">
-                    Cargando asistencia…
+                  <div className="rounded-lg border border-dashed bg-muted/60 p-6">
+                    <LoadingState label="Cargando asistencia…" />
                   </div>
                 )}
 
@@ -2049,8 +2050,8 @@ export default function ReportesPage() {
                 )}
 
                 {loadingTeacherAbsences && !teacherError && (
-                  <div className="rounded-lg border border-dashed bg-muted/60 p-6 text-sm text-muted-foreground">
-                    Cargando inasistencias docentes…
+                  <div className="rounded-lg border border-dashed bg-muted/60 p-6">
+                    <LoadingState label="Cargando inasistencias docentes…" />
                   </div>
                 )}
 
@@ -2222,8 +2223,8 @@ export default function ReportesPage() {
                     )}
 
                     {loadingActasRegistro && !actaErrorMsg && (
-                      <div className="rounded-lg border border-dashed bg-muted/60 p-4 text-sm text-muted-foreground">
-                        Cargando actas…
+                      <div className="rounded-lg border border-dashed bg-muted/60 p-4">
+                        <LoadingState label="Cargando actas…" />
                       </div>
                     )}
 

--- a/frontend-ecep/src/components/common/LoadingSpinner.tsx
+++ b/frontend-ecep/src/components/common/LoadingSpinner.tsx
@@ -1,7 +1,3 @@
-export default function LoadingSpinner() {
-  return (
-    <div className="flex items-center justify-center min-h-screen">
-      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
-    </div>
-  );
-}
+import LoadingState from "./LoadingState";
+
+export default LoadingState;

--- a/frontend-ecep/src/components/common/LoadingState.tsx
+++ b/frontend-ecep/src/components/common/LoadingState.tsx
@@ -1,0 +1,22 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type LoadingStateProps = {
+  label?: string;
+  className?: string;
+  iconClassName?: string;
+};
+
+export default function LoadingState({
+  label = "Cargando…",
+  className,
+  iconClassName,
+}: LoadingStateProps) {
+  return (
+    <div className={cn("flex h-48 items-center justify-center", className)}>
+      <Loader2 className={cn("h-6 w-6 animate-spin text-primary", iconClassName)} />
+      <span className="ml-2 text-sm text-muted-foreground">{label}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `LoadingState` component with customizable label and styling
- replace scattered loading placeholders across dashboard views (pagos, reportes, evaluaciones, etc.) with the shared component
- keep existing button spinners while standardizing data-loading feedback and keeping `LoadingSpinner` as a re-export

## Testing
- bun install *(fails: registry returned HTTP 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cda5432278832796738b93cbaa576f