### PR TITLE
Fix hook order for teacher section pages

### DIFF
--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
@@ -67,6 +67,11 @@ export default function CalificacionesSeccionPage() {
     };
   }, [accessStatus, seccionId]);
 
+  const nivel = useMemo(
+    () => (seccion?.nivel ?? "").toUpperCase() as "PRIMARIO" | "INICIAL" | "",
+    [seccion],
+  );
+
   if (accessStatus === "admin") {
     return (
       <DashboardLayout>
@@ -104,11 +109,6 @@ export default function CalificacionesSeccionPage() {
       </DashboardLayout>
     );
   }
-
-  const nivel = useMemo(
-    () => (seccion?.nivel ?? "").toUpperCase() as "PRIMARIO" | "INICIAL" | "",
-    [seccion],
-  );
 
   const heading =
     nivel === "PRIMARIO" ? "Calificación Trimestral" : "Informes de Inicial";

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -177,6 +177,37 @@ export default function SeccionEvaluacionesPage() {
     };
   }, [accessStatus, seccionId, filterMateriaId, refreshKey]);
 
+  const materiaNombreById = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const it of materias) m.set(it.id, it.nombre);
+    return m;
+  }, [materias]);
+
+  const materiasDeSeccion = useMemo(() => {
+    const ids = new Set(
+      (secMats ?? []).map((sm) => (sm as any).materiaId as number),
+    );
+    return materias.filter((m) => ids.has(m.id));
+  }, [secMats, materias]);
+
+  const seccionNombre = useMemo(() => {
+    if (!seccion) return `Sección #${seccionId}`;
+    const nombre = `${seccion.gradoSala ?? ""} ${seccion.division ?? ""}`.trim();
+    return nombre || `Sección #${seccion.id}`;
+  }, [seccion, seccionId]);
+
+  const turnoNombre = useMemo(() => seccion?.turno ?? "—", [seccion]);
+
+  const filteredEvals = useMemo(() => {
+    if (filterMateriaId === "all") return evaluaciones;
+    const wanted = Number(filterMateriaId);
+    if (Number.isNaN(wanted)) return evaluaciones;
+    return evaluaciones.filter((e: any) => {
+      const sm = (secMats ?? []).find((x) => x.id === e.seccionMateriaId) as any;
+      return sm?.materiaId === wanted;
+    });
+  }, [evaluaciones, filterMateriaId, secMats]);
+
   if (accessStatus === "admin") {
     return (
       <DashboardLayout>
@@ -214,37 +245,6 @@ export default function SeccionEvaluacionesPage() {
       </DashboardLayout>
     );
   }
-
-  const materiaNombreById = useMemo(() => {
-    const m = new Map<number, string>();
-    for (const it of materias) m.set(it.id, it.nombre);
-    return m;
-  }, [materias]);
-
-  const materiasDeSeccion = useMemo(() => {
-    const ids = new Set(
-      (secMats ?? []).map((sm) => (sm as any).materiaId as number),
-    );
-    return materias.filter((m) => ids.has(m.id));
-  }, [secMats, materias]);
-
-  const seccionNombre = useMemo(() => {
-    if (!seccion) return `Sección #${seccionId}`;
-    const nombre = `${seccion.gradoSala ?? ""} ${seccion.division ?? ""}`.trim();
-    return nombre || `Sección #${seccion.id}`;
-  }, [seccion, seccionId]);
-
-  const turnoNombre = useMemo(() => seccion?.turno ?? "—", [seccion]);
-
-  const filteredEvals = useMemo(() => {
-    if (filterMateriaId === "all") return evaluaciones;
-    const wanted = Number(filterMateriaId);
-    if (Number.isNaN(wanted)) return evaluaciones;
-    return evaluaciones.filter((e: any) => {
-      const sm = (secMats ?? []).find((x) => x.id === e.seccionMateriaId) as any;
-      return sm?.materiaId === wanted;
-    });
-  }, [evaluaciones, filterMateriaId, secMats]);
 
   const createExamen = async () => {
     try {


### PR DESCRIPTION
## Summary
- ensure the evaluations section memoized helpers are created before any conditional returns so hook order stays consistent for docentes
- move the calificaciones level memo ahead of early returns to avoid hook-order crashes when docentes access the page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1a808cb088327b51718095e8e00f3