### PR TITLE
Fix alumno familiar mapping for convive flag

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/mappers/AlumnoFamiliarMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/mappers/AlumnoFamiliarMapper.java
@@ -13,16 +13,19 @@ public interface AlumnoFamiliarMapper {
 
     @Mapping(target = "alumnoId", source = "alumno.id")
     @Mapping(target = "familiarId", source = "familiar.id")
+    @Mapping(target = "esTutorLegal", source = "convive")
     AlumnoFamiliarDTO toDto(AlumnoFamiliar e);
 
     // CREATE
     @Mapping(target = "alumno", source = "alumnoId")
     @Mapping(target = "familiar", source = "familiarId")
+    @Mapping(target = "convive", source = "esTutorLegal")
     AlumnoFamiliar toEntity(AlumnoFamiliarCreateDTO dto);
 
     // UPDATE
     @Mapping(target = "alumno", source = "alumnoId")
     @Mapping(target = "familiar", source = "familiarId")
+    @Mapping(target = "convive", source = "esTutorLegal")
     @Mapping(target = "id", ignore = true)
     void update(@MappingTarget AlumnoFamiliar e, AlumnoFamiliarDTO dto);
 }


### PR DESCRIPTION
## Summary
- map the esTutorLegal flag in AlumnoFamiliar DTOs to the convive column so the entity respects the NOT NULL constraint when persisting

## Testing
- ./mvnw -q test *(fails: Maven wrapper cannot download Maven distribution in the offline container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0785392ec83279bff0efd8b4088e8