### PR TITLE
Handle bracketed personaIds query param for chat online status

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/rest/ChatController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/rest/ChatController.java
@@ -89,9 +89,22 @@ public class ChatController {
     }
 
     @GetMapping("/online-status")
-    public ResponseEntity<Map<Long, Boolean>> getOnlineStatus(@RequestParam List<Long> personaIds) {
+    public ResponseEntity<Map<Long, Boolean>> getOnlineStatus(
+            @RequestParam(value = "personaIds", required = false) List<Long> personaIds,
+            @RequestParam(value = "personaIds[]", required = false) List<Long> personaIdsWithBrackets
+    ) {
         try {
-            Map<Long, Boolean> onlineStatus = chatService.getOnlineStatus(personaIds);
+            List<Long> resolvedPersonaIds = personaIds;
+
+            if ((resolvedPersonaIds == null || resolvedPersonaIds.isEmpty()) && personaIdsWithBrackets != null) {
+                resolvedPersonaIds = personaIdsWithBrackets;
+            }
+
+            if (resolvedPersonaIds == null || resolvedPersonaIds.isEmpty()) {
+                return ResponseEntity.badRequest().build();
+            }
+
+            Map<Long, Boolean> onlineStatus = chatService.getOnlineStatus(resolvedPersonaIds);
             return ResponseEntity.ok(onlineStatus);
         } catch (Exception ex) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();


### PR DESCRIPTION
## Summary
- allow the chat online status endpoint to accept both personaIds and personaIds[] query parameters
- validate that at least one persona id is provided before calling the service

## Testing
- `./mvnw test` *(fails: unable to download Maven due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1780f373c83279054f619bd46abd4