### PR TITLE
feat: respect selected role across viewer scope

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -48,6 +48,7 @@ import type {
   EstadoActaAccidente,
   EmpleadoDTO,
 } from "@/types/api-generated";
+import { UserRole } from "@/types/api-generated";
 
 const todayISO = () => new Date().toISOString().slice(0, 10);
 
@@ -70,13 +71,15 @@ type ActaVM = {
 };
 
 export default function AccidentesIndexPage() {
-  const { roles, type } = useViewerScope();
+  const { activeRole } = useViewerScope();
   const { periodoEscolarId, hoyISO } = useActivePeriod();
 
-  const isDirector = type === "staff" && roles.includes("DIRECTOR");
-  const isAdmin = type === "staff" && roles.includes("ADMIN");
-  const isSecret = type === "staff" && roles.includes("SECRETARY");
-  const isTeacher = roles.includes("TEACHER");
+  const role = activeRole ?? null;
+  const isDirector = role === UserRole.DIRECTOR;
+  const isAdmin = role === UserRole.ADMIN;
+  const isSecret = role === UserRole.SECRETARY;
+  const isTeacher =
+    role === UserRole.TEACHER || role === UserRole.ALTERNATE;
   const noAccess = !isDirector && !isAdmin && !isSecret && !isTeacher;
 
   const canCreate = isDirector || isSecret || isAdmin || isTeacher;

--- a/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
@@ -39,6 +39,7 @@ import NewActaDialog from "../../_components/NewActaDialog";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { toast } from "sonner";
 import EditActaDialog from "../../_components/EditActaDialog";
+import { UserRole } from "@/types/api-generated";
 
 type ActaVM = {
   id: number;
@@ -76,12 +77,14 @@ export default function AccidentesSeccionPage() {
   const seccionId = Number(params.id);
   const router = useRouter();
   const { hoyISO } = useActivePeriod();
-  const { roles, type } = useViewerScope();
+  const { activeRole } = useViewerScope();
+  const role = activeRole ?? null;
 
-  const isDirector = type === "staff" && roles.includes("DIRECTOR");
-  const isSecret = type === "staff" && roles.includes("SECRETARY");
-  const isAdmin = type === "staff" && roles.includes("ADMIN");
-  const isTeacher = roles.includes("TEACHER");
+  const isDirector = role === UserRole.DIRECTOR;
+  const isSecret = role === UserRole.SECRETARY;
+  const isAdmin = role === UserRole.ADMIN;
+  const isTeacher =
+    role === UserRole.TEACHER || role === UserRole.ALTERNATE;
 
   const canCreate = isDirector || isSecret || isAdmin || isTeacher;
   const canManageActas = isDirector || isSecret;

--- a/frontend-ecep/src/app/dashboard/comunicados/_components/NewComunicadoDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/comunicados/_components/NewComunicadoDialog.tsx
@@ -36,6 +36,7 @@ import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { toast } from "sonner";
+import { UserRole } from "@/types/api-generated";
 
 type Props = {
   open?: boolean;
@@ -59,12 +60,15 @@ export default function NewComunicadoDialog({
   onCreated,
   asButton,
 }: Props) {
-  const { roles } = useViewerScope();
-  const isDirector = roles.includes("DIRECTOR");
-  const isAdmin = roles.includes("ADMIN");
-  const isSecret = roles.includes("SECRETARY");
-  const isTeacher = roles.includes("TEACHER");
-  const isAdminLike = isDirector || isAdmin || isSecret;
+  const { activeRole } = useViewerScope();
+  const role = activeRole ?? null;
+  const isDirector = role === UserRole.DIRECTOR;
+  const isAdmin = role === UserRole.ADMIN;
+  const isSecret = role === UserRole.SECRETARY;
+  const isCoordinator = role === UserRole.COORDINATOR;
+  const isTeacher =
+    role === UserRole.TEACHER || role === UserRole.ALTERNATE;
+  const isAdminLike = isDirector || isAdmin || isSecret || isCoordinator;
 
   const { periodoEscolarId } = useActivePeriod();
   const { secciones } = useScopedSecciones({

--- a/frontend-ecep/src/app/dashboard/comunicados/page.tsx
+++ b/frontend-ecep/src/app/dashboard/comunicados/page.tsx
@@ -39,6 +39,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { UserRole } from "@/types/api-generated";
 
 const alcanceFilterOptions = [
   { value: "ALL", label: "Todos los alcances" },
@@ -114,13 +115,16 @@ function preview(text: string, max = 220) {
 }
 
 export default function ComunicadosPage() {
-  const { type, roles } = useViewerScope();
+  const { type, activeRole } = useViewerScope();
+  const role = activeRole ?? null;
 
-  const isDirector = roles.includes("DIRECTOR");
-  const isAdmin = roles.includes("ADMIN");
-  const isSecret = roles.includes("SECRETARY");
-  const isTeacher = roles.includes("TEACHER");
-  const isAdminLike = isDirector || isAdmin || isSecret;
+  const isDirector = role === UserRole.DIRECTOR;
+  const isAdmin = role === UserRole.ADMIN;
+  const isSecret = role === UserRole.SECRETARY;
+  const isCoordinator = role === UserRole.COORDINATOR;
+  const isTeacher =
+    role === UserRole.TEACHER || role === UserRole.ALTERNATE;
+  const isAdminLike = isDirector || isAdmin || isSecret || isCoordinator;
   const canCreate = isAdminLike || isTeacher;
 
   const { periodoEscolarId } = useActivePeriod();

--- a/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
@@ -33,6 +33,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { School, Clock3 } from "lucide-react";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { toast } from "sonner";
+import { UserRole } from "@/types/api-generated";
 
 const fechaLargaFormatter = new Intl.DateTimeFormat("es-AR", {
   dateStyle: "long",
@@ -66,10 +67,16 @@ export default function ExamenDetailPage() {
   const params = useParams<{ id: string }>();
   const examenId = Number(params?.id);
   const router = useRouter();
-  const { roles } = useViewerScope();
+  const { activeRole } = useViewerScope();
+  const role = activeRole ?? null;
 
-  const isStaff = roles.includes("ADMIN") || roles.includes("DIRECTOR") || roles.includes("SECRETARY");
-  const isTeacher = roles.includes("TEACHER");
+  const isStaff =
+    role === UserRole.ADMIN ||
+    role === UserRole.DIRECTOR ||
+    role === UserRole.SECRETARY ||
+    role === UserRole.COORDINATOR;
+  const isTeacher =
+    role === UserRole.TEACHER || role === UserRole.ALTERNATE;
   const canEdit = isStaff || isTeacher;
 
   const [loading, setLoading] = useState(true);

--- a/frontend-ecep/src/app/dashboard/materias/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/page.tsx
@@ -17,6 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { api } from "@/services/api";
+import { UserRole } from "@/types/api-generated";
 import type { SeccionDTO, NivelAcademico } from "@/types/api-generated";
 
 type Seccion = SeccionDTO;
@@ -43,12 +44,13 @@ function isPrimario(s: Seccion) {
 
 export default function MateriasPage() {
   const router = useRouter();
-  const { roles } = useViewerScope();
+  const { activeRole } = useViewerScope();
   const { periodoEscolarId } = useActivePeriod();
 
-  const isDirector = roles.includes("DIRECTOR");
-  const isSecret = roles.includes("SECRETARY");
-  const isAdmin = roles.includes("ADMIN");
+  const role = activeRole ?? null;
+  const isDirector = role === UserRole.DIRECTOR;
+  const isSecret = role === UserRole.SECRETARY;
+  const isAdmin = role === UserRole.ADMIN;
   if (!isDirector && !isSecret && !isAdmin) {
     return (
       <DashboardLayout>


### PR DESCRIPTION
## Summary
- derive an active role in `useViewerScope` that honours the role selected by the user and expose it to consumers
- update the dashboards for actas, comunicados, materias and evaluaciones so that permissions and behaviour depend on the active role rather than all assigned roles
- align the comunicado creation dialog with the new role handling and allow coordinators to access admin flows

## Testing
- npm install *(fails: registry returns 403 Forbidden)*
- bun install *(fails: registry returns 403 Forbidden)*
- npm run lint *(fails: `next` binary missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d07bef1e588327bb873d1386a9e8e3