### PR TITLE
Keep familiar creation transactional

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/mappers/FamiliarMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/mappers/FamiliarMapper.java
@@ -10,10 +10,11 @@ public interface FamiliarMapper {
     @Mapping(target = "personaId", source = "persona.id")
     FamiliarDTO toDto(Familiar e);
 
-    @Mapping(target = "persona", source = "personaId")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "persona", ignore = true)
     Familiar toEntity(FamiliarDTO dto);
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "persona", source = "personaId")
+    @Mapping(target = "persona", ignore = true)
     void update(@MappingTarget Familiar e, FamiliarDTO dto);
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/FamiliarService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/FamiliarService.java
@@ -1,11 +1,13 @@
 package edu.ecep.base_app.service;
 
 import edu.ecep.base_app.domain.Familiar;
+import edu.ecep.base_app.domain.Persona;
 import edu.ecep.base_app.dtos.FamiliarDTO;
 import edu.ecep.base_app.mappers.FamiliarMapper;
 import edu.ecep.base_app.repos.AlumnoFamiliarRepository;
 import edu.ecep.base_app.repos.AspiranteFamiliarRepository;
 import edu.ecep.base_app.repos.FamiliarRepository;
+import edu.ecep.base_app.repos.PersonaRepository;
 import edu.ecep.base_app.util.NotFoundException;
 import java.util.List;
 
@@ -22,17 +24,20 @@ public class FamiliarService {
 
     private final AlumnoFamiliarRepository alumnoFamiliarRepository;
     private final AspiranteFamiliarRepository aspiranteFamiliarRepository;
+    private final PersonaRepository personaRepository;
     private final FamiliarMapper mapper;
 
     public FamiliarService(
             FamiliarRepository familiarRepository,
             AlumnoFamiliarRepository alumnoFamiliarRepository,
             AspiranteFamiliarRepository aspiranteFamiliarRepository,
+            PersonaRepository personaRepository,
             FamiliarMapper mapper
     ) {
         this.familiarRepository = familiarRepository;
         this.alumnoFamiliarRepository = alumnoFamiliarRepository;
         this.aspiranteFamiliarRepository = aspiranteFamiliarRepository;
+        this.personaRepository = personaRepository;
         this.mapper = mapper;
     }
 
@@ -44,12 +49,36 @@ public class FamiliarService {
         return familiarRepository.findById(id).map(mapper::toDto).orElseThrow(NotFoundException::new);
     }
 
+    @Transactional
     public Long create(FamiliarDTO dto) {
-        return familiarRepository.save(mapper.toEntity(dto)).getId();
+        if (dto.getPersonaId() == null) {
+            throw new IllegalArgumentException("Debe enviar personaId");
+        }
+
+        Persona persona = personaRepository.findById(dto.getPersonaId())
+                .orElseThrow(() -> new NotFoundException("Persona no encontrada"));
+
+        if (familiarRepository.existsByPersonaId(persona.getId())) {
+            throw new IllegalArgumentException("La persona ya tiene rol Familiar");
+        }
+
+        Familiar entity = mapper.toEntity(dto);
+        entity.setPersona(persona);
+        entity.setId(persona.getId());
+        return familiarRepository.save(entity).getId();
     }
 
     public void update(Long id, FamiliarDTO dto) {
         Familiar entity = familiarRepository.findById(id).orElseThrow(NotFoundException::new);
+        if (dto.getPersonaId() != null) {
+            Long currentPersonaId = entity.getPersona() != null ? entity.getPersona().getId() : null;
+            if (!dto.getPersonaId().equals(currentPersonaId)) {
+                throw new IllegalArgumentException(
+                        "No se puede cambiar la persona de un Familiar. Elimine y cree uno nuevo con el personaId correcto."
+                );
+            }
+        }
+
         mapper.update(entity, dto);
         familiarRepository.save(entity);
     }


### PR DESCRIPTION
## Summary
- wrap familiar creation in a transaction so the loaded persona stays managed when persisting the familiar
- copy the persona identifier onto the familiar to maintain the shared primary key mapping during insert

## Testing
- mvn -q -DskipTests=false test *(fails: requires downloading the Spring Boot parent POM from Maven Central, which is not accessible in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05a0f8140832781e1a8c076dc06eb