### PR TITLE
Fix resultados API alias and harden chat socket reconnect

### DIFF
--- a/frontend-ecep/src/services/api/index.ts
+++ b/frontend-ecep/src/services/api/index.ts
@@ -50,6 +50,7 @@ export const api = {
 
   // académico
   evaluaciones: academico.evaluaciones,
+  resultados: academico.resultados,
   resultadosEvaluacion: academico.resultados,
   calificaciones: academico.calificaciones,
   informes: academico.informes,


### PR DESCRIPTION
## Summary
- expose the academic resultados service on the api helper to unblock the family evaluations screen
- make the chat socket hook resolve its base URL on the client, guard SockJS creation, and reset state when the user/role changes to prevent crashes when switching roles

## Testing
- npm install *(fails: registry access returns 403)*
- bun install *(fails: registry access returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d15af31a688327bd302f4506cedc77