### PR TITLE
Ensure familiar creation loads persona before save

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/mappers/FamiliarMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/mappers/FamiliarMapper.java
@@ -10,10 +10,11 @@ public interface FamiliarMapper {
     @Mapping(target = "personaId", source = "persona.id")
     FamiliarDTO toDto(Familiar e);
 
-    @Mapping(target = "persona", source = "personaId")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "persona", ignore = true)
     Familiar toEntity(FamiliarDTO dto);
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "persona", source = "personaId")
+    @Mapping(target = "persona", ignore = true)
     void update(@MappingTarget Familiar e, FamiliarDTO dto);
 }


### PR DESCRIPTION
## Summary
- ensure familiar creation validates persona existence and avoids duplicate familiars before persisting
- adjust the familiar mapper to leave id/persona assignment to the service so inserts use the shared primary key correctly

## Testing
- mvn -q -DskipTests=false test *(fails: requires downloading Spring Boot parent POM from Maven Central, which is not accessible in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05a0f8140832781e1a8c076dc06eb