### PR TITLE
Fix familiar creation optimistic locking error

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/FamiliarService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/FamiliarService.java
@@ -63,10 +63,11 @@ public class FamiliarService {
         }
 
         Familiar entity = mapper.toEntity(dto);
-        entity.setPersona(persona);
-        entity.setId(persona.getId());
+        entity.setPersona(persona); // dejar que @MapsId copie el id de Persona
 
-        return familiarRepository.save(entity).getId();
+        Familiar saved = familiarRepository.save(entity);
+        Long familiarId = saved.getId();
+        return familiarId != null ? familiarId : persona.getId();
     }
 
     public void update(Long id, FamiliarDTO dto) {


### PR DESCRIPTION
## Summary
- avoid forcing the familiar id before persisting so Hibernate treats the entity as new
- return the generated identifier while keeping the shared primary key with Persona

## Testing
- `./mvnw test` *(fails: cannot download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d07243c0f48327b90bb10181b1cb2a