### PR TITLE
Prevent forcing HTTPS for localhost websockets

### DIFF
--- a/frontend-ecep/src/hooks/useChatSocket.ts
+++ b/frontend-ecep/src/hooks/useChatSocket.ts
@@ -36,10 +36,34 @@ const ensureWsEndpoint = (value: string): string => {
   }
 };
 
+const isLoopbackHostname = (hostname: string): boolean => {
+  const normalized = hostname.replace(/\.$/, "").toLowerCase();
+
+  if (normalized === "localhost" || normalized === "::1") return true;
+
+  if (/^127(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}$/.test(normalized)) return true;
+
+  return false;
+};
+
 const alignProtocolWithPage = (value: string): string => {
   if (!value || typeof window === "undefined") return value;
 
   if (window.location.protocol !== "https:") return value;
+
+  try {
+    const url = new URL(value, window.location.origin);
+    const protocol = url.protocol.toLowerCase();
+
+    if (
+      (protocol === "http:" || protocol === "ws:") &&
+      isLoopbackHostname(url.hostname)
+    ) {
+      return value;
+    }
+  } catch (_error) {
+    // Ignoramos errores al parsear la URL; en esos casos aplicamos la lógica de fallback.
+  }
 
   if (/^http:\/\//i.test(value)) {
     return value.replace(/^http:/i, "https:");


### PR DESCRIPTION
## Summary
- prevent the websocket helper from upgrading loopback hosts to HTTPS/WSS when the page runs on HTTPS
- keep the automatic protocol upgrade for other hosts to avoid mixed-content issues

## Testing
- npm install *(fails: npm registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d168ae5a488327b72201f06753b154