### PR TITLE
Add family and student dashboards for attendance and evaluations

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -63,7 +63,7 @@ export default function AlumnosIndexPage() {
   const { hoyISO } = useActivePeriod();
 
   useEffect(() => {
-    if (scope === "family") return;
+    if (scope === "family" || scope === "student") return;
     let cancelled = false;
     (async () => {
       setLoadingAlumnos(true);
@@ -125,10 +125,12 @@ export default function AlumnosIndexPage() {
                 ? `Período escolar activo: #${periodoEscolarId ?? "—"} • Hoy: ${hoyISO}`
                 : scope === "teacher"
                   ? "Gestión de alumnos por sección"
-                  : "Vista de hijos y perfiles"}
+                  : scope === "student"
+                    ? "Consulta de mi información académica"
+                    : "Vista de hijos y perfiles"}
             </div>
           </div>
-          {scope !== "family" && (
+          {(scope === "staff" || scope === "teacher") && (
             <div className="flex items-center space-x-2">
               <Button onClick={() => router.push("/dashboard/alumnos/alta")}>
                 <UserPlus className="h-4 w-4 mr-2" />
@@ -139,7 +141,7 @@ export default function AlumnosIndexPage() {
         </div>
 
         {/* Search global (para Aspirantes / Historial) */}
-        {scope !== "family" && (
+        {(scope === "staff" || scope === "teacher") && (
           <div className="flex items-center space-x-2">
             <div className="relative flex-1 max-w-sm">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
@@ -156,13 +158,18 @@ export default function AlumnosIndexPage() {
         {loading && <LoadingState label="Cargando información…" />}
         {error && <div className="text-sm text-red-600">{String(error)}</div>}
 
-        {/* FAMILY: lista de hijos */}
-        {!loading && !error && scope === "family" && (
-          <FamilyView hijos={hijos} />
+        {/* FAMILY / STUDENT: lista de hijos o matrícula propia */}
+        {!loading && !error && (scope === "family" || scope === "student") && (
+          <FamilyView
+            hijos={hijos}
+            title={scope === "student" ? "Mi matrícula" : "Mis hijos/as"}
+          />
         )}
 
         {/* STAFF / TEACHER: Tabs */}
-        {!loading && !error && scope !== "family" && (
+        {!loading &&
+          !error &&
+          (scope === "staff" || scope === "teacher") && (
           <Tabs
             value={selectedTab}
             onValueChange={(v) => setSelectedTab(v as any)}

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useViewerAlumnosLite } from "@/hooks/useViewerAlumnosLite";
+import { api } from "@/services/api";
+import type {
+  AlumnoLiteDTO,
+  DetalleAsistenciaDTO,
+  JornadaAsistenciaDTO,
+  NivelAcademico,
+} from "@/types/api-generated";
+import { NivelAcademico as NivelAcademicoEnum, UserRole } from "@/types/api-generated";
+import { CheckCircle, Minus, X } from "lucide-react";
+
+function Donut({ percent }: { percent: number }) {
+  const r = 36;
+  const c = 2 * Math.PI * r;
+  const normalized = Math.max(0, Math.min(100, percent));
+  const off = c - (normalized / 100) * c;
+  return (
+    <svg width="100" height="100" viewBox="0 0 100 100">
+      <circle
+        cx="50"
+        cy="50"
+        r={r}
+        fill="transparent"
+        stroke="#e5e7eb"
+        strokeWidth="10"
+      />
+      <circle
+        cx="50"
+        cy="50"
+        r={r}
+        fill="transparent"
+        stroke="currentColor"
+        strokeWidth="10"
+        strokeDasharray={c}
+        strokeDashoffset={off}
+        transform="rotate(-90 50 50)"
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        fontSize="16"
+      >
+        {normalized}%
+      </text>
+    </svg>
+  );
+}
+
+const dateFormatter = new Intl.DateTimeFormat("es-AR", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const parsed = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return dateFormatter.format(parsed);
+}
+
+function nivelLabel(nivel?: NivelAcademico | null) {
+  if (!nivel) return "Nivel no disponible";
+  if (nivel === NivelAcademicoEnum.PRIMARIO) return "Nivel primario";
+  if (nivel === NivelAcademicoEnum.INICIAL) return "Nivel inicial";
+  return String(nivel);
+}
+
+function estadoLabel(estado?: string | null) {
+  if (!estado) return "Sin dato";
+  const normalized = estado.toLowerCase();
+  if (normalized === "presente") return "Presente";
+  if (normalized === "ausente") return "Ausente";
+  if (normalized === "tarde") return "Llegó tarde";
+  if (normalized === "justificada") return "Ausencia justificada";
+  return estado
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (l) => l.toUpperCase())
+    .trim();
+}
+
+function estadoVariant(estado?: string | null) {
+  if (!estado) return "outline" as const;
+  const normalized = estado.toLowerCase();
+  if (normalized === "presente") return "default" as const;
+  if (normalized === "ausente") return "destructive" as const;
+  return "secondary" as const;
+}
+
+export function FamilyAttendanceView() {
+  const { role, alumnos, loading, error } = useViewerAlumnosLite();
+  const [selectedMatriculaId, setSelectedMatriculaId] = useState<number | null>(
+    null,
+  );
+  const [detalles, setDetalles] = useState<DetalleAsistenciaDTO[]>([]);
+  const [jornadas, setJornadas] = useState<Map<number, JornadaAsistenciaDTO>>(
+    new Map(),
+  );
+  const [loadingDetalles, setLoadingDetalles] = useState(false);
+  const [errorDetalles, setErrorDetalles] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!alumnos.length) {
+      setSelectedMatriculaId(null);
+      setDetalles([]);
+      setJornadas(new Map());
+      return;
+    }
+
+    if (
+      selectedMatriculaId == null ||
+      !alumnos.some((a) => a.matriculaId === selectedMatriculaId)
+    ) {
+      setSelectedMatriculaId(alumnos[0].matriculaId);
+    }
+  }, [alumnos, selectedMatriculaId]);
+
+  const alumnoSeleccionado: AlumnoLiteDTO | null = useMemo(() => {
+    if (selectedMatriculaId == null) return null;
+    return (
+      alumnos.find((al) => al.matriculaId === selectedMatriculaId) ?? null
+    );
+  }, [alumnos, selectedMatriculaId]);
+
+  useEffect(() => {
+    let alive = true;
+
+    async function fetchDetalles() {
+      if (!alumnoSeleccionado) {
+        setDetalles([]);
+        setJornadas(new Map());
+        setErrorDetalles(null);
+        return;
+      }
+
+      try {
+        setLoadingDetalles(true);
+        setErrorDetalles(null);
+
+        const { data } = await api.detallesAsistencia.search({
+          matriculaId: alumnoSeleccionado.matriculaId,
+        });
+        if (!alive) return;
+        const registros = data ?? [];
+        setDetalles(registros);
+
+        const jornadaIds = Array.from(
+          new Set(
+            registros
+              .map((d) => d.jornadaId)
+              .filter((id): id is number => typeof id === "number"),
+          ),
+        );
+
+        if (!jornadaIds.length) {
+          setJornadas(new Map());
+          return;
+        }
+
+        const entries = await Promise.all(
+          jornadaIds.map(async (jid) => {
+            try {
+              const res = await api.jornadasAsistencia.byId(jid);
+              return [jid, res.data ?? null] as const;
+            } catch {
+              return [jid, null] as const;
+            }
+          }),
+        );
+        if (!alive) return;
+        const next = new Map<number, JornadaAsistenciaDTO>();
+        for (const [jid, jornada] of entries) {
+          if (jornada) next.set(jid, jornada);
+        }
+        setJornadas(next);
+      } catch (fetchError: any) {
+        if (!alive) return;
+        setErrorDetalles(
+          fetchError?.response?.data?.message ??
+            fetchError?.message ??
+            "No se pudo obtener el historial de asistencias.",
+        );
+        setDetalles([]);
+        setJornadas(new Map());
+      } finally {
+        if (alive) setLoadingDetalles(false);
+      }
+    }
+
+    fetchDetalles();
+
+    return () => {
+      alive = false;
+    };
+  }, [alumnoSeleccionado]);
+
+  const resumen = useMemo(() => {
+    if (!detalles.length) {
+      return {
+        total: 0,
+        presentes: 0,
+        ausentes: 0,
+        otros: 0,
+        porcentaje: 0,
+      };
+    }
+
+    const presentes = detalles.filter(
+      (d) => String(d.estado).toUpperCase() === "PRESENTE",
+    ).length;
+    const ausentes = detalles.filter(
+      (d) => String(d.estado).toUpperCase() === "AUSENTE",
+    ).length;
+    const otros = detalles.length - presentes - ausentes;
+    const porcentaje = Math.round((presentes / detalles.length) * 100);
+
+    return { total: detalles.length, presentes, ausentes, otros, porcentaje };
+  }, [detalles]);
+
+  const historial = useMemo(() => {
+    return detalles
+      .map((detalle) => {
+        const jornada = detalle.jornadaId
+          ? jornadas.get(detalle.jornadaId)
+          : null;
+        return {
+          id: detalle.id,
+          estado: detalle.estado,
+          observacion: detalle.observacion,
+          fecha: jornada?.fecha ?? null,
+        };
+      })
+      .sort((a, b) => (b.fecha ?? "").localeCompare(a.fecha ?? ""));
+  }, [detalles, jornadas]);
+
+  if (loading) {
+    return <LoadingState label="Cargando alumnos vinculados…" />;
+  }
+
+  if (error) {
+    return <div className="text-sm text-red-600">{error}</div>;
+  }
+
+  if (!alumnos.length) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        No hay alumnos asociados a tu cuenta en este momento.
+      </div>
+    );
+  }
+
+  const titulo =
+    role === UserRole.STUDENT ? "Mi asistencia" : "Asistencia por alumno";
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h3 className="text-2xl font-semibold tracking-tight">{titulo}</h3>
+        <p className="text-sm text-muted-foreground">
+          Seleccioná un alumno para revisar su historial diario y el porcentaje
+          total de asistencias.
+        </p>
+      </header>
+
+      {alumnos.length > 1 && (
+        <div className="flex flex-wrap gap-2">
+          {alumnos.map((al) => (
+            <Button
+              key={al.matriculaId}
+              size="sm"
+              variant={
+                selectedMatriculaId === al.matriculaId ? "default" : "outline"
+              }
+              onClick={() => setSelectedMatriculaId(al.matriculaId)}
+            >
+              {al.nombreCompleto}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {alumnoSeleccionado && (
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>{alumnoSeleccionado.nombreCompleto}</CardTitle>
+              <CardDescription className="space-y-1">
+                {alumnoSeleccionado.seccionNombre && (
+                  <div>Sección: {alumnoSeleccionado.seccionNombre}</div>
+                )}
+                <div>{nivelLabel(alumnoSeleccionado.nivel)}</div>
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loadingDetalles ? (
+                <LoadingState label="Cargando asistencias…" className="h-32" />
+              ) : (
+                <div className="flex flex-col gap-6 md:flex-row md:items-center">
+                  <div className="text-primary">
+                    <Donut percent={resumen.porcentaje} />
+                  </div>
+                  <div className="flex-1 space-y-3 text-sm">
+                    <div className="flex items-center gap-2">
+                      <CheckCircle className="h-4 w-4 text-green-600" />
+                      <span className="font-medium">
+                        Presentes: {resumen.presentes}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <X className="h-4 w-4 text-red-600" />
+                      <span className="font-medium">
+                        Ausentes: {resumen.ausentes}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Minus className="h-4 w-4 text-muted-foreground" />
+                      <span className="font-medium">
+                        Otros registros: {resumen.otros}
+                      </span>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Total de días registrados: {resumen.total}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Historial diario</CardTitle>
+              <CardDescription>
+                Registros de asistencias e inasistencias cargados por los
+                docentes.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {loadingDetalles && (
+                <LoadingState label="Cargando historial…" className="h-32" />
+              )}
+
+              {!loadingDetalles && errorDetalles && (
+                <div className="text-sm text-red-600">{errorDetalles}</div>
+              )}
+
+              {!loadingDetalles && !errorDetalles && !historial.length && (
+                <div className="text-sm text-muted-foreground">
+                  Aún no hay asistencias registradas en el período consultado.
+                </div>
+              )}
+
+              {!loadingDetalles && !errorDetalles && historial.length > 0 && (
+                <div className="space-y-2">
+                  {historial.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex items-center justify-between rounded border p-3"
+                    >
+                      <div className="space-y-1">
+                        <div className="text-sm font-medium">
+                          {formatDate(item.fecha)}
+                        </div>
+                        {item.observacion && (
+                          <p className="text-xs text-muted-foreground">
+                            {item.observacion}
+                          </p>
+                        )}
+                      </div>
+                      <Badge variant={estadoVariant(item.estado)}>
+                        {estadoLabel(item.estado)}
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FamilyAttendanceView;

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
@@ -1,0 +1,601 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/common/LoadingState";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  AlumnoLiteDTO,
+  EvaluacionDTO,
+  InformeInicialDTO,
+  MateriaDTO,
+  ResultadoEvaluacionDTO,
+  SeccionMateriaDTO,
+  TrimestreDTO,
+} from "@/types/api-generated";
+import { NivelAcademico as NivelAcademicoEnum } from "@/types/api-generated";
+import { api } from "@/services/api";
+import { CheckCircle2, Clock, FileText, GraduationCap } from "lucide-react";
+
+interface FamilyEvaluationsViewProps {
+  alumnos: AlumnoLiteDTO[];
+  scope: "family" | "student";
+  initialLoading?: boolean;
+  initialError?: string | null;
+}
+
+interface EvaluacionDetalle {
+  id: number;
+  fecha?: string | null;
+  tema?: string | null;
+  trimestreLabel: string;
+  notaNumerica?: number | null;
+  notaConceptual?: string | null;
+  observaciones?: string | null;
+  estado: "Calificada" | "Pendiente";
+}
+
+interface MateriaEvaluaciones {
+  key: string;
+  materiaNombre: string;
+  evaluaciones: EvaluacionDetalle[];
+}
+
+interface InformePorTrimestre {
+  trimestre: TrimestreDTO;
+  informe: InformeInicialDTO | null;
+}
+
+function resolveNivel(alumno: AlumnoLiteDTO | null) {
+  if (!alumno) return null;
+  if (alumno.nivel) return alumno.nivel;
+  const nombre = (alumno.seccionNombre ?? "").toLowerCase();
+  if (nombre.includes("sala")) return NivelAcademicoEnum.INICIAL;
+  return NivelAcademicoEnum.PRIMARIO;
+}
+
+const dateFormatter = new Intl.DateTimeFormat("es-AR", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const parsed = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return dateFormatter.format(parsed);
+}
+
+function formatTrimestre(trimestre?: TrimestreDTO | null) {
+  if (!trimestre) return "Trimestre";
+  const numero = trimestre.orden ?? "";
+  const inicio = trimestre.inicio ? formatDate(trimestre.inicio) : null;
+  const fin = trimestre.fin ? formatDate(trimestre.fin) : null;
+  const rango = inicio && fin ? `${inicio} – ${fin}` : null;
+  return rango ? `Trimestre ${numero} · ${rango}` : `Trimestre ${numero}`;
+}
+
+function promedioNumerico(resultados: ResultadoEvaluacionDTO[]) {
+  const notas = resultados
+    .map((r) => (typeof r.notaNumerica === "number" ? r.notaNumerica : null))
+    .filter((n): n is number => n != null);
+  if (!notas.length) return null;
+  const sum = notas.reduce((acc, n) => acc + n, 0);
+  return Math.round((sum / notas.length) * 100) / 100;
+}
+
+export function FamilyEvaluationsView({
+  alumnos,
+  scope,
+  initialLoading,
+  initialError,
+}: FamilyEvaluationsViewProps) {
+  const [selectedMatriculaId, setSelectedMatriculaId] = useState<number | null>(
+    null,
+  );
+  const [loadingDetalle, setLoadingDetalle] = useState(false);
+  const [errorDetalle, setErrorDetalle] = useState<string | null>(null);
+  const [materias, setMaterias] = useState<MateriaEvaluaciones[] | null>(null);
+  const [informesInicial, setInformesInicial] = useState<
+    InformePorTrimestre[] | null
+  >(null);
+  const [trimestres, setTrimestres] = useState<Map<number, TrimestreDTO>>(
+    new Map(),
+  );
+  const [resumen, setResumen] = useState<{
+    promedio: number | null;
+    totalEvaluaciones: number;
+    evaluacionesCalificadas: number;
+  }>({ promedio: null, totalEvaluaciones: 0, evaluacionesCalificadas: 0 });
+
+  useEffect(() => {
+    if (!alumnos.length) {
+      setSelectedMatriculaId(null);
+      setMaterias(null);
+      setInformesInicial(null);
+      setResumen({ promedio: null, totalEvaluaciones: 0, evaluacionesCalificadas: 0 });
+      return;
+    }
+
+    if (
+      selectedMatriculaId == null ||
+      !alumnos.some((a) => a.matriculaId === selectedMatriculaId)
+    ) {
+      setSelectedMatriculaId(alumnos[0].matriculaId);
+    }
+  }, [alumnos, selectedMatriculaId]);
+
+  const alumnoSeleccionado = useMemo(() => {
+    if (selectedMatriculaId == null) return null;
+    return (
+      alumnos.find((al) => al.matriculaId === selectedMatriculaId) ?? null
+    );
+  }, [alumnos, selectedMatriculaId]);
+
+  useEffect(() => {
+    let alive = true;
+
+    async function cargarDetalle() {
+      if (!alumnoSeleccionado) {
+        setMaterias(null);
+        setInformesInicial(null);
+        setErrorDetalle(null);
+        setResumen({ promedio: null, totalEvaluaciones: 0, evaluacionesCalificadas: 0 });
+        return;
+      }
+
+      const nivel = resolveNivel(alumnoSeleccionado);
+
+      try {
+        setLoadingDetalle(true);
+        setErrorDetalle(null);
+
+        const trimestresRes = await api.trimestres
+          .list()
+          .catch(() => ({ data: [] as TrimestreDTO[] }));
+        if (!alive) return;
+        const mapaTrimestres = new Map<number, TrimestreDTO>();
+        for (const t of trimestresRes.data ?? []) {
+          if (t.id != null) mapaTrimestres.set(t.id, t);
+        }
+        setTrimestres(mapaTrimestres);
+
+        if (nivel === NivelAcademicoEnum.INICIAL) {
+          const informesRes = await api.informes
+            .list()
+            .catch(() => ({ data: [] as InformeInicialDTO[] }));
+          if (!alive) return;
+
+          const informesAlumno = (informesRes.data ?? []).filter(
+            (inf) => inf.matriculaId === alumnoSeleccionado.matriculaId,
+          );
+          const map = new Map<number, InformeInicialDTO>();
+          for (const inf of informesAlumno) {
+            if (inf.trimestreId != null) map.set(inf.trimestreId, inf);
+          }
+
+          const ordenados = Array.from(mapaTrimestres.values()).sort(
+            (a, b) => (a.orden ?? 0) - (b.orden ?? 0),
+          );
+
+          setInformesInicial(
+            ordenados.map((tri) => ({
+              trimestre: tri,
+              informe: map.get(tri.id ?? -1) ?? null,
+            })),
+          );
+          setMaterias(null);
+          setResumen({ promedio: null, totalEvaluaciones: 0, evaluacionesCalificadas: 0 });
+          return;
+        }
+
+        const seccionId = alumnoSeleccionado.seccionId ?? null;
+
+        const [evaluacionesRes, resultadosRes, seccionMateriasRes, materiasRes] =
+          await Promise.all([
+            seccionId
+              ? api.evaluaciones
+                  .search({ seccionId })
+                  .catch(() => ({ data: [] as EvaluacionDTO[] }))
+              : api.evaluaciones
+                  .list()
+                  .catch(() => ({ data: [] as EvaluacionDTO[] })),
+            api.resultados
+              .list({ matriculaId: alumnoSeleccionado.matriculaId })
+              .catch(() => ({ data: [] as ResultadoEvaluacionDTO[] })),
+            api.seccionMaterias
+              .list()
+              .catch(() => ({ data: [] as SeccionMateriaDTO[] })),
+            api.materias
+              .list()
+              .catch(() => ({ data: [] as MateriaDTO[] })),
+          ]);
+
+        if (!alive) return;
+
+        const seccionMaterias = (seccionMateriasRes.data ?? []).filter((sm) => {
+          if (!seccionId) return true;
+          const sid = sm.seccionId ?? (sm as any)?.seccion?.id;
+          return sid === seccionId;
+        });
+        const materiasCatalogo = materiasRes.data ?? [];
+        const evaluaciones = (evaluacionesRes.data ?? []) as EvaluacionDTO[];
+        const resultados = (resultadosRes.data ?? []) as ResultadoEvaluacionDTO[];
+
+        const materiaNombreById = new Map<number, string>();
+        for (const mat of materiasCatalogo) {
+          if (mat.id != null) {
+            materiaNombreById.set(
+              mat.id,
+              mat.nombre ?? `Materia ${mat.id}`,
+            );
+          }
+        }
+
+        const materiaPorSeccionMateria = new Map<number, string>();
+        for (const sm of seccionMaterias) {
+          if (sm.id == null) continue;
+          const materiaId = sm.materiaId ?? (sm as any)?.materia?.id;
+          if (materiaId != null && materiaNombreById.has(materiaId)) {
+            materiaPorSeccionMateria.set(
+              sm.id,
+              materiaNombreById.get(materiaId)!,
+            );
+          } else {
+            materiaPorSeccionMateria.set(
+              sm.id,
+              `Materia ${materiaId ?? sm.id}`,
+            );
+          }
+        }
+
+        const seccionPorSeccionMateria = new Map<number, number>();
+        for (const sm of seccionMaterias) {
+          if (sm.id != null) {
+            const sid = sm.seccionId ?? (sm as any)?.seccion?.id;
+            if (sid != null) seccionPorSeccionMateria.set(sm.id, sid);
+          }
+        }
+
+        const evaluacionesFiltradas = evaluaciones.filter((ev) => {
+          const smId = (ev as any)?.seccionMateriaId;
+          if (smId == null) return !seccionId;
+          if (!seccionId) return true;
+          return seccionPorSeccionMateria.get(smId) === seccionId;
+        });
+
+        const resultadoPorEvaluacion = new Map<number, ResultadoEvaluacionDTO>();
+        for (const res of resultados) {
+          if (res.evaluacionId != null) {
+            resultadoPorEvaluacion.set(res.evaluacionId, res);
+          }
+        }
+
+        const materiasMap = new Map<string, MateriaEvaluaciones>();
+
+        for (const evaluacion of evaluacionesFiltradas) {
+          const smId = (evaluacion as any)?.seccionMateriaId as
+            | number
+            | undefined;
+          const materiaNombre = smId
+            ? materiaPorSeccionMateria.get(smId) ?? `Materia ${smId}`
+            : "Sin materia asignada";
+          const key = smId != null ? String(smId) : `sin-${evaluacion.id}`;
+
+          if (!materiasMap.has(key)) {
+            materiasMap.set(key, {
+              key,
+              materiaNombre,
+              evaluaciones: [],
+            });
+          }
+
+          const resultado = resultadoPorEvaluacion.get(evaluacion.id);
+          const trimestre =
+            evaluacion.trimestreId != null
+              ? mapaTrimestres.get(evaluacion.trimestreId)
+              : null;
+
+          materiasMap.get(key)!.evaluaciones.push({
+            id: evaluacion.id,
+            fecha: evaluacion.fecha ?? null,
+            tema: evaluacion.tema ?? "—",
+            trimestreLabel: trimestre
+              ? `Trimestre ${trimestre.orden ?? ""}`
+              : "Sin trimestre",
+            notaNumerica: resultado?.notaNumerica ?? null,
+            notaConceptual: resultado?.notaConceptual ?? null,
+            observaciones: resultado?.observaciones ?? null,
+            estado: resultado ? "Calificada" : "Pendiente",
+          });
+        }
+
+        const materiasOrdenadas = Array.from(materiasMap.values()).map(
+          (mat) => ({
+            ...mat,
+            evaluaciones: mat.evaluaciones.sort((a, b) =>
+              (b.fecha ?? "").localeCompare(a.fecha ?? ""),
+            ),
+          }),
+        );
+
+        setMaterias(
+          materiasOrdenadas.sort((a, b) =>
+            a.materiaNombre.localeCompare(b.materiaNombre, "es"),
+          ),
+        );
+        setInformesInicial(null);
+
+        const totalEvaluaciones = evaluacionesFiltradas.length;
+        const evaluacionesCalificadas = evaluacionesFiltradas.filter((ev) =>
+          resultadoPorEvaluacion.has(ev.id),
+        ).length;
+        setResumen({
+          promedio: promedioNumerico(resultados),
+          totalEvaluaciones,
+          evaluacionesCalificadas,
+        });
+      } catch (err: any) {
+        if (!alive) return;
+        setErrorDetalle(
+          err?.response?.data?.message ??
+            err?.message ??
+            "No se pudo cargar la información académica.",
+        );
+        setMaterias(null);
+        setInformesInicial(null);
+        setResumen({ promedio: null, totalEvaluaciones: 0, evaluacionesCalificadas: 0 });
+      } finally {
+        if (alive) setLoadingDetalle(false);
+      }
+    }
+
+    cargarDetalle();
+
+    return () => {
+      alive = false;
+    };
+  }, [alumnoSeleccionado]);
+
+  if (initialLoading) {
+    return <LoadingState label="Cargando evaluaciones…" />;
+  }
+
+  if (initialError) {
+    return <div className="text-sm text-red-600">{initialError}</div>;
+  }
+
+  if (!alumnos.length) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        {scope === "student"
+          ? "Todavía no hay evaluaciones registradas para tu matrícula."
+          : "No hay alumnos asociados para consultar evaluaciones."}
+      </div>
+    );
+  }
+
+  const titulo =
+    scope === "student" ? "Mis evaluaciones" : "Evaluaciones de mis hijos";
+
+  const nivel = resolveNivel(alumnoSeleccionado);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h3 className="text-2xl font-semibold tracking-tight">{titulo}</h3>
+        <p className="text-sm text-muted-foreground">
+          Explorá las calificaciones y observaciones registradas por los
+          docentes.
+        </p>
+      </header>
+
+      {alumnos.length > 1 && (
+        <div className="flex flex-wrap gap-2">
+          {alumnos.map((al) => (
+            <Button
+              key={al.matriculaId}
+              size="sm"
+              variant={
+                selectedMatriculaId === al.matriculaId ? "default" : "outline"
+              }
+              onClick={() => setSelectedMatriculaId(al.matriculaId)}
+            >
+              {al.nombreCompleto}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {alumnoSeleccionado && (
+        <Card>
+          <CardHeader className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle className="text-xl">
+                {alumnoSeleccionado.nombreCompleto}
+              </CardTitle>
+              <CardDescription className="space-y-1 text-sm">
+                {alumnoSeleccionado.seccionNombre && (
+                  <div>
+                    Sección: {alumnoSeleccionado.seccionNombre}
+                  </div>
+                )}
+                <div>
+                  Nivel: {nivel === NivelAcademicoEnum.INICIAL ? "Inicial" : "Primario"}
+                </div>
+              </CardDescription>
+            </div>
+            <div className="flex gap-3 text-sm">
+              <Badge variant="secondary" className="flex items-center gap-1">
+                <GraduationCap className="h-3 w-3" />
+                {resumen.totalEvaluaciones} evaluaciones
+              </Badge>
+              <Badge variant="secondary" className="flex items-center gap-1">
+                <CheckCircle2 className="h-3 w-3" />
+                {resumen.evaluacionesCalificadas} calificadas
+              </Badge>
+              <Badge variant="outline" className="flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                Promedio: {resumen.promedio ?? "—"}
+              </Badge>
+            </div>
+          </CardHeader>
+        </Card>
+      )}
+
+      {loadingDetalle && <LoadingState label="Actualizando información…" />}
+
+      {errorDetalle && !loadingDetalle && (
+        <div className="text-sm text-red-600">{errorDetalle}</div>
+      )}
+
+      {!loadingDetalle && !errorDetalle && nivel === NivelAcademicoEnum.PRIMARIO && (
+        <div className="space-y-4">
+          {!materias?.length && (
+            <div className="text-sm text-muted-foreground">
+              No hay evaluaciones registradas para esta sección todavía.
+            </div>
+          )}
+
+          {materias?.map((mat) => (
+            <Card key={mat.key} className="overflow-hidden">
+              <CardHeader>
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <CardTitle className="text-lg">{mat.materiaNombre}</CardTitle>
+                  <Badge variant="outline">
+                    {mat.evaluaciones.filter((e) => e.estado === "Calificada").length}
+                    /{mat.evaluaciones.length} calificadas
+                  </Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {mat.evaluaciones.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No se registraron evaluaciones en esta materia.
+                  </p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className="min-w-[120px]">Fecha</TableHead>
+                          <TableHead className="min-w-[140px]">
+                            Trimestre
+                          </TableHead>
+                          <TableHead className="min-w-[200px]">Tema</TableHead>
+                          <TableHead className="min-w-[120px]">Nota</TableHead>
+                          <TableHead className="min-w-[160px]">
+                            Observaciones
+                          </TableHead>
+                          <TableHead className="min-w-[120px] text-right">
+                            Estado
+                          </TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {mat.evaluaciones.map((ev) => (
+                          <TableRow key={ev.id}>
+                            <TableCell>{formatDate(ev.fecha)}</TableCell>
+                            <TableCell>{ev.trimestreLabel}</TableCell>
+                            <TableCell>{ev.tema}</TableCell>
+                            <TableCell>
+                              {ev.notaNumerica != null
+                                ? ev.notaNumerica
+                                : ev.notaConceptual ?? "—"}
+                            </TableCell>
+                            <TableCell>
+                              {ev.observaciones ? (
+                                <span className="text-xs text-muted-foreground">
+                                  {ev.observaciones}
+                                </span>
+                              ) : (
+                                <span className="text-muted-foreground">—</span>
+                              )}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Badge
+                                variant={
+                                  ev.estado === "Calificada"
+                                    ? "default"
+                                    : "secondary"
+                                }
+                              >
+                                {ev.estado}
+                              </Badge>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {!loadingDetalle && !errorDetalle && nivel === NivelAcademicoEnum.INICIAL && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {!informesInicial?.length && (
+            <div className="text-sm text-muted-foreground">
+              Aún no se cargaron informes para los trimestres del nivel inicial.
+            </div>
+          )}
+
+          {informesInicial?.map((item) => {
+            const cerrado = item.trimestre.cerrado ?? false;
+            const descripcion = item.informe?.descripcion ?? null;
+            return (
+              <Card key={item.trimestre.id ?? Math.random()}>
+                <CardHeader className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-lg">
+                      Trimestre {item.trimestre.orden ?? ""}
+                    </CardTitle>
+                    <Badge variant={cerrado ? "default" : "outline"}>
+                      {cerrado ? "Cerrado" : "En curso"}
+                    </Badge>
+                  </div>
+                  <CardDescription>
+                    {formatTrimestre(item.trimestre)}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {descripcion ? (
+                    <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                      {descripcion}
+                    </p>
+                  ) : (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <FileText className="h-4 w-4" />
+                      Informe pendiente de publicación.
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FamilyEvaluationsView;

--- a/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
@@ -26,6 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ActiveTrimestreBadge } from "@/app/dashboard/_components/ActiveTrimestreBadge";
+import FamilyEvaluationsView from "@/app/dashboard/evaluaciones/_components/FamilyEvaluationsView";
 
 function isPrimario(s: SeccionDTO): boolean {
   const n = (s as any)?.nivel as NivelAcademico | undefined;
@@ -52,6 +53,7 @@ export default function EvaluacionesIndexPage() {
     error: errorScope,
     secciones,
     titularBySeccionId,
+    hijos,
   } = useScopedIndex({ includeTitularSec: true });
 
   const [loading, setLoading] = useState(true);
@@ -163,7 +165,35 @@ export default function EvaluacionesIndexPage() {
     materiaNombreById,
   ]);
 
-  const title = scope === "teacher" ? "Examenes" : "Examenes";
+  if (scope === "family" || scope === "student") {
+    return (
+      <DashboardLayout>
+        <div className="p-4 md:p-8 space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-3xl font-bold tracking-tight">
+                {scope === "student" ? "Mis evaluaciones" : "Evaluaciones"}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Consultá calificaciones y observaciones de las materias
+                cursadas.
+              </p>
+              <ActiveTrimestreBadge className="mt-2" />
+            </div>
+          </div>
+
+          <FamilyEvaluationsView
+            alumnos={hijos}
+            scope={scope}
+            initialLoading={loadingScope}
+            initialError={errorScope ? String(errorScope) : null}
+          />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  const title = scope === "teacher" ? "Exámenes" : "Exámenes";
 
   return (
     <DashboardLayout>

--- a/frontend-ecep/src/hooks/scope/useScopedIndex.ts
+++ b/frontend-ecep/src/hooks/scope/useScopedIndex.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useViewerScope } from "./useViewerScope";
 import { useActivePeriod } from "./useActivePeriod";
 import { useScopedSecciones } from "./useScopedSecciones";
-import { useFamilyAlumnos } from "@/hooks/useFamilyAlumnos";
+import { useViewerAlumnosLite } from "@/hooks/useViewerAlumnosLite";
 
 /**
  * Unifica la “pantalla índice”:
@@ -37,26 +37,24 @@ export function useScopedIndex(opts?: {
 
   // Hijos para family
   const {
-    alumnos,
-    loading: loadingHijos,
-    error: errorHijos,
-  } = useFamilyAlumnos?.() ?? {
-    alumnos: [],
-    loading: false,
-    error: null,
-  };
+    alumnos: viewerAlumnos,
+    loading: loadingViewerAlumnos,
+    error: errorViewerAlumnos,
+  } = useViewerAlumnosLite();
+
+  const isFamilyLike = type === "family" || type === "student";
 
   const loading =
-    loadingPeriodo || (type === "family" ? loadingHijos : loadingSecs);
-  const error = type === "family" ? errorHijos : errorSecs;
+    loadingPeriodo || (isFamilyLike ? loadingViewerAlumnos : loadingSecs);
+  const error = isFamilyLike ? errorViewerAlumnos : errorSecs;
 
   return useMemo(() => {
-    if (type === "family") {
+    if (type === "family" || type === "student") {
       return {
-        scope: "family" as const,
+        scope: (type === "family" ? "family" : "student") as const,
         loading,
         error,
-        hijos: alumnos, // array de AlumnoLiteDTO
+        hijos: viewerAlumnos, // array de AlumnoLiteDTO
         secciones: [] as any[], // vacío en family
         titularBySeccionId: new Map<number, string>(),
         periodoEscolarId,
@@ -68,7 +66,7 @@ export function useScopedIndex(opts?: {
       scope: (type === "staff" ? "staff" : "teacher") as const,
       loading,
       error,
-      hijos: [] as any[], // vacío si no es family
+      hijos: [] as any[], // vacío si no es family/student
       secciones, // array de SeccionDTO
       titularBySeccionId,
       periodoEscolarId,
@@ -78,7 +76,7 @@ export function useScopedIndex(opts?: {
     type,
     loading,
     error,
-    alumnos,
+    viewerAlumnos,
     secciones,
     titularBySeccionId,
     periodoEscolarId,

--- a/frontend-ecep/src/hooks/scope/useViewerScope.ts
+++ b/frontend-ecep/src/hooks/scope/useViewerScope.ts
@@ -13,15 +13,18 @@ export function useViewerScope() {
     const isStaff = roles.some((r) => ROLES_STAFF.has(r));
     const isTeacher = roles.includes("TEACHER");
     const isFamily = roles.includes("FAMILY");
+    const isStudent = roles.includes("STUDENT");
 
     // prioridad: si es staff, lo tratamos como staff (aunque también sea teacher)
-    const type: "staff" | "teacher" | "family" | "guest" = isStaff
+    const type: "staff" | "teacher" | "family" | "student" | "guest" = isStaff
       ? "staff"
       : isTeacher
         ? "teacher"
         : isFamily
           ? "family"
-          : "guest";
+          : isStudent
+            ? "student"
+            : "guest";
 
     return {
       type,

--- a/frontend-ecep/src/hooks/useViewerAlumnosLite.ts
+++ b/frontend-ecep/src/hooks/useViewerAlumnosLite.ts
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { normalizeRole } from "@/lib/auth-roles";
+import { api } from "@/services/api";
+import type {
+  AlumnoDTO,
+  AlumnoLiteDTO,
+  MatriculaDTO,
+  NivelAcademico,
+  SeccionDTO,
+  UserRole,
+} from "@/types/api-generated";
+import { NivelAcademico as NivelAcademicoEnum, UserRole as UserRoleEnum } from "@/types/api-generated";
+
+interface ViewerAlumnosState {
+  alumnos: AlumnoLiteDTO[];
+  loading: boolean;
+  error: string | null;
+}
+
+function inferNivel(
+  seccion: Partial<SeccionDTO> | null | undefined,
+  nombre?: string | null,
+): NivelAcademico | null {
+  if (seccion?.nivel) return seccion.nivel;
+  const base = (nombre ?? "").toLowerCase();
+  if (!base) return null;
+  if (base.includes("sala")) return NivelAcademicoEnum.INICIAL;
+  return NivelAcademicoEnum.PRIMARIO;
+}
+
+async function fetchStudentAlumnosLite(personaId: number) {
+  const [alumnosRes, matriculasRes, seccionesRes] = await Promise.all([
+    api.alumnos
+      .list()
+      .catch(() => ({ data: [] as AlumnoDTO[] })),
+    api.matriculas
+      .list()
+      .catch(() => ({ data: [] as MatriculaDTO[] })),
+    api.secciones
+      .list()
+      .catch(() => ({ data: [] as SeccionDTO[] })),
+  ]);
+
+  const alumnos = alumnosRes.data ?? [];
+  const alumno = alumnos.find((a) => a.personaId === personaId);
+  if (!alumno || !alumno.id) {
+    throw new Error("No se encontró la información del alumno actual.");
+  }
+
+  const matriculas = (matriculasRes.data ?? []).filter(
+    (m) => m.alumnoId === alumno.id,
+  );
+  if (!matriculas.length) {
+    throw new Error("No se encontró una matrícula activa para el alumno.");
+  }
+
+  const matricula = [...matriculas]
+    .sort((a, b) => (b.id ?? 0) - (a.id ?? 0))
+    .find((m) => !!m.id);
+  if (!matricula?.id) {
+    throw new Error("La matrícula del alumno no es válida.");
+  }
+
+  const secciones = seccionesRes.data ?? [];
+  const seccion = secciones.find((s) => s.id === alumno.seccionActualId) ?? null;
+
+  const nombreCompleto = [alumno.apellido, alumno.nombre]
+    .filter(Boolean)
+    .join(", ")
+    .trim();
+
+  const lite: AlumnoLiteDTO = {
+    matriculaId: matricula.id,
+    alumnoId: alumno.id,
+    nombreCompleto: nombreCompleto || `Alumno #${alumno.id}`,
+    seccionId: alumno.seccionActualId ?? seccion?.id ?? null,
+    seccionNombre:
+      alumno.seccionActualNombre ??
+      (seccion
+        ? `${seccion.gradoSala ?? ""} ${seccion.division ?? ""}`.trim() ||
+          seccion.nombre ??
+          null
+        : null),
+    nivel: inferNivel(seccion, alumno.seccionActualNombre),
+  };
+
+  return [lite];
+}
+
+export function useViewerAlumnosLite(): {
+  role: UserRole | null;
+  alumnos: AlumnoLiteDTO[];
+  loading: boolean;
+  error: string | null;
+} {
+  const { user, selectedRole } = useAuth();
+  const personaId = user?.personaId ?? null;
+
+  const normalizedRole = useMemo(() => {
+    if (selectedRole) return selectedRole;
+    const raw = user?.roles?.[0];
+    return raw ? normalizeRole(raw) : null;
+  }, [selectedRole, user]);
+
+  const [state, setState] = useState<ViewerAlumnosState>({
+    alumnos: [],
+    loading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    let alive = true;
+
+    async function resolve() {
+      if (
+        !personaId ||
+        normalizedRole == null ||
+        (normalizedRole !== UserRoleEnum.FAMILY &&
+          normalizedRole !== UserRoleEnum.STUDENT)
+      ) {
+        if (alive) {
+          setState({ alumnos: [], loading: false, error: null });
+        }
+        return;
+      }
+
+      setState({ alumnos: [], loading: true, error: null });
+
+      try {
+        if (normalizedRole === UserRoleEnum.FAMILY) {
+          const res = await api.familiaresAlumnos.byFamiliarId(personaId);
+          if (!alive) return;
+          setState({ alumnos: res.data ?? [], loading: false, error: null });
+          return;
+        }
+
+        const alumnosLite = await fetchStudentAlumnosLite(personaId);
+        if (!alive) return;
+        setState({ alumnos: alumnosLite, loading: false, error: null });
+      } catch (error: any) {
+        if (!alive) return;
+        setState({
+          alumnos: [],
+          loading: false,
+          error:
+            error?.response?.data?.message ??
+            error?.message ??
+            "No se pudo obtener la información académica.",
+        });
+      }
+    }
+
+    resolve();
+
+    return () => {
+      alive = false;
+    };
+  }, [normalizedRole, personaId]);
+
+  return { role: normalizedRole, ...state };
+}


### PR DESCRIPTION
## Summary
- add a `FamilyAttendanceView` to present attendance summaries and history to family and student roles, wiring it into the asistencia index
- extend role detection (`useViewerScope`, `useScopedIndex`) with a new `useViewerAlumnosLite` hook and update the alumnos index to support student-level views
- introduce a `FamilyEvaluationsView` and render it from the evaluaciones index so families and students can review exams or initial reports

## Testing
- `npm run lint` *(fails: next binary missing because dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68cddeaea2bc8327bc2537342d49b1c5