### PR TITLE
Move informe inicial to gestion academica module

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/InformeInicialService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/InformeInicialService.java
@@ -1,12 +1,11 @@
-package edu.ecep.base_app.vidaescolar.application;
+package edu.ecep.base_app.gestionacademica.application;
 
-import edu.ecep.base_app.vidaescolar.domain.InformeInicial;
-import edu.ecep.base_app.gestionacademica.domain.Trimestre;
-import edu.ecep.base_app.vidaescolar.presentation.dto.InformeInicialCreateDTO;
-import edu.ecep.base_app.vidaescolar.presentation.dto.InformeInicialDTO;
+import edu.ecep.base_app.gestionacademica.domain.InformeInicial;
+import edu.ecep.base_app.gestionacademica.presentation.dto.InformeInicialCreateDTO;
+import edu.ecep.base_app.gestionacademica.presentation.dto.InformeInicialDTO;
+import edu.ecep.base_app.gestionacademica.infrastructure.mapper.InformeInicialMapper;
+import edu.ecep.base_app.gestionacademica.infrastructure.persistence.InformeInicialRepository;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.TrimestreRepository;
-import edu.ecep.base_app.vidaescolar.infrastructure.mapper.InformeInicialMapper;
-import edu.ecep.base_app.vidaescolar.infrastructure.persistence.InformeInicialRepository;
 import edu.ecep.base_app.shared.exception.NotFoundException;
 import java.util.List;
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/InformeInicial.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/InformeInicial.java
@@ -1,5 +1,7 @@
-package edu.ecep.base_app.vidaescolar.domain;
+package edu.ecep.base_app.gestionacademica.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/mapper/InformeInicialMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/mapper/InformeInicialMapper.java
@@ -1,8 +1,8 @@
-package edu.ecep.base_app.vidaescolar.infrastructure.mapper;
+package edu.ecep.base_app.gestionacademica.infrastructure.mapper;
 
-import edu.ecep.base_app.vidaescolar.domain.InformeInicial;
-import edu.ecep.base_app.vidaescolar.presentation.dto.InformeInicialCreateDTO;
-import edu.ecep.base_app.vidaescolar.presentation.dto.InformeInicialDTO;
+import edu.ecep.base_app.gestionacademica.domain.InformeInicial;
+import edu.ecep.base_app.gestionacademica.presentation.dto.InformeInicialCreateDTO;
+import edu.ecep.base_app.gestionacademica.presentation.dto.InformeInicialDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/InformeInicialRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/InformeInicialRepository.java
@@ -1,7 +1,6 @@
-package edu.ecep.base_app.vidaescolar.infrastructure.persistence;
+package edu.ecep.base_app.gestionacademica.infrastructure.persistence;
 
-import edu.ecep.base_app.identidad.domain.Alumno;
-import edu.ecep.base_app.vidaescolar.domain.InformeInicial;
+import edu.ecep.base_app.gestionacademica.domain.InformeInicial;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/dto/InformeInicialCreateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/dto/InformeInicialCreateDTO.java
@@ -1,4 +1,4 @@
-package edu.ecep.base_app.vidaescolar.presentation.dto;
+package edu.ecep.base_app.gestionacademica.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,13 +9,11 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class InformeInicialDTO {
-    Long id;
+public class InformeInicialCreateDTO {
     @NotNull
     Long trimestreId;
     @NotNull
     Long matriculaId;
     @NotBlank
     String descripcion;
-    boolean publicado;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/dto/InformeInicialDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/dto/InformeInicialDTO.java
@@ -1,4 +1,4 @@
-package edu.ecep.base_app.vidaescolar.presentation.dto;
+package edu.ecep.base_app.gestionacademica.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,11 +9,13 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class InformeInicialCreateDTO {
+public class InformeInicialDTO {
+    Long id;
     @NotNull
     Long trimestreId;
     @NotNull
     Long matriculaId;
     @NotBlank
     String descripcion;
+    boolean publicado;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/rest/InformeInicialController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/rest/InformeInicialController.java
@@ -1,6 +1,6 @@
-package edu.ecep.base_app.vidaescolar.presentation.rest;
+package edu.ecep.base_app.gestionacademica.presentation.rest;
 
-import edu.ecep.base_app.vidaescolar.application.InformeInicialService;
+import edu.ecep.base_app.gestionacademica.application.InformeInicialService;
 
 import java.util.List;
 
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 
-import edu.ecep.base_app.vidaescolar.presentation.dto.*;
+import edu.ecep.base_app.gestionacademica.presentation.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 


### PR DESCRIPTION
## Summary
- relocate the informe inicial domain, application, mapper, repository, DTOs and controller into the gestionacademica package hierarchy
- update package statements and imports to match the new module location while keeping existing API behavior intact

## Testing
- ./mvnw test *(fails: unable to download Maven wrapper distribution in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f1f46b248327a004ab48f2ea2566