### PR TITLE
Fix accident report section labels

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
@@ -187,7 +187,11 @@ export default function NewActaDialog({
               ",",
             );
           const seccion =
-            a.seccion ?? a.seccionActual?.nombre ?? a.gradoSala ?? null;
+            a.seccionNombre ??
+            a.seccion ??
+            a.seccionActual?.nombre ??
+            a.gradoSala ??
+            null;
           return {
             id,
             display: `${full} — ${seccion ?? "Sin sección"}`,

--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -239,15 +239,23 @@ export default function AccidentesIndexPage() {
               .catch(() => []),
           ),
         );
-        const nombreSeccion = (s: SeccionDTO) =>
-          `${s.gradoSala ?? ""} ${s.division ?? ""} • ${s.turno ?? ""}`.trim() ||
-          `Sección #${s.id}`;
+        const nombreSeccion = (s: SeccionDTO) => {
+          const base = `${s.gradoSala ?? ""} ${s.division ?? ""}`.trim();
+          const turno = String(s.turno ?? "").trim();
+          if (base && turno) return `${base} (${turno})`;
+          if (base) return base;
+          return `Sección #${s.id}`;
+        };
         // asignar
         secciones.forEach((s, idx) => {
-          const etiqueta = nombreSeccion(s);
-          for (const au of chunks[idx] as any[]) {
+          const roster = Array.isArray(chunks[idx]) ? chunks[idx] : [];
+          for (const au of roster as any[]) {
             const id = au.alumnoId ?? au.id;
-            if (id != null && !map.has(id)) map.set(id, etiqueta);
+            if (id == null || map.has(id)) continue;
+            const etiqueta =
+              (au.seccionNombre as string | undefined | null)?.trim() ||
+              nombreSeccion(s);
+            map.set(id, etiqueta);
           }
         });
         if (alive) setAlumnoSeccion(map);


### PR DESCRIPTION
## Summary
- prefer the roster-provided section name when showing accident report entries so each student displays the correct section label
- include the section name returned by the API in the new acta dialog autocomplete to stay consistent with backend formatting

## Testing
- `npm run lint` *(fails: missing local Next.js binary because dependencies cannot be installed in this environment)*
- `npm install` *(fails: 403 Forbidden when downloading packages from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a25f2e0c8327a9ea77d9d63876f6