### PR TITLE
Resaltar bordes de campos inválidos en postulación

### DIFF
--- a/frontend-ecep/src/app/postulacion/Step1.tsx
+++ b/frontend-ecep/src/app/postulacion/Step1.tsx
@@ -56,6 +56,7 @@ export function Step1({
             value={formData.nombre || ""}
             onChange={(e) => handleInputChange("nombre", e.target.value)}
             placeholder="Ingrese el nombre"
+            aria-invalid={errors.nombre || undefined}
             className={cn(errors.nombre && "border-destructive")}
           />
         </div>
@@ -68,6 +69,7 @@ export function Step1({
             value={formData.apellido || ""}
             onChange={(e) => handleInputChange("apellido", e.target.value)}
             placeholder="Ingrese el apellido"
+            aria-invalid={errors.apellido || undefined}
             className={cn(errors.apellido && "border-destructive")}
           />
         </div>
@@ -85,6 +87,7 @@ export function Step1({
             value={formData.dni || ""}
             onChange={(e) => handleInputChange("dni", formatDni(e.target.value))}
             placeholder="12345678"
+            aria-invalid={errors.dni || undefined}
             className={cn(errors.dni && "border-destructive")}
           />
           <div className="mt-1 text-xs text-muted-foreground min-h-[16px]">
@@ -107,6 +110,7 @@ export function Step1({
             onChange={(e) =>
               handleInputChange("fechaNacimiento", e.target.value)
             }
+            aria-invalid={errors.fechaNacimiento || undefined}
             className={cn(errors.fechaNacimiento && "border-destructive")}
           />
         </div>
@@ -117,9 +121,11 @@ export function Step1({
           <Select
             value={formData.cursoSolicitado}
             onValueChange={(v) => handleInputChange("cursoSolicitado", v)}
-            className={cn(errors.cursoSolicitado && "border-destructive")}
           >
-            <SelectTrigger>
+            <SelectTrigger
+              aria-invalid={errors.cursoSolicitado || undefined}
+              className={cn(errors.cursoSolicitado && "border-destructive")}
+            >
               <SelectValue placeholder="Seleccione un curso" />
             </SelectTrigger>
             <SelectContent>
@@ -145,9 +151,11 @@ export function Step1({
           <Select
             value={formData.turnoPreferido}
             onValueChange={(v) => handleInputChange("turnoPreferido", v)}
-            className={cn(errors.turnoPreferido && "border-destructive")}
           >
-            <SelectTrigger>
+            <SelectTrigger
+              aria-invalid={errors.turnoPreferido || undefined}
+              className={cn(errors.turnoPreferido && "border-destructive")}
+            >
               <SelectValue placeholder="Seleccione un turno" />
             </SelectTrigger>
             <SelectContent>
@@ -164,6 +172,7 @@ export function Step1({
             id="escuelaActual"
             value={formData.escuelaActual || ""}
             onChange={(e) => handleInputChange("escuelaActual", e.target.value)}
+            aria-invalid={errors.escuelaActual || undefined}
             className={cn(errors.escuelaActual && "border-destructive")}
           />
         </div>
@@ -175,6 +184,7 @@ export function Step1({
             id="domicilio"
             value={formData.domicilio || ""}
             onChange={(e) => handleInputChange("domicilio", e.target.value)}
+            aria-invalid={errors.domicilio || undefined}
             className={cn(errors.domicilio && "border-destructive")}
           />
         </div>
@@ -186,6 +196,7 @@ export function Step1({
             id="nacionalidad"
             value={formData.nacionalidad || ""}
             onChange={(e) => handleInputChange("nacionalidad", e.target.value)}
+            aria-invalid={errors.nacionalidad || undefined}
             className={cn(errors.nacionalidad && "border-destructive")}
           />
         </div>

--- a/frontend-ecep/src/app/postulacion/Step2.tsx
+++ b/frontend-ecep/src/app/postulacion/Step2.tsx
@@ -45,6 +45,8 @@ export function Step2({
     { value: RolVinculo.OTRO, label: "Otro/a" },
   ];
 
+  const hasError = (key: string) => Boolean(errors?.[key]);
+
   return (
     <div className="space-y-4">
       {/* ——— Título + Botón ——— */}
@@ -78,205 +80,206 @@ export function Step2({
 
       {/* ——— Lista de Formularios de cada Familiar ——— */}
       <div className="space-y-6">
-        {familiares.map((f, i) => (
-          <div key={i} className="border rounded-lg p-4">
-            <h4 className="font-medium mb-4">Familiar {i + 1}</h4>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {/* Relación */}
-              <div>
-                <Label htmlFor={`tipoRelacion-${i}`}>Relación</Label>
-                <Select
-                  id={`tipoRelacion-${i}`}
-                  value={f.tipoRelacion}
-                  onValueChange={(v) =>
-                    handleInputChange(
-                      "familiares",
-                      familiares.map((x, j) =>
-                        j === i ? { ...x, tipoRelacion: v as string } : x,
-                      ),
-                      { errorKeys: [`familiares.${i}.tipoRelacion`] },
-                    )
-                  }
-                  className={cn(
-                    errors[`familiares.${i}.tipoRelacion`] &&
-                      "border-destructive",
-                  )}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Seleccione relación" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {relationshipOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+        {familiares.map((f, i) => {
+          const entryKey = `familiares.${i}`;
+          const familiarKey = `${entryKey}.familiar`;
+          const tipoRelacionError = hasError(`${entryKey}.tipoRelacion`);
+          const nombreError = hasError(`${familiarKey}.nombre`);
+          const apellidoError = hasError(`${familiarKey}.apellido`);
+          const dniError = hasError(`${familiarKey}.dni`);
+          const fechaNacimientoError = hasError(`${familiarKey}.fechaNacimiento`);
+          const emailError = hasError(`${familiarKey}.emailContacto`);
 
-              {/* Nombre */}
-              <div>
-                <Label htmlFor={`familiar-nombre-${i}`}>Nombre</Label>
-                <Input
-                  id={`familiar-nombre-${i}`}
-                  value={f.familiar?.nombre ?? ""}
-                  onChange={(e) =>
-                    handleInputChange(
-                      "familiares",
-                      familiares.map((x, j) =>
-                        j === i
-                          ? {
-                              ...x,
-                              familiar: {
-                                ...x.familiar!,
-                                nombre: e.target.value,
-                              },
-                            }
-                          : x,
-                      ),
-                      { errorKeys: [`familiares.${i}.familiar.nombre`] },
-                    )
-                  }
-                  placeholder="Nombre"
-                  className={cn(
-                    errors[`familiares.${i}.familiar.nombre`] &&
-                      "border-destructive",
-                  )}
-                />
-              </div>
+          return (
+            <div key={i} className="border rounded-lg p-4">
+              <h4 className="font-medium mb-4">Familiar {i + 1}</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {/* Relación */}
+                <div>
+                  <Label htmlFor={`tipoRelacion-${i}`}>Relación</Label>
+                  <Select
+                    id={`tipoRelacion-${i}`}
+                    value={f.tipoRelacion}
+                    onValueChange={(v) =>
+                      handleInputChange(
+                        "familiares",
+                        familiares.map((x, j) =>
+                          j === i ? { ...x, tipoRelacion: v as string } : x,
+                        ),
+                        { errorKeys: [`familiares.${i}.tipoRelacion`] },
+                      )
+                    }
+                  >
+                    <SelectTrigger
+                      aria-invalid={tipoRelacionError || undefined}
+                      className={cn(tipoRelacionError && "border-destructive")}
+                    >
+                      <SelectValue placeholder="Seleccione relación" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {relationshipOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
 
-              {/* Apellido */}
-              <div>
-                <Label htmlFor={`familiar-apellido-${i}`}>Apellido</Label>
-                <Input
-                  id={`familiar-apellido-${i}`}
-                  value={f.familiar?.apellido ?? ""}
-                  onChange={(e) =>
-                    handleInputChange(
-                      "familiares",
-                      familiares.map((x, j) =>
-                        j === i
-                          ? {
-                              ...x,
-                              familiar: {
-                                ...x.familiar!,
-                                apellido: e.target.value,
-                              },
-                            }
-                          : x,
-                      ),
-                      { errorKeys: [`familiares.${i}.familiar.apellido`] },
-                    )
-                  }
-                  placeholder="Apellido"
-                  className={cn(
-                    errors[`familiares.${i}.familiar.apellido`] &&
-                      "border-destructive",
-                  )}
-                />
-              </div>
+                {/* Nombre */}
+                <div>
+                  <Label htmlFor={`familiar-nombre-${i}`}>Nombre</Label>
+                  <Input
+                    id={`familiar-nombre-${i}`}
+                    value={f.familiar?.nombre ?? ""}
+                    onChange={(e) =>
+                      handleInputChange(
+                        "familiares",
+                        familiares.map((x, j) =>
+                          j === i
+                            ? {
+                                ...x,
+                                familiar: {
+                                  ...x.familiar!,
+                                  nombre: e.target.value,
+                                },
+                              }
+                            : x,
+                        ),
+                        { errorKeys: [`familiares.${i}.familiar.nombre`] },
+                      )
+                    }
+                    placeholder="Nombre"
+                    aria-invalid={nombreError || undefined}
+                    className={cn(nombreError && "border-destructive")}
+                  />
+                </div>
 
-              {/* DNI */}
-              <div>
-                <Label htmlFor={`familiar-dni-${i}`}>DNI</Label>
-                <Input
-                  id={`familiar-dni-${i}`}
-                  inputMode="numeric"
-                  pattern="\d*"
-                  minLength={7}
-                  maxLength={10}
-                  value={f.familiar?.dni ?? ""}
-                  onChange={(e) =>
-                    handleInputChange(
-                      "familiares",
-                      familiares.map((x, j) =>
-                        j === i
-                          ? {
-                              ...x,
-                              familiar: {
-                                ...x.familiar!,
-                                dni: formatDni(e.target.value),
-                              },
-                            }
-                          : x,
-                      ),
-                      { errorKeys: [`familiares.${i}.familiar.dni`] },
-                    )
-                  }
-                  placeholder="12345678"
-                  className={cn(
-                    errors[`familiares.${i}.familiar.dni`] &&
-                      "border-destructive",
-                  )}
-                />
-              </div>
+                {/* Apellido */}
+                <div>
+                  <Label htmlFor={`familiar-apellido-${i}`}>Apellido</Label>
+                  <Input
+                    id={`familiar-apellido-${i}`}
+                    value={f.familiar?.apellido ?? ""}
+                    onChange={(e) =>
+                      handleInputChange(
+                        "familiares",
+                        familiares.map((x, j) =>
+                          j === i
+                            ? {
+                                ...x,
+                                familiar: {
+                                  ...x.familiar!,
+                                  apellido: e.target.value,
+                                },
+                              }
+                            : x,
+                        ),
+                        { errorKeys: [`familiares.${i}.familiar.apellido`] },
+                      )
+                    }
+                    placeholder="Apellido"
+                    aria-invalid={apellidoError || undefined}
+                    className={cn(apellidoError && "border-destructive")}
+                  />
+                </div>
 
-              {/* Fecha de Nacimiento */}
-              <div>
-                <Label htmlFor={`familiar-fecha-${i}`}>
-                  Fecha de Nacimiento
-                </Label>
-                <Input
-                  id={`familiar-fecha-${i}`}
-                  type="date"
-                  max={maxBirthDate}
-                  value={f.familiar?.fechaNacimiento ?? ""}
-                  onChange={(e) =>
-                    handleInputChange(
-                      "familiares",
-                      familiares.map((x, j) =>
-                        j === i
-                          ? {
-                              ...x,
-                              familiar: {
-                                ...x.familiar!,
-                                fechaNacimiento: e.target.value,
-                              },
-                            }
-                          : x,
-                      ),
-                      { errorKeys: [`familiares.${i}.familiar.fechaNacimiento`] },
-                    )
-                  }
-                  className={cn(
-                    errors[`familiares.${i}.familiar.fechaNacimiento`] &&
-                      "border-destructive",
-                  )}
-                />
-              </div>
+                {/* DNI */}
+                <div>
+                  <Label htmlFor={`familiar-dni-${i}`}>DNI</Label>
+                  <Input
+                    id={`familiar-dni-${i}`}
+                    inputMode="numeric"
+                    pattern="\d*"
+                    minLength={7}
+                    maxLength={10}
+                    value={f.familiar?.dni ?? ""}
+                    onChange={(e) =>
+                      handleInputChange(
+                        "familiares",
+                        familiares.map((x, j) =>
+                          j === i
+                            ? {
+                                ...x,
+                                familiar: {
+                                  ...x.familiar!,
+                                  dni: formatDni(e.target.value),
+                                },
+                              }
+                            : x,
+                        ),
+                        { errorKeys: [`familiares.${i}.familiar.dni`] },
+                      )
+                    }
+                    placeholder="12345678"
+                    aria-invalid={dniError || undefined}
+                    className={cn(dniError && "border-destructive")}
+                  />
+                </div>
 
-              {/* Email */}
-              <div>
-                <Label htmlFor={`familiar-email-${i}`}>Email</Label>
-                <Input
-                  id={`familiar-email-${i}`}
-                  type="email"
-                  value={f.familiar?.emailContacto ?? ""}
-                  onChange={(e) =>
-                    handleInputChange(
-                      "familiares",
-                      familiares.map((x, j) =>
-                        j === i
-                          ? {
-                              ...x,
-                              familiar: {
-                                ...x.familiar!,
-                                emailContacto: e.target.value,
-                              },
-                            }
-                          : x,
-                      ),
-                      { errorKeys: [`familiares.${i}.familiar.emailContacto`] },
-                    )
-                  }
-                  placeholder="email@dominio.com"
-                  className={cn(
-                    errors[`familiares.${i}.familiar.emailContacto`] &&
-                      "border-destructive",
-                  )}
-                />
-              </div>
+                {/* Fecha de Nacimiento */}
+                <div>
+                  <Label htmlFor={`familiar-fecha-${i}`}>
+                    Fecha de Nacimiento
+                  </Label>
+                  <Input
+                    id={`familiar-fecha-${i}`}
+                    type="date"
+                    max={maxBirthDate}
+                    value={f.familiar?.fechaNacimiento ?? ""}
+                    onChange={(e) =>
+                      handleInputChange(
+                        "familiares",
+                        familiares.map((x, j) =>
+                          j === i
+                            ? {
+                                ...x,
+                                familiar: {
+                                  ...x.familiar!,
+                                  fechaNacimiento: e.target.value,
+                                },
+                              }
+                            : x,
+                        ),
+                        { errorKeys: [`familiares.${i}.familiar.fechaNacimiento`] },
+                      )
+                    }
+                    aria-invalid={fechaNacimientoError || undefined}
+                    className={cn(
+                      fechaNacimientoError && "border-destructive",
+                    )}
+                  />
+                </div>
+
+                {/* Email */}
+                <div>
+                  <Label htmlFor={`familiar-email-${i}`}>Email</Label>
+                  <Input
+                    id={`familiar-email-${i}`}
+                    type="email"
+                    value={f.familiar?.emailContacto ?? ""}
+                    onChange={(e) =>
+                      handleInputChange(
+                        "familiares",
+                        familiares.map((x, j) =>
+                          j === i
+                            ? {
+                                ...x,
+                                familiar: {
+                                  ...x.familiar!,
+                                  emailContacto: e.target.value,
+                                },
+                              }
+                            : x,
+                        ),
+                        { errorKeys: [`familiares.${i}.familiar.emailContacto`] },
+                      )
+                    }
+                    placeholder="email@dominio.com"
+                    aria-invalid={emailError || undefined}
+                    className={cn(emailError && "border-destructive")}
+                  />
+                </div>
 
               {/* Teléfono */}
               <div>
@@ -374,7 +377,8 @@ export function Step2({
               </div>
             </div>
           </div>
-        ))}
+        );
+      })}
       </div>
     </div>
   );

--- a/frontend-ecep/src/app/postulacion/Step3.tsx
+++ b/frontend-ecep/src/app/postulacion/Step3.tsx
@@ -34,6 +34,8 @@ interface Step3Props {
 }
 
 export function Step3({ formData, handleInputChange, errors = {} }: Step3Props) {
+  const hasError = (key: string) => Boolean(errors?.[key]);
+
   return (
     <div className="space-y-4">
       <div className="flex items-center mb-6">
@@ -52,6 +54,7 @@ export function Step3({ formData, handleInputChange, errors = {} }: Step3Props) 
             required
           >
             <SelectTrigger
+              aria-invalid={hasError("conectividadInternet") || undefined}
               className={cn(
                 errors.conectividadInternet && "border-destructive",
               )}
@@ -81,6 +84,9 @@ export function Step3({ formData, handleInputChange, errors = {} }: Step3Props) 
             placeholder="Ej: PC, tablet, smartphone..."
             rows={3}
             required
+            aria-invalid={
+              hasError("dispositivosDisponibles") || undefined
+            }
             className={cn(
               errors.dispositivosDisponibles && "border-destructive",
             )}
@@ -99,6 +105,7 @@ export function Step3({ formData, handleInputChange, errors = {} }: Step3Props) 
             }
             placeholder="Ej: Español, Inglés..."
             required
+            aria-invalid={hasError("idiomasHabladosHogar") || undefined}
             className={cn(
               errors.idiomasHabladosHogar && "border-destructive",
             )}

--- a/frontend-ecep/src/components/ui/input.tsx
+++ b/frontend-ecep/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-[invalid=true]:border-destructive focus-visible:aria-[invalid=true]:ring-destructive',
           className
         )}
         ref={ref}

--- a/frontend-ecep/src/components/ui/select.tsx
+++ b/frontend-ecep/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-[invalid=true]:border-destructive focus:aria-[invalid=true]:ring-destructive [&>span]:line-clamp-1',
       className
     )}
     {...props}

--- a/frontend-ecep/src/components/ui/textarea.tsx
+++ b/frontend-ecep/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 aria-[invalid=true]:border-destructive focus-visible:aria-[invalid=true]:ring-destructive',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- Propagar los indicadores de error en los pasos 1 a 3 de la postulación para marcar con `aria-invalid` todos los campos con validaciones fallidas.
- Ajustar los componentes base `Input`, `Textarea` y `SelectTrigger` para que muestren bordes rojos cuando reciben `aria-invalid`.

## Testing
- `npm run lint` *(falla: `next` no encontrado porque no se pudieron instalar dependencias previamente)*
- `npm install` *(falla: error 403 al descargar @hookform/resolvers)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc8d8671c8327abd0c2da2fb99244