### PR TITLE
Allow editing staff records and tighten onboarding form

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/service/AlumnoService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/service/AlumnoService.java
@@ -87,7 +87,9 @@ public class AlumnoService {
                     .orElseThrow(() -> new NotFoundException("Persona no encontrada"));
 
             // Si esa persona ya es alumno y no es el mismo registro, rechazar
-            if (alumnoRepository.existsByPersonaId(persona.getId())) {
+            var alumnoConPersona = alumnoRepository.findByPersonaId(persona.getId());
+            if (alumnoConPersona.isPresent() &&
+                    !alumnoConPersona.get().getId().equals(existing.getId())) {
                 throw new IllegalArgumentException("La persona ya tiene rol Alumno");
             }
             existing.setPersona(persona);


### PR DESCRIPTION
## Summary
- add an edit dialog so dirección/admin can update persona and empleado fields for existing staff records
- make the staff registration form require personal/contact details, swap key fields to dropdowns, and capture CUIL with prefijo-DNI-sufijo while defaulting the situación to Activo
- push CUIL updates to personas and tighten validation when creating or editing legajos

## Testing
- `npm install` *(fails: registry returns 403 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d18862aa00832785cf05195614875d