### PR TITLE
Enhance chat presence feedback

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/dtos/TypingNotificationDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/dtos/TypingNotificationDTO.java
@@ -1,0 +1,9 @@
+package edu.ecep.base_app.dtos;
+
+import lombok.Data;
+
+@Data
+public class TypingNotificationDTO {
+    private Long receptorId;
+    private boolean typing;
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/ChatSocketController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/ChatSocketController.java
@@ -4,6 +4,7 @@ import edu.ecep.base_app.domain.Mensaje;
 import edu.ecep.base_app.domain.Persona;
 import edu.ecep.base_app.dtos.ChatMessageDTO;
 import edu.ecep.base_app.dtos.SendMessageRequest;
+import edu.ecep.base_app.dtos.TypingNotificationDTO;
 import edu.ecep.base_app.service.ChatService;
 import edu.ecep.base_app.service.PersonaAccountService;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +12,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class ChatSocketController {
 
     private final ChatService chatService;
     private final PersonaAccountService personaAccountService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/chat.send")
     @SendToUser("/queue/ack")
@@ -32,5 +36,31 @@ public class ChatSocketController {
         Persona emisor = personaAccountService.getPersonaById(Long.valueOf(principal.getName()));
         Mensaje saved = chatService.saveAndSend(req, emisor);
         return chatService.toDto(saved);
+    }
+
+    @MessageMapping("/chat.typing")
+    public void typing(
+            @Payload TypingNotificationDTO notification,
+            Principal principal
+    ) {
+        if (notification == null || notification.getReceptorId() == null) {
+            log.debug("Typing notification inválida: {}", notification);
+            return;
+        }
+
+        if (principal == null) {
+            log.warn("Evento typing sin principal asociado");
+            return;
+        }
+
+        Long senderId = Long.valueOf(principal.getName());
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(notification.getReceptorId()),
+                "/queue/typing",
+                Map.of(
+                        "userId", senderId,
+                        "typing", notification.isTyping()
+                )
+        );
     }
 }

--- a/frontend-ecep/src/services/api/modules/chat.ts
+++ b/frontend-ecep/src/services/api/modules/chat.ts
@@ -12,4 +12,8 @@ export const chat = {
     http.get<DTO.PersonaResumenDTO[]>("/api/chat/active-chats"),
   getUnreadCounts: () =>
     http.get<Record<number, number>>("/api/chat/unread-count"),
+  getOnlineStatus: (personaIds: number[]) =>
+    http.get<Record<number, boolean>>("/api/chat/online-status", {
+      params: { personaIds },
+    }),
 };


### PR DESCRIPTION
## Summary
- add a typing notification DTO and websocket handler so the backend can broadcast typing events to chat contacts
- extend the chat socket hook to track online status, typing indicators, and read receipts while fetching initial presence information from the API
- refresh the chat UI to use the full available height, surface online/typing labels, and replace checkmarks with dot-based message state indicators

## Testing
- `npm run lint` *(fails: missing local dependencies because npm registry requests return 403 in this environment)*
- `./mvnw test` *(fails: Maven wrapper cannot download the Maven distribution due to HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68cddd3df3f88327a44f0fcb9e4c3060