### PR TITLE
Fix lazy-loaded persona errors and stabilize chat handshake

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/repos/AlumnoFamiliarRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/repos/AlumnoFamiliarRepository.java
@@ -16,8 +16,11 @@ public interface AlumnoFamiliarRepository extends JpaRepository<AlumnoFamiliar, 
     boolean existsByAlumnoId(Long id);
 
     @Query("""
-         select af.alumno
+         select distinct alumno
          from AlumnoFamiliar af
+         join af.alumno alumno
+         join fetch alumno.persona
          where af.familiar.id = :familiarId
          """)
-    List<Alumno> findAlumnosByFamiliar(@Param("familiarId") Long familiarId);}
+    List<Alumno> findAlumnosByFamiliar(@Param("familiarId") Long familiarId);
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/repos/AsignacionDocenteMateriaRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/repos/AsignacionDocenteMateriaRepository.java
@@ -1,6 +1,7 @@
 package edu.ecep.base_app.repos;
 
 import edu.ecep.base_app.domain.AsignacionDocenteMateria;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface AsignacionDocenteMateriaRepository extends JpaRepository<AsignacionDocenteMateria, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {"seccionMateria", "empleado"})
+    List<AsignacionDocenteMateria> findAll();
+
     boolean existsByEmpleadoId(Long empleadoId); // +++
     @Query("""
       select (count(a) > 0) from AsignacionDocenteMateria a

--- a/backend-ecep/src/main/java/edu/ecep/base_app/repos/AsignacionDocenteSeccionRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/repos/AsignacionDocenteSeccionRepository.java
@@ -2,6 +2,7 @@ package edu.ecep.base_app.repos;
 
 import edu.ecep.base_app.domain.AsignacionDocenteSeccion;
 import edu.ecep.base_app.domain.Seccion;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +12,11 @@ import java.util.List;
 
 
 public interface AsignacionDocenteSeccionRepository extends JpaRepository<AsignacionDocenteSeccion, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {"seccion", "empleado"})
+    List<AsignacionDocenteSeccion> findAll();
+
     boolean existsByEmpleadoId(Long empleadoId);
 
     List<AsignacionDocenteSeccion> findByEmpleado_Id(Long empleadoId);
@@ -25,6 +31,7 @@ public interface AsignacionDocenteSeccionRepository extends JpaRepository<Asigna
                               @Param("desde") LocalDate desde,
                               @Param("hasta") LocalDate hasta,
                               @Param("excludeId") Long excludeId);
+    @EntityGraph(attributePaths = {"seccion", "empleado"})
     @Query("""
         select a
         from AsignacionDocenteSeccion a

--- a/backend-ecep/src/main/java/edu/ecep/base_app/repos/FamiliarRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/repos/FamiliarRepository.java
@@ -1,6 +1,8 @@
 package edu.ecep.base_app.repos;
 
 import edu.ecep.base_app.domain.Familiar;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,6 +10,15 @@ import java.util.Optional;
 
 
 public interface FamiliarRepository extends JpaRepository<Familiar, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = "persona")
+    List<Familiar> findAll(Sort sort);
+
+    @Override
+    @EntityGraph(attributePaths = "persona")
+    Optional<Familiar> findById(Long id);
+
     List<Familiar> findByPersona_NombreContainingIgnoreCaseOrPersona_ApellidoContainingIgnoreCase(String q1, String q2);
     boolean existsByPersonaId(Long id);
     Optional<Familiar> findByPersonaId(Long personaId);

--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/AsignacionDocenteSeccionController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/AsignacionDocenteSeccionController.java
@@ -1,8 +1,7 @@
 package edu.ecep.base_app.rest;
 
-import edu.ecep.base_app.domain.AsignacionDocenteSeccion;
-import edu.ecep.base_app.dtos.*;
-import edu.ecep.base_app.repos.AsignacionDocenteSeccionRepository;
+import edu.ecep.base_app.dtos.AsignacionDocenteSeccionCreateDTO;
+import edu.ecep.base_app.dtos.AsignacionDocenteSeccionDTO;
 import edu.ecep.base_app.service.AsignacionDocenteSeccionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/asignaciones/seccion")
@@ -21,16 +20,22 @@ import java.util.*;
 @Validated
 public class AsignacionDocenteSeccionController {
     private final AsignacionDocenteSeccionService service;
-    private final AsignacionDocenteSeccionRepository repo;
 
-    @GetMapping public List<AsignacionDocenteSeccionDTO> list(){ return service.findAll(); }
-    @PostMapping public ResponseEntity<Long> create(@RequestBody @Valid AsignacionDocenteSeccionCreateDTO dto){ return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED); }
+    @GetMapping
+    public List<AsignacionDocenteSeccionDTO> list() {
+        return service.findAll();
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> create(@RequestBody @Valid AsignacionDocenteSeccionCreateDTO dto) {
+        return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED);
+    }
+
     @GetMapping("/by-docente")
-    public List<AsignacionDocenteSeccion> byDocente(@RequestParam Long empleadoId,
-                                                    @RequestParam(required=false)
-                                                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha) {
-        LocalDate f = fecha != null ? fecha : LocalDate.now();
-        return repo.findVigentesByEmpleado(empleadoId, f);
+    public List<AsignacionDocenteSeccionDTO> byDocente(@RequestParam Long empleadoId,
+                                                       @RequestParam(required = false)
+                                                       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha) {
+        return service.findVigentesByEmpleado(empleadoId, fecha);
     }
 
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/JwtService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/JwtService.java
@@ -78,4 +78,18 @@ public class JwtService {
             return Optional.empty();
         }
     }
+
+    public Optional<Long> safeExtractPersonaId(String token) {
+        try {
+            Object personaId = extractAllClaims(token).get("personaId");
+            if (personaId instanceof Number number) {
+                return Optional.of(number.longValue());
+            }
+            if (personaId instanceof String str && !str.isBlank()) {
+                return Optional.of(Long.valueOf(str));
+            }
+        } catch (Exception ignored) {
+        }
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure familiar-to-alumno lookups eagerly load personas to avoid LAZY_INITIALIZATION errors
- return docente assignments as DTOs with transactional service methods and entity graphs so docentes and familias can see their data
- fall back to the personaId claim during WebSocket handshakes for more robust chat reconnections

## Testing
- `mvn test` *(fails: cannot download Maven dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d14f3ab0888327b3a57f83378af0ab