### PR TITLE
Normalize Volver button layout

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
@@ -19,7 +19,6 @@ import {
   Calendar,
   CheckCircle,
   X,
-  ArrowLeft,
   Plus,
   Eye,
   Pencil,
@@ -327,7 +326,14 @@ export default function AccidentesSeccionPage() {
   return (
     <DashboardLayout>
       <div className="p-4 md:p-8 space-y-6">
-        <div className="flex items-start md:items-center justify-between gap-3 flex-col md:flex-row">
+        <Button
+          variant="outline"
+          onClick={() => router.push("/dashboard/accidentes")}
+        >
+          Volver
+        </Button>
+
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div>
             <h2 className="text-2xl font-semibold">
               Actas de Accidentes — Sección{" "}
@@ -344,7 +350,7 @@ export default function AccidentesSeccionPage() {
               ) : null}
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center">
             <div className="hidden md:block">
               <label className="text-xs block mb-1">
                 Fecha (roster activo)
@@ -364,12 +370,6 @@ export default function AccidentesSeccionPage() {
                 className="pl-10"
               />
             </div>
-            <Button
-              variant="outline"
-              onClick={() => router.push("/dashboard/accidentes")}
-            >
-              <ArrowLeft className="h-4 w-4 mr-1" /> Volver
-            </Button>
             {canCreate && (
               <NewActaDialog
                 open={openNew}

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -867,8 +867,11 @@ export default function AlumnoPerfilPage() {
   return (
     <DashboardLayout>
       <div className="p-4 md:p-8 space-y-6">
+        <Button variant="outline" onClick={() => router.back()}>
+          Volver
+        </Button>
         {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">
               Perfil del Alumno
@@ -1120,9 +1123,6 @@ export default function AlumnoPerfilPage() {
                 </DialogFooter>
               </DialogContent>
             </Dialog>
-            <Button variant="outline" onClick={() => router.back()}>
-              Volver
-            </Button>
           </div>
         </div>
 

--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -243,14 +243,17 @@ export default function AltaAlumnoPage() {
   return (
     <DashboardLayout>
       <div className="flex-1 space-y-6 p-4 md:p-8">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold">Alta manual de alumno</h1>
-            <p className="text-muted-foreground">
-              Cargá la persona y los datos básicos para vincularla como alumno.
-            </p>
-          </div>
-          <Button variant="outline" onClick={() => router.push("/dashboard/alumnos")}>Volver</Button>
+        <Button
+          variant="outline"
+          onClick={() => router.push("/dashboard/alumnos")}
+        >
+          Volver
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold">Alta manual de alumno</h1>
+          <p className="text-muted-foreground">
+            Cargá la persona y los datos básicos para vincularla como alumno.
+          </p>
         </div>
 
         <Card>

--- a/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
@@ -28,20 +28,18 @@ export default function SeccionAlumnosPage() {
   return (
     <DashboardLayout>
       <div className="p-4 md:p-8 space-y-6">
+        <Button
+          variant="outline"
+          onClick={() => router.push("/dashboard/alumnos")}
+        >
+          Volver
+        </Button>
         {/* Header sin filtros */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-3xl font-bold tracking-tight">
-              Alumnos por sección
-            </h2>
-            <div className="text-muted-foreground">Sección #{seccionId}</div>
-          </div>
-          <Button
-            variant="outline"
-            onClick={() => router.push("/dashboard/alumnos")}
-          >
-            Volver
-          </Button>
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">
+            Alumnos por sección
+          </h2>
+          <div className="text-muted-foreground">Sección #{seccionId}</div>
         </div>
 
         {/* Contenido: solo alumnos */}

--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -21,7 +21,7 @@ import {
   AlertDescription,
   AlertTitle,
 } from "@/components/ui/alert";
-import { Calendar, ArrowLeft, Plus } from "lucide-react";
+import { Calendar, Plus } from "lucide-react";
 import { api } from "@/services/api";
 import type {
   SeccionDTO,
@@ -208,7 +208,6 @@ export default function SeccionHistorialPage() {
           variant="outline"
           onClick={() => router.push("/dashboard/asistencia")}
         >
-          <ArrowLeft className="h-4 w-4 mr-1" />
           Volver
         </Button>
 

--- a/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { ArrowLeft, School, Clock3 } from "lucide-react";
+import { School, Clock3 } from "lucide-react";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { toast } from "sonner";
 
@@ -357,8 +357,8 @@ export default function ExamenDetailPage() {
     return (
       <DashboardLayout>
         <div className="p-6 space-y-4">
-          <Button variant="ghost" onClick={() => router.back()}>
-            <ArrowLeft className="h-4 w-4 mr-1" /> Volver
+          <Button variant="outline" onClick={() => router.back()}>
+            Volver
           </Button>
           <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
             {error}
@@ -372,8 +372,8 @@ export default function ExamenDetailPage() {
     return (
       <DashboardLayout>
         <div className="p-6 space-y-4">
-          <Button variant="ghost" onClick={() => router.back()}>
-            <ArrowLeft className="h-4 w-4 mr-1" /> Volver
+          <Button variant="outline" onClick={() => router.back()}>
+            Volver
           </Button>
           <div className="rounded-md border p-4 text-sm">
             No encontramos datos para el examen solicitado.
@@ -386,11 +386,9 @@ export default function ExamenDetailPage() {
   return (
     <DashboardLayout>
       <div className="p-4 md:p-8 space-y-6">
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="sm" onClick={() => router.back()}>
-            <ArrowLeft className="h-4 w-4 mr-1" /> Volver
-          </Button>
-        </div>
+        <Button variant="outline" onClick={() => router.back()}>
+          Volver
+        </Button>
 
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Calendar, Edit, Plus, ArrowLeft, School, Clock3 } from "lucide-react";
+import { Calendar, Edit, Plus, School, Clock3 } from "lucide-react";
 import NotasExamenDialog from "@/app/dashboard/evaluaciones/_components/NotasExamenDialog";
 import { toast } from "sonner";
 
@@ -259,6 +259,12 @@ export default function SeccionEvaluacionesPage() {
   return (
     <DashboardLayout>
       <div className="p-4 md:p-8 space-y-6">
+        <Button
+          variant="outline"
+          onClick={() => router.push("/dashboard/evaluaciones")}
+        >
+          Volver
+        </Button>
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">Evaluaciones</h1>
@@ -423,12 +429,6 @@ export default function SeccionEvaluacionesPage() {
               </DialogContent>
             </Dialog>
 
-            <Button
-              variant="outline"
-              onClick={() => router.push("/dashboard/evaluaciones")}
-            >
-              <ArrowLeft className="h-4 w-4 mr-1" /> Volver
-            </Button>
           </div>
         </div>
 

--- a/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
@@ -297,7 +297,10 @@ export default function FamiliarPerfilPage() {
   return (
     <DashboardLayout>
       <div className="p-4 md:p-8 space-y-6">
-        <div className="flex items-center justify-between">
+        <Button variant="outline" onClick={() => router.back()}>
+          Volver
+        </Button>
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">Perfil del Familiar</h2>
             <p className="text-muted-foreground">ID: {familiarId}</p>
@@ -423,9 +426,6 @@ export default function FamiliarPerfilPage() {
                 </DialogFooter>
               </DialogContent>
             </Dialog>
-            <Button variant="outline" onClick={() => router.back()}>
-              Volver
-            </Button>
           </div>
         </div>
 

--- a/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { ArrowLeft, Plus, UserPlus } from "lucide-react";
+import { Plus, UserPlus } from "lucide-react";
 import { api } from "@/services/api";
 import type {
   SeccionDTO,
@@ -231,7 +231,6 @@ export default function MateriasSeccionPage() {
           variant="outline"
           onClick={() => router.push("/dashboard/materias")}
         >
-          <ArrowLeft className="h-4 w-4 mr-1" />
           Volver
         </Button>
 

--- a/frontend-ecep/src/app/postulacion/page.tsx
+++ b/frontend-ecep/src/app/postulacion/page.tsx
@@ -630,14 +630,11 @@ export default function PostulacionPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 p-4">
-      <div className="max-w-4xl mx-auto">
-        <Link
-          href="/"
-          className="inline-flex items-center text-primary mb-4 hover:text-primary/80"
-        >
-          Volver
-        </Link>
-        <div className="text-center mb-6">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <Button variant="outline" asChild>
+          <Link href="/">Volver</Link>
+        </Button>
+        <div className="text-center">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
             Postulación de Alumno
           </h1>


### PR DESCRIPTION
## Summary
- show the postulacion "Volver" control as an outlined button positioned above the page heading
- standardize dashboard "Volver" buttons across accidents, attendance, evaluations, students, families, and subjects so they sit above the section titles without the back-arrow icon

## Testing
- `npm run lint` *(fails: the `next` binary is missing because dependencies could not be installed in this environment)*
- `npm install` *(fails: npm registry returns HTTP 403 so dependencies cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68cde6a6bfb083279fbe7e8cb05ddcb5