### PR TITLE
Adjust family-facing dashboard cards

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/_components/FamilyView.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/FamilyView.tsx
@@ -2,9 +2,8 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import type { AlumnoLiteDTO } from "@/types/api-generated";
-import { useRouter } from "next/navigation";
+import { NivelAcademico } from "@/types/api-generated";
 
 export default function FamilyView({
   hijos,
@@ -13,7 +12,17 @@ export default function FamilyView({
   hijos: AlumnoLiteDTO[];
   title?: string;
 }) {
-  const router = useRouter();
+  const nivelLabel = (nivel?: NivelAcademico | null) => {
+    if (!nivel) return null;
+    switch (nivel) {
+      case NivelAcademico.PRIMARIO:
+        return "Nivel primario";
+      case NivelAcademico.INICIAL:
+        return "Nivel inicial";
+      default:
+        return String(nivel);
+    }
+  };
 
   if (!hijos?.length) {
     return (
@@ -27,34 +36,44 @@ export default function FamilyView({
     <div className="space-y-4">
       <h3 className="text-lg font-semibold">{title}</h3>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {hijos.map((hijo) => (
-          <Card
-            key={`${hijo.matriculaId}-${hijo.alumnoId}`}
-            className="hover:shadow-md transition-shadow"
-          >
-            <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
+        {hijos.map((hijo) => {
+          const nivelTexto = nivelLabel(hijo.nivel);
+          return (
+            <Card
+              key={`${hijo.matriculaId}-${hijo.alumnoId}`}
+              className="hover:shadow-md transition-shadow"
+            >
+              <CardHeader className="pb-3 space-y-2">
                 <CardTitle className="text-lg">{hijo.nombreCompleto}</CardTitle>
-                <Badge variant="outline">#{hijo.matriculaId}</Badge>
-              </div>
-              {/* Evitamos <div> dentro de <p> (no usamos CardDescription) */}
-              <div className="text-sm text-muted-foreground">
-                Alumno ID: {hijo.alumnoId}
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Button
-                variant="outline"
-                className="w-full"
-                onClick={() =>
-                  router.push(`/dashboard/alumno/${hijo.alumnoId}`)
-                }
-              >
-                Ver perfil
-              </Button>
-            </CardContent>
-          </Card>
-        ))}
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  {hijo.seccionNombre && (
+                    <Badge variant="outline">{hijo.seccionNombre}</Badge>
+                  )}
+                  {nivelTexto && (
+                    <Badge variant="secondary">{nivelTexto}</Badge>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-1 text-sm text-muted-foreground">
+                {hijo.seccionNombre && (
+                  <div>
+                    <span className="font-medium text-foreground">Sección:</span>{" "}
+                    {hijo.seccionNombre}
+                  </div>
+                )}
+                {nivelTexto && (
+                  <div>
+                    <span className="font-medium text-foreground">Nivel:</span>{" "}
+                    {nivelTexto}
+                  </div>
+                )}
+                <div>
+                  Consultá su información académica desde el menú lateral.
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
@@ -299,12 +299,12 @@ export function FamilyAttendanceView() {
           <Card>
             <CardHeader>
               <CardTitle>{alumnoSeleccionado.nombreCompleto}</CardTitle>
-              <CardDescription className="space-y-1">
+              <div className="space-y-1 text-sm text-muted-foreground">
                 {alumnoSeleccionado.seccionNombre && (
                   <div>Sección: {alumnoSeleccionado.seccionNombre}</div>
                 )}
                 <div>{nivelLabel(alumnoSeleccionado.nivel)}</div>
-              </CardDescription>
+              </div>
             </CardHeader>
             <CardContent>
               {loadingDetalles ? (

--- a/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
@@ -301,7 +301,7 @@ export default function FamilyCalificacionesView({
                     <CardTitle>
                       {alumno.seccionNombre ?? seccion?.nombre ?? "Sección"}
                     </CardTitle>
-                    <CardDescription className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                       <Badge variant="outline">{nivelLabel(nivel)}</Badge>
                       {turno && <Badge variant="outline">Turno {turno}</Badge>}
                       {seccion?.periodoEscolarId && (
@@ -309,7 +309,7 @@ export default function FamilyCalificacionesView({
                           Período {seccion.periodoEscolarId}
                         </Badge>
                       )}
-                    </CardDescription>
+                    </div>
                   </CardHeader>
                 </Card>
 

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
@@ -430,7 +430,7 @@ export function FamilyEvaluationsView({
               <CardTitle className="text-xl">
                 {alumnoSeleccionado.nombreCompleto}
               </CardTitle>
-              <CardDescription className="space-y-1 text-sm">
+              <div className="space-y-1 text-sm text-muted-foreground">
                 {alumnoSeleccionado.seccionNombre && (
                   <div>
                     Sección: {alumnoSeleccionado.seccionNombre}
@@ -439,7 +439,7 @@ export function FamilyEvaluationsView({
                 <div>
                   Nivel: {nivel === NivelAcademicoEnum.INICIAL ? "Inicial" : "Primario"}
                 </div>
-              </CardDescription>
+              </div>
             </div>
             <div className="flex gap-3 text-sm">
               <Badge variant="secondary" className="flex items-center gap-1">

--- a/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
@@ -343,7 +343,7 @@ export default function FamilyMateriasView({
                       detalle?.seccion?.nombre ??
                       "Sección sin nombre"
                     }</CardTitle>
-                    <CardDescription className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                       <Badge variant="outline">{nivelLabel(nivel)}</Badge>
                       {turno && <Badge variant="outline">Turno {turno}</Badge>}
                       {detalle?.seccion?.periodoEscolarId && (
@@ -351,7 +351,7 @@ export default function FamilyMateriasView({
                           Período {detalle.seccion.periodoEscolarId}
                         </Badge>
                       )}
-                    </CardDescription>
+                    </div>
                   </CardHeader>
                   <CardContent className="space-y-2 text-sm">
                     {detalle?.docentesSeccion?.length ? (


### PR DESCRIPTION
## Summary
- update the family alumnos cards to remove administrative navigation and show friendly details only
- replace CardDescription wrappers that enclosed badges in family-facing pages to avoid invalid DOM nesting
- align attendance and evaluations views with neutral containers so the UI renders without console errors

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d155cb26508327ba0f37381c723412