### PR TITLE
Fix missing domain imports and mapper visibility

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/Aspirante.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/Aspirante.java
@@ -1,6 +1,7 @@
 package edu.ecep.base_app.admisiones.domain;
 
 import edu.ecep.base_app.admisiones.domain.enums.Curso;
+import edu.ecep.base_app.identidad.domain.Persona;
 import edu.ecep.base_app.shared.domain.enums.Turno;
 import jakarta.persistence.*;
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/AspiranteFamiliar.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/AspiranteFamiliar.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.admisiones.domain;
 
+import edu.ecep.base_app.identidad.domain.Familiar;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import edu.ecep.base_app.shared.domain.enums.RolVinculo;
 import jakarta.persistence.*;
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/SolicitudAdmision.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/SolicitudAdmision.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.admisiones.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/domain/AsistenciaEmpleados.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/domain/AsistenciaEmpleados.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.asistencias.domain;
 
+import edu.ecep.base_app.identidad.domain.Empleado;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/domain/DetalleAsistencia.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/domain/DetalleAsistencia.java
@@ -1,6 +1,8 @@
 package edu.ecep.base_app.asistencias.domain;
 
 import edu.ecep.base_app.asistencias.domain.enums.EstadoAsistencia;
+import edu.ecep.base_app.shared.domain.BaseEntity;
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/domain/JornadaAsistencia.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/domain/JornadaAsistencia.java
@@ -1,5 +1,8 @@
 package edu.ecep.base_app.asistencias.domain;
 
+import edu.ecep.base_app.gestionacademica.domain.Seccion;
+import edu.ecep.base_app.gestionacademica.domain.Trimestre;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/calendario/domain/DiaNoHabil.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/calendario/domain/DiaNoHabil.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.calendario.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/calendario/domain/PeriodoEscolar.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/calendario/domain/PeriodoEscolar.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.calendario.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/comunicacion/domain/Comunicado.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/comunicacion/domain/Comunicado.java
@@ -1,6 +1,8 @@
 package edu.ecep.base_app.comunicacion.domain;
 
 import edu.ecep.base_app.comunicacion.domain.enums.AlcanceComunicado;
+import edu.ecep.base_app.gestionacademica.domain.Seccion;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import edu.ecep.base_app.shared.domain.enums.NivelAcademico;
 import jakarta.persistence.*;
 
@@ -32,4 +34,3 @@ public class Comunicado extends BaseEntity {
     private OffsetDateTime fechaProgPublicacion;
     @Column(nullable=false) private boolean publicado = false;
 }
-

--- a/backend-ecep/src/main/java/edu/ecep/base_app/comunicacion/domain/Mensaje.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/comunicacion/domain/Mensaje.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.comunicacion.domain;
 
+import edu.ecep.base_app.identidad.domain.Persona;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/Cuota.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/Cuota.java
@@ -2,6 +2,8 @@ package edu.ecep.base_app.finanzas.domain;
 
 import edu.ecep.base_app.finanzas.domain.enums.ConceptoCuota;
 import edu.ecep.base_app.finanzas.domain.enums.EstadoCuota;
+import edu.ecep.base_app.shared.domain.BaseEntity;
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/EmisionCuota.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/EmisionCuota.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.finanzas.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import edu.ecep.base_app.finanzas.domain.enums.ConceptoCuota;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/EmisionCuotaSeccion.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/EmisionCuotaSeccion.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.finanzas.domain;
 
+import edu.ecep.base_app.gestionacademica.domain.Seccion;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/PagoCuota.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/PagoCuota.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.finanzas.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import edu.ecep.base_app.finanzas.domain.enums.EstadoPago;
 import edu.ecep.base_app.finanzas.domain.enums.MedioPago;
 import jakarta.persistence.*;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/ReciboSueldo.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/finanzas/domain/ReciboSueldo.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.finanzas.domain;
 
+import edu.ecep.base_app.identidad.domain.Empleado;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/AsignacionDocenteMateria.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/AsignacionDocenteMateria.java
@@ -1,6 +1,8 @@
 package edu.ecep.base_app.gestionacademica.domain;
 
 import edu.ecep.base_app.gestionacademica.domain.enums.RolMateria;
+import edu.ecep.base_app.identidad.domain.Empleado;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/AsignacionDocenteSeccion.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/AsignacionDocenteSeccion.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.gestionacademica.domain;
 import edu.ecep.base_app.gestionacademica.domain.enums.RolSeccion;
+import edu.ecep.base_app.identidad.domain.Empleado;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/CalificacionTrimestral.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/CalificacionTrimestral.java
@@ -1,6 +1,8 @@
 package edu.ecep.base_app.gestionacademica.domain;
 
 import edu.ecep.base_app.gestionacademica.domain.enums.CalificacionConceptual;
+import edu.ecep.base_app.shared.domain.BaseEntity;
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Evaluacion.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Evaluacion.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.gestionacademica.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Materia.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Materia.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.gestionacademica.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 
 import java.util.HashSet;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/ResultadoEvaluacion.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/ResultadoEvaluacion.java
@@ -3,6 +3,8 @@ package edu.ecep.base_app.gestionacademica.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import edu.ecep.base_app.shared.domain.BaseEntity;
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
 
 @Entity @Table(name="resultados_evaluacion",
         uniqueConstraints=@UniqueConstraint(columnNames={"evaluacion_id","matricula_id"}))

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Seccion.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Seccion.java
@@ -2,6 +2,8 @@ package edu.ecep.base_app.gestionacademica.domain;
 
 import edu.ecep.base_app.shared.domain.enums.NivelAcademico;
 import edu.ecep.base_app.shared.domain.enums.Turno;
+import edu.ecep.base_app.calendario.domain.PeriodoEscolar;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 
 import java.util.HashSet;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/SeccionMateria.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/SeccionMateria.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.gestionacademica.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Trimestre.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/domain/Trimestre.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
+import edu.ecep.base_app.calendario.domain.PeriodoEscolar;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 
 import java.time.LocalDate;
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/AlumnoFamiliar.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/AlumnoFamiliar.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.identidad.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import edu.ecep.base_app.shared.domain.enums.RolVinculo;
 import jakarta.persistence.*;
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Empleado.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Empleado.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.identidad.domain;
 
+import edu.ecep.base_app.finanzas.domain.ReciboSueldo;
 import edu.ecep.base_app.identidad.domain.enums.RolEmpleado;
 import jakarta.persistence.*;
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/FormacionAcademica.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/FormacionAcademica.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.identidad.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Licencia.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Licencia.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.identidad.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Persona.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Persona.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.identidad.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import edu.ecep.base_app.identidad.domain.enums.UserRole;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -66,5 +67,4 @@ public class Persona extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Set<UserRole> roles = new HashSet<>();
 }
-
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/mapper/ModelMapperConfig.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/mapper/ModelMapperConfig.java
@@ -7,5 +7,5 @@ import org.mapstruct.ReportingPolicy;
 // Config + helper de referencias (IDs -> entidades con sólo id)
 // =============================================================
 @MapperConfig(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-interface ModelMapperConfig {
+public interface ModelMapperConfig {
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/mapper/RefMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/mapper/RefMapper.java
@@ -18,109 +18,109 @@ import edu.ecep.base_app.vidaescolar.domain.Matricula;
 import org.springframework.stereotype.Component;
 
 @Component
-class RefMapper {
+public class RefMapper {
 
     // === Helpers por entidad (sin genéricos) ===
 
-    Persona toPersona(Long id) {
+    public Persona toPersona(Long id) {
         if (id == null) return null;
         Persona x = new Persona();
         x.setId(id);
         return x;
     }
 
-    Alumno toAlumno(Long id) {
+    public Alumno toAlumno(Long id) {
         if (id == null) return null;
         Alumno x = new Alumno();
         x.setId(id);
         return x;
     }
 
-    Familiar toFamiliar(Long id) {
+    public Familiar toFamiliar(Long id) {
         if (id == null) return null;
         Familiar x = new Familiar();
         x.setId(id);
         return x;
     }
 
-    Empleado toEmpleado(Long id) {
+    public Empleado toEmpleado(Long id) {
         if (id == null) return null;
         Empleado x = new Empleado();
         x.setId(id);
         return x;
     }
 
-    PeriodoEscolar toPeriodoEscolar(Long id) {
+    public PeriodoEscolar toPeriodoEscolar(Long id) {
         if (id == null) return null;
         PeriodoEscolar x = new PeriodoEscolar();
         x.setId(id);
         return x;
     }
 
-    Trimestre toTrimestre(Long id) {
+    public Trimestre toTrimestre(Long id) {
         if (id == null) return null;
         Trimestre x = new Trimestre();
         x.setId(id);
         return x;
     }
 
-    Seccion toSeccion(Long id) {
+    public Seccion toSeccion(Long id) {
         if (id == null) return null;
         Seccion x = new Seccion();
         x.setId(id);
         return x;
     }
 
-    Materia toMateria(Long id) {
+    public Materia toMateria(Long id) {
         if (id == null) return null;
         Materia x = new Materia();
         x.setId(id);
         return x;
     }
 
-    SeccionMateria toSeccionMateria(Long id) {
+    public SeccionMateria toSeccionMateria(Long id) {
         if (id == null) return null;
         SeccionMateria x = new SeccionMateria();
         x.setId(id);
         return x;
     }
 
-    Matricula toMatricula(Long id) {
+    public Matricula toMatricula(Long id) {
         if (id == null) return null;
         Matricula x = new Matricula();
         x.setId(id);
         return x;
     }
 
-    EmisionCuota toEmisionCuota(Long id) {
+    public EmisionCuota toEmisionCuota(Long id) {
         if (id == null) return null;
         EmisionCuota x = new EmisionCuota();
         x.setId(id);
         return x;
     }
 
-    Cuota toCuota(Long id) {
+    public Cuota toCuota(Long id) {
         if (id == null) return null;
         Cuota x = new Cuota();
         x.setId(id);
         return x;
     }
 
-    Aspirante toAspirante(Long id) {
+    public Aspirante toAspirante(Long id) {
         if (id == null) return null;
         Aspirante x = new Aspirante();
         x.setId(id);
         return x;
     }
 
-    Evaluacion toEvaluacion(Long id) {
+    public Evaluacion toEvaluacion(Long id) {
         if (id == null) return null;
         Evaluacion x = new Evaluacion();
         x.setId(id);
         return x;
     }
 
-    JornadaAsistencia toJornadaAsistencia(Long id) {
+    public JornadaAsistencia toJornadaAsistencia(Long id) {
         if (id == null) return null;
         JornadaAsistencia x = new JornadaAsistencia();
         x.setId(id);

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/ActaAccidente.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/ActaAccidente.java
@@ -1,6 +1,9 @@
 package edu.ecep.base_app.vidaescolar.domain;
 
 import edu.ecep.base_app.vidaescolar.domain.enums.EstadoActaAccidente;
+import edu.ecep.base_app.identidad.domain.Alumno;
+import edu.ecep.base_app.identidad.domain.Empleado;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/Matricula.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/Matricula.java
@@ -1,6 +1,9 @@
 package edu.ecep.base_app.vidaescolar.domain;
 
 import edu.ecep.base_app.vidaescolar.domain.enums.EstadoMatricula;
+import edu.ecep.base_app.calendario.domain.PeriodoEscolar;
+import edu.ecep.base_app.identidad.domain.Alumno;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Filter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/MatriculaSeccionHistorial.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/MatriculaSeccionHistorial.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.vidaescolar.domain;
 
+import edu.ecep.base_app.gestionacademica.domain.Seccion;
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/SolicitudBajaAlumno.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/SolicitudBajaAlumno.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.vidaescolar.domain;
 
+import edu.ecep.base_app.shared.domain.BaseEntity;
 import edu.ecep.base_app.vidaescolar.domain.enums.EstadoSolicitudBaja;
 import jakarta.persistence.*;
 import lombok.Getter;


### PR DESCRIPTION
## Summary
- add the missing BaseEntity and domain imports across entities that extend the shared base class
- wire cross-domain relationships by importing Persona, Matricula, Empleado, and other referenced models
- make the shared ModelMapperConfig and RefMapper beans public so MapStruct mappers can access them

## Testing
- ./mvnw -q -e -DskipTests compile *(fails: repository download blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d283361e308327a81adf863d8a3b18