### PR TITLE
Fix chat online status request serialization

### DIFF
--- a/frontend-ecep/src/services/api/modules/chat.ts
+++ b/frontend-ecep/src/services/api/modules/chat.ts
@@ -12,8 +12,18 @@ export const chat = {
     http.get<DTO.PersonaResumenDTO[]>("/api/chat/active-chats"),
   getUnreadCounts: () =>
     http.get<Record<number, number>>("/api/chat/unread-count"),
-  getOnlineStatus: (personaIds: number[]) =>
-    http.get<Record<number, boolean>>("/api/chat/online-status", {
-      params: { personaIds },
-    }),
+  getOnlineStatus: (personaIds: number[]) => {
+    const params = new URLSearchParams();
+
+    for (const rawId of personaIds || []) {
+      const id = Number(rawId);
+      if (!Number.isFinite(id) || id <= 0) continue;
+
+      params.append("personaIds", String(id));
+    }
+
+    return http.get<Record<number, boolean>>("/api/chat/online-status", {
+      params,
+    });
+  },
 };


### PR DESCRIPTION
## Summary
- ensure the chat online status request sends persona ids as repeated query parameters using URLSearchParams to match the backend expectations

## Testing
- bun install *(fails: registry.npmjs.org responded 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d17a23b6d48327a27339d9fce42f5c