### PR TITLE
Restrict academic data to active school period

### DIFF
--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -70,6 +70,7 @@ export default function CalificacionesIndexPage() {
             alumnos={hijos}
             initialLoading={loading}
             initialError={error ? String(error) : null}
+            periodoEscolarId={periodoEscolarId}
           />
         </div>
       </DashboardLayout>

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
@@ -146,9 +146,15 @@ export default function CalificacionesSeccionPage() {
         {!loading && !error && (
           <>
             {nivel === "PRIMARIO" ? (
-              <CierrePrimarioView seccionId={seccionId} />
+              <CierrePrimarioView
+                seccionId={seccionId}
+                periodoEscolarId={seccion?.periodoEscolarId ?? null}
+              />
             ) : (
-              <InformeInicialView seccionId={seccionId} />
+              <InformeInicialView
+                seccionId={seccionId}
+                periodoEscolarId={seccion?.periodoEscolarId ?? null}
+              />
             )}
           </>
         )}


### PR DESCRIPTION
## Summary
- close historical matricula-seccion records for prior periods during seed data generation
- avoid returning family enrollments without an active section assignment
- filter calificaciones and trimestres in the dashboard UI so only the current period is shown for families and staff

## Testing
- `./backend-ecep/mvnw -pl backend-ecep test` *(fails: Maven download blocked in environment)*
- `npm run lint` *(fails: Next.js dependencies unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d6c11d6c8327b10241a5f9a7a6a1