### PR TITLE
Fix alumno profile derived state initialization

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -132,12 +132,6 @@ export default function AlumnoPerfilPage() {
     const formatted = String(value).replace(/_/g, " ").toLowerCase();
     return formatted.replace(/\b\w/g, (char) => char.toUpperCase());
   };
-  const addDniValue = formatDni(addPersonaDraft.dni);
-  const addDniValid = addDniValue.length >= 7 && addDniValue.length <= 10;
-  const addPersonaExists = Boolean(addPersonaId);
-  const addPersonaReady =
-    addPersonaExists ||
-    (addDniValid && addLookupCompleted && !addLookupLoading);
 
   const [editOpen, setEditOpen] = useState(false);
   const [savingProfile, setSavingProfile] = useState(false);
@@ -183,6 +177,13 @@ export default function AlumnoPerfilPage() {
   const [addEsTutor, setAddEsTutor] = useState(false);
   const [savingFamily, setSavingFamily] = useState(false);
   const [familiaresCatalog, setFamiliaresCatalog] = useState<FamiliarDTO[]>([]);
+
+  const addDniValue = formatDni(addPersonaDraft.dni);
+  const addDniValid = addDniValue.length >= 7 && addDniValue.length <= 10;
+  const addPersonaExists = Boolean(addPersonaId);
+  const addPersonaReady =
+    addPersonaExists ||
+    (addDniValid && addLookupCompleted && !addLookupLoading);
 
   useEffect(() => {
     if (credentialsDialogOpen) {


### PR DESCRIPTION
## Summary
- prevent referencing add-family form state before its hooks are initialized on the alumno profile page
- keep derived DNI helpers after the related state declarations so the alumno detail view renders correctly

## Testing
- npm run lint *(fails: next not found because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcfc3b0708327bd8c84579b7e6845