### PR TITLE
Permitir asignar titular sin fechas y exigir vigencias para suplentes

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/dtos/AsignacionDocenteMateriaCreateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/dtos/AsignacionDocenteMateriaCreateDTO.java
@@ -18,7 +18,6 @@ public class AsignacionDocenteMateriaCreateDTO {
     Long empleadoId;
     @NotNull
     RolMateria rol;
-    @NotNull
     LocalDate vigenciaDesde;
     LocalDate vigenciaHasta;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/repos/AsignacionDocenteMateriaRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/repos/AsignacionDocenteMateriaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface AsignacionDocenteMateriaRepository extends JpaRepository<AsignacionDocenteMateria, Long> {
     boolean existsByEmpleadoId(Long empleadoId); // +++
@@ -20,4 +21,14 @@ public interface AsignacionDocenteMateriaRepository extends JpaRepository<Asigna
                               @Param("desde") LocalDate desde,
                               @Param("hasta") LocalDate hasta,
                               @Param("excludeId") Long excludeId);
+
+    @Query("""
+      select a from AsignacionDocenteMateria a
+      where a.seccionMateria.id = :smId and a.rol = edu.ecep.base_app.domain.enums.RolMateria.TITULAR
+        and a.vigenciaDesde <= :fecha
+        and (a.vigenciaHasta is null or a.vigenciaHasta >= :fecha)
+      order by a.vigenciaDesde desc
+    """)
+    List<AsignacionDocenteMateria> findTitularesVigentesEn(@Param("smId") Long seccionMateriaId,
+                                                           @Param("fecha") LocalDate fecha);
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/AsignacionDocenteMateriaService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/AsignacionDocenteMateriaService.java
@@ -1,6 +1,7 @@
 package edu.ecep.base_app.service;
 
 
+import edu.ecep.base_app.domain.AsignacionDocenteMateria;
 import edu.ecep.base_app.domain.enums.RolMateria;
 import edu.ecep.base_app.dtos.AsignacionDocenteMateriaCreateDTO;
 import edu.ecep.base_app.dtos.AsignacionDocenteMateriaDTO;
@@ -8,6 +9,7 @@ import edu.ecep.base_app.mappers.AsignacionDocenteMateriaMapper;
 import edu.ecep.base_app.repos.AsignacionDocenteMateriaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,10 +19,40 @@ import java.util.List;
 public class AsignacionDocenteMateriaService {
     private final AsignacionDocenteMateriaRepository repo; private final AsignacionDocenteMateriaMapper mapper;
     public List<AsignacionDocenteMateriaDTO> findAll(){ return repo.findAll().stream().map(mapper::toDto).toList(); }
+    @Transactional
     public Long create(AsignacionDocenteMateriaCreateDTO dto){
-        LocalDate hasta = dto.getVigenciaHasta()==null? LocalDate.of(9999,12,31): dto.getVigenciaHasta();
-        if(dto.getRol()== RolMateria.TITULAR && repo.hasTitularOverlap(dto.getSeccionMateriaId(), dto.getVigenciaDesde(), hasta, null))
+        LocalDate desde = dto.getVigenciaDesde();
+        if(desde == null){
+            desde = LocalDate.now();
+        }
+
+        LocalDate hasta = dto.getVigenciaHasta();
+        if(dto.getRol() == RolMateria.SUPLENTE){
+            if(hasta == null){
+                throw new IllegalArgumentException("La suplencia debe tener una fecha de finalización.");
+            }
+            if(hasta.isBefore(desde)){
+                throw new IllegalArgumentException("La fecha hasta no puede ser anterior a la fecha desde.");
+            }
+        } else {
+            hasta = null;
+            LocalDate cierre = desde.minusDays(1);
+            for(AsignacionDocenteMateria vigente : repo.findTitularesVigentesEn(dto.getSeccionMateriaId(), desde)){
+                vigente.setVigenciaHasta(cierre);
+                repo.save(vigente);
+            }
+        }
+
+        dto.setVigenciaDesde(desde);
+        dto.setVigenciaHasta(hasta);
+
+        LocalDate hastaValidacion = hasta == null ? LocalDate.of(9999,12,31) : hasta;
+        if(dto.getRol()== RolMateria.TITULAR && repo.hasTitularOverlap(dto.getSeccionMateriaId(), desde, hastaValidacion, null))
             throw new IllegalArgumentException("Ya hay un titular vigente en ese rango");
-        return repo.save(mapper.toEntity(dto)).getId();
+
+        AsignacionDocenteMateria entity = mapper.toEntity(dto);
+        entity.setVigenciaHasta(hasta);
+        entity.setVigenciaDesde(desde);
+        return repo.save(entity).getId();
     }
 }


### PR DESCRIPTION
## Summary
- permitir que la creación de un titular configure automáticamente la fecha de inicio y cierre al titular vigente si existía
- agregar en el repositorio la consulta de titulares vigentes para soportar el cambio de docente
- exigir vigencias completas a los suplentes y mostrar los campos de fecha solo cuando corresponda en la interfaz

## Testing
- ./mvnw test *(falla: wget no puede descargar Maven por restricción de red)*
- npm install *(falla: registro de npm devuelve 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc0c701d08327a460ebfbc333e8e0