### PR TITLE
Fix familiar creation by mapping persona id

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/mappers/FamiliarMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/mappers/FamiliarMapper.java
@@ -10,6 +10,7 @@ public interface FamiliarMapper {
     @Mapping(target = "personaId", source = "persona.id")
     FamiliarDTO toDto(Familiar e);
 
+    @Mapping(target = "id", source = "personaId")
     @Mapping(target = "persona", source = "personaId")
     Familiar toEntity(FamiliarDTO dto);
 


### PR DESCRIPTION
## Summary
- map personaId onto the Familiar entity id when converting from DTOs to ensure the identifier is set during persistence

## Testing
- mvn -q -DskipTests=false test *(fails: requires downloading Spring Boot parent POM from Maven Central, which is not accessible in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05a0f8140832781e1a8c076dc06eb