### PR TITLE
Fix personnel loading and profile fallbacks

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -212,8 +212,17 @@ export default function AlumnoPerfilPage() {
         if (a.personaId) {
           try {
             p = (await api.personasCore.getById(a.personaId)).data ?? null;
-          } catch {
-            p = null;
+          } catch (personaError) {
+            console.error("No se pudo obtener la persona del alumno", personaError);
+          }
+          if (!p) {
+            const fallbackPersona: PersonaDTO = {
+              id: a.personaId,
+              nombre: a.nombre ?? undefined,
+              apellido: a.apellido ?? undefined,
+              dni: a.dni ?? undefined,
+            };
+            p = fallbackPersona;
           }
         }
         if (!alive) return;

--- a/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
@@ -109,25 +109,44 @@ export default function FamiliarPerfilPage() {
               await api.personasCore.getById(familiarData.personaId)
             ).data ?? null;
           } catch (error) {
-            console.error(error);
-            personaData = null;
+            console.error("No se pudo obtener la persona del familiar", error);
+          }
+          if (!personaData) {
+            const fallbackPersona: PersonaDTO = { id: familiarData.personaId };
+            personaData = fallbackPersona;
           }
         }
         if (!alive) return;
         setPersona(personaData);
         setOcupacion((familiarData as any)?.ocupacion ?? "");
 
-        const linksData = ((await api.alumnoFamiliares.list()).data ?? []).filter(
-          (link: any) => link.familiarId === familiarId,
-        );
+        let linksData: AlumnoFamiliarDTO[] = [];
+        try {
+          const { data } = await api.alumnoFamiliares.list();
+          linksData = ((data ?? []) as any[]).filter(
+            (link: any) => link.familiarId === familiarId,
+          ) as AlumnoFamiliarDTO[];
+        } catch (linksError) {
+          console.error(
+            "No se pudieron obtener los vínculos del familiar",
+            linksError,
+          );
+        }
         if (!alive) return;
-        setLinks(linksData as AlumnoFamiliarDTO[]);
+        setLinks(linksData);
 
-        const alumnosData = (
-          await api.familiaresAlumnos.byFamiliarId(familiarId)
-        ).data ?? [];
+        let alumnosData: AlumnoLiteDTO[] = [];
+        try {
+          const { data } = await api.familiaresAlumnos.byFamiliarId(familiarId);
+          alumnosData = (data ?? []) as AlumnoLiteDTO[];
+        } catch (alumnosError) {
+          console.error(
+            "No se pudieron obtener los alumnos vinculados",
+            alumnosError,
+          );
+        }
         if (!alive) return;
-        setAlumnos(alumnosData as AlumnoLiteDTO[]);
+        setAlumnos(alumnosData);
 
       } catch (fetchError: any) {
         if (!alive) return;


### PR DESCRIPTION
## Summary
- prevent the personnel dashboard from failing when ancillary endpoints error by wrapping fetches and reuse the data for the active tab actions
- align the personal/licence action buttons with the tab list and show the appropriate action per tab
- add fallbacks when fetching personas for relatives and students so their profiles remain editable even if the detailed record is unavailable

## Testing
- npm run lint *(fails: next not found in env)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbdfbf5388327a0454e837f9c6060