### PR TITLE
Import EstadoAsistencia enum in DataLoader

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/bootstrap/DataLoader.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/bootstrap/DataLoader.java
@@ -4,6 +4,7 @@ package edu.ecep.base_app.shared.bootstrap;
 import edu.ecep.base_app.admisiones.domain.*;
 import edu.ecep.base_app.admisiones.infrastructure.persistence.*;
 import edu.ecep.base_app.asistencias.domain.*;
+import edu.ecep.base_app.asistencias.domain.enums.EstadoAsistencia;
 import edu.ecep.base_app.asistencias.infrastructure.persistence.*;
 import edu.ecep.base_app.calendario.domain.*;
 import edu.ecep.base_app.calendario.infrastructure.persistence.*;


### PR DESCRIPTION
## Summary
- add the missing import for the EstadoAsistencia enum used while seeding attendance records

## Testing
- `./mvnw -DskipTests compile` *(fails: offline environment prevents downloading Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68d2924a742c8327abba3d6f4a4dff55