### PR TITLE
Add missing cross-module imports

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AlumnoService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AlumnoService.java
@@ -1,15 +1,16 @@
 package edu.ecep.base_app.identidad.application;
 
+import edu.ecep.base_app.gestionacademica.domain.Seccion;
 import edu.ecep.base_app.identidad.domain.Alumno;
-import edu.ecep.base_app.identidad.domain.Persona;
-import edu.ecep.base_app.identidad.presentation.dto.AlumnoDTO;
 import edu.ecep.base_app.identidad.infrastructure.mapper.AlumnoMapper;
 import edu.ecep.base_app.identidad.infrastructure.persistence.AlumnoFamiliarRepository;
 import edu.ecep.base_app.identidad.infrastructure.persistence.AlumnoRepository;
+import edu.ecep.base_app.identidad.infrastructure.persistence.PersonaRepository;
+import edu.ecep.base_app.identidad.presentation.dto.AlumnoDTO;
+import edu.ecep.base_app.shared.exception.NotFoundException;
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
 import edu.ecep.base_app.vidaescolar.infrastructure.persistence.MatriculaRepository;
 import edu.ecep.base_app.vidaescolar.infrastructure.persistence.MatriculaSeccionHistorialRepository;
-import edu.ecep.base_app.identidad.infrastructure.persistence.PersonaRepository;
-import edu.ecep.base_app.shared.exception.NotFoundException;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -21,7 +22,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 
-import edu.ecep.base_app.identidad.domain.Alumno;
 import lombok.RequiredArgsConstructor;
 
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Alumno.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Alumno.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.identidad.domain;
 
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Familiar.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Familiar.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.identidad.domain;
 
+import edu.ecep.base_app.admisiones.domain.AspiranteFamiliar;
 import jakarta.persistence.*;
 
 import java.util.HashSet;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/web/GlobalExceptionHandler.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/web/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.shared.web;
 
+import edu.ecep.base_app.shared.exception.NotFoundException;
+import edu.ecep.base_app.shared.exception.ReferencedException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
## Summary
- add missing Matricula and AspiranteFamiliar imports so identity entities compile
- update AlumnoService to import Seccion and Matricula for section name resolution
- restore custom exception imports in the global handler to wire mapped responses

## Testing
- mvn -q -DskipTests compile *(fails: network unreachable while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d28c1d1f1c8327912fbc8cda752599