### PR TITLE
Update trimester status indicators with new iconography

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ActiveTrimestreBadge.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ActiveTrimestreBadge.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import type { ComponentProps } from "react";
-
-import { Badge } from "@/components/ui/badge";
+import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { cn } from "@/lib/utils";
 import {
   formatTrimestreRange,
   getTrimestreEstado,
   TRIMESTRE_ESTADO_LABEL,
+  type TrimestreEstado,
 } from "@/lib/trimestres";
 
 interface ActiveTrimestreBadgeProps {
@@ -18,12 +17,12 @@ interface ActiveTrimestreBadgeProps {
 export function ActiveTrimestreBadge({ className }: ActiveTrimestreBadgeProps) {
   const { trimestreActivo, loading } = useActivePeriod();
 
+  let estado: TrimestreEstado = "inactivo";
   let label = "Sin trimestre activo";
   let description = "";
-  let variant: ComponentProps<typeof Badge>["variant"] = "secondary";
 
   if (trimestreActivo) {
-    const estado = getTrimestreEstado(trimestreActivo);
+    estado = getTrimestreEstado(trimestreActivo);
     const range = formatTrimestreRange(trimestreActivo);
     const numero = trimestreActivo.orden;
     const numeroLabel = numero ? ` ${numero}` : "";
@@ -31,26 +30,10 @@ export function ActiveTrimestreBadge({ className }: ActiveTrimestreBadgeProps) {
     description = range ?? "";
 
     const estadoBaseLabel = TRIMESTRE_ESTADO_LABEL[estado] ?? estado;
-
-    switch (estado) {
-      case "activo":
-        label = `Trimestre${numeroLabel} ${estadoBaseLabel.toLowerCase()}`;
-        variant = "outline";
-        break;
-      case "cerrado":
-        label = `Trimestre${numeroLabel} ${estadoBaseLabel.toLowerCase()}`;
-        variant = "secondary";
-        break;
-      case "inactivo":
-      default:
-        label = `Trimestre${numeroLabel} ${estadoBaseLabel.toLowerCase()}`;
-        variant = "secondary";
-        break;
-    }
+    label = `Trimestre${numeroLabel} ${estadoBaseLabel.toLowerCase()}`;
   }
 
   if (loading || (!label && !description)) return null;
-
 
   return (
     <div
@@ -59,9 +42,11 @@ export function ActiveTrimestreBadge({ className }: ActiveTrimestreBadgeProps) {
         className,
       )}
     >
-      <Badge variant={variant} className="whitespace-nowrap">
-        {label}
-      </Badge>
+      <TrimestreEstadoBadge
+        estado={estado}
+        label={label}
+        className="whitespace-nowrap"
+      />
       {description ? <span>{description}</span> : null}
     </div>
   );

--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -19,15 +19,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
 import { api } from "@/services/api";
 import type { PeriodoEscolarDTO, TrimestreDTO } from "@/types/api-generated";
 import { UserRole } from "@/types/api-generated";
 import {
-  TRIMESTRE_ESTADO_BADGE_VARIANT,
-  TRIMESTRE_ESTADO_LABEL,
   getTrimestreEstado,
   getTrimestreFin,
   getTrimestreInicio,
@@ -419,12 +417,6 @@ function DireccionConfig({ open }: DireccionConfigProps) {
   };
 
   const periodoAbierto = periodoActual?.activo !== false;
-  const estadoBadgeVariant: Record<
-    TrimestreEstado,
-    "default" | "secondary" | "destructive" | "outline"
-  > = TRIMESTRE_ESTADO_BADGE_VARIANT;
-  const estadoBadgeLabel: Record<TrimestreEstado, string> = TRIMESTRE_ESTADO_LABEL;
-
   return (
     <div className="space-y-6">
       <Card>
@@ -495,11 +487,10 @@ function DireccionConfig({ open }: DireccionConfigProps) {
                         <span>
                           Período {resolveTrimestrePeriodoId(tri, periodoActual?.id) ?? "—"}
                         </span>
-                        <Badge
-                          variant={estadoBadgeVariant[estado] ?? "outline"}
-                        >
-                          {estadoBadgeLabel[estado]}
-                        </Badge>
+                        <TrimestreEstadoBadge
+                          estado={estado}
+                          className="text-xs text-muted-foreground"
+                        />
                       </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
@@ -11,7 +11,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { FileText, Plus } from "lucide-react";
 import {
@@ -25,11 +24,8 @@ import {
 import { useAsistenciasData } from "@/hooks/useAsistenciasData";
 import { api } from "@/services/api";
 import { toast } from "sonner";
-import {
-  getTrimestreEstado,
-  TRIMESTRE_ESTADO_BADGE_VARIANT,
-  TRIMESTRE_ESTADO_LABEL,
-} from "@/lib/trimestres";
+import { getTrimestreEstado, TRIMESTRE_ESTADO_LABEL } from "@/lib/trimestres";
+import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
 
 function fmt(iso?: string) {
   if (!iso) return "";
@@ -178,9 +174,13 @@ export default function VistaDireccion() {
                     {(() => {
                       const estado = getTrimestreEstado(t);
                       const label = TRIMESTRE_ESTADO_LABEL[estado] ?? estado;
-                      const variant =
-                        TRIMESTRE_ESTADO_BADGE_VARIANT[estado] ?? "outline";
-                      return <Badge variant={variant}>{label}</Badge>;
+                      return (
+                        <TrimestreEstadoBadge
+                          estado={estado}
+                          label={label}
+                          className="text-xs text-muted-foreground"
+                        />
+                      );
                     })()}
                     <Button
                       variant="outline"

--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -36,13 +36,13 @@ import {
   getTrimestreEstado,
   getTrimestreFin,
   getTrimestreInicio,
-  TRIMESTRE_ESTADO_BADGE_VARIANT,
   TRIMESTRE_ESTADO_LABEL,
 } from "@/lib/trimestres";
 import { cn } from "@/lib/utils";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
 import { UserRole } from "@/types/api-generated";
+import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
 
 function fmt(iso?: string) {
   if (!iso) return "—";
@@ -342,8 +342,6 @@ export default function SeccionHistorialPage() {
               const rangeLabel = formatTrimestreRange(tri);
               const estado = getTrimestreEstado(tri);
               const estadoLabel = TRIMESTRE_ESTADO_LABEL[estado] ?? estado;
-              const estadoBadgeVariant =
-                TRIMESTRE_ESTADO_BADGE_VARIANT[estado] ?? "outline";
               const canEdit = estado === "activo";
               const estadoMessage =
                 estado === "cerrado"
@@ -372,9 +370,10 @@ export default function SeccionHistorialPage() {
                                     <Calendar className="h-5 w-5 mr-2" />
                                     Jornadas del trimestre
                                   </span>
-                                  <Badge variant={estadoBadgeVariant}>
-                                    {estadoLabel}
-                                  </Badge>
+                                  <TrimestreEstadoBadge
+                                    estado={estado}
+                                    className="text-xs text-muted-foreground"
+                                  />
                                 </CardTitle>
                                 <CardDescription>
                                   Seleccioná una fecha para ver o editar la

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -18,7 +18,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -33,7 +32,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  TRIMESTRE_ESTADO_BADGE_VARIANT,
   TRIMESTRE_ESTADO_LABEL,
   getTrimestreEstado,
   resolveTrimestrePeriodoId,
@@ -41,6 +39,7 @@ import {
 } from "@/lib/trimestres";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
 
 const CONCEPTOS = Object.values(CalificacionConceptual).filter(
   (value): value is CalificacionConceptual => typeof value === "string",
@@ -577,8 +576,6 @@ export default function CierrePrimarioView({
                   {triOpts.map((o) => {
                     const active = String(o.id) === triId;
                     const estadoLabel = TRIMESTRE_ESTADO_LABEL[o.estado] ?? "";
-                    const badgeVariant =
-                      TRIMESTRE_ESTADO_BADGE_VARIANT[o.estado] ?? "secondary";
                     return (
                       <Button
                         key={o.id}
@@ -592,9 +589,13 @@ export default function CierrePrimarioView({
                       >
                         <span>{o.label}</span>
                         {estadoLabel ? (
-                          <Badge variant={badgeVariant} className="ml-2">
-                            {estadoLabel}
-                          </Badge>
+                          <TrimestreEstadoBadge
+                            estado={o.estado}
+                            label={estadoLabel}
+                            className="ml-2 shrink-0 text-[11px] text-muted-foreground"
+                            circleClassName="h-5 w-5"
+                            iconClassName="h-2.5 w-2.5"
+                          />
                         ) : null}
                       </Button>
                     );
@@ -657,9 +658,15 @@ export default function CierrePrimarioView({
           <CardContent className="space-y-4">
             {triSoloLectura && (
               <div className="flex flex-wrap items-center gap-2 text-sm">
-                <Badge variant={triCerrado ? "destructive" : "secondary"}>
-                  {triCerrado ? "Trimestre cerrado" : "Trimestre inactivo"}
-                </Badge>
+                <TrimestreEstadoBadge
+                  estado={triCerrado ? "cerrado" : "inactivo"}
+                  label={
+                    triCerrado ? "Trimestre cerrado" : "Trimestre inactivo"
+                  }
+                  className="text-xs text-muted-foreground"
+                  circleClassName="h-5 w-5"
+                  iconClassName="h-2.5 w-2.5"
+                />
                 <span className="text-muted-foreground">
                   {triCerrado
                     ? "Los datos se muestran solo para consulta."

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/InformeInicialView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/InformeInicialView.tsx
@@ -14,9 +14,8 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
 import {
-  TRIMESTRE_ESTADO_BADGE_VARIANT,
   TRIMESTRE_ESTADO_LABEL,
   getTrimestreEstado,
   resolveTrimestrePeriodoId,
@@ -144,8 +143,6 @@ function TrimestreInformeTile({
   const estado = getTrimestreEstado(trimestre);
   const esCerrado = estado === "cerrado";
   const esSoloLectura = estado !== "activo";
-  const estadoBadgeVariant =
-    TRIMESTRE_ESTADO_BADGE_VARIANT[estado] ?? "secondary";
   const estadoLabel = TRIMESTRE_ESTADO_LABEL[estado];
 
   useEffect(() => {
@@ -188,7 +185,11 @@ function TrimestreInformeTile({
     <Card className="border-dashed">
       <CardHeader className="flex flex-row items-center justify-between gap-2">
         <CardTitle className="text-base">Trimestre {trimestre.orden}</CardTitle>
-        <Badge variant={estadoBadgeVariant}>{estadoLabel}</Badge>
+        <TrimestreEstadoBadge
+          estado={estado}
+          label={estadoLabel}
+          className="text-xs text-muted-foreground"
+        />
       </CardHeader>
       <CardContent>
         {existing ? (

--- a/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
+++ b/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
@@ -1,0 +1,63 @@
+import { Dot, Lock, Minus } from "lucide-react";
+
+import { TRIMESTRE_ESTADO_LABEL, type TrimestreEstado } from "@/lib/trimestres";
+import { cn } from "@/lib/utils";
+
+const CIRCLE_STYLES: Record<TrimestreEstado, string> = {
+  activo: "bg-emerald-500 text-emerald-50 border-transparent",
+  inactivo: "bg-white text-foreground border-border",
+  cerrado: "bg-red-500 text-red-50 border-transparent",
+};
+
+export interface TrimestreEstadoBadgeProps {
+  estado: TrimestreEstado;
+  label?: string;
+  showLabel?: boolean;
+  className?: string;
+  circleClassName?: string;
+  iconClassName?: string;
+}
+
+export function TrimestreEstadoBadge({
+  estado,
+  label,
+  showLabel = true,
+  className,
+  circleClassName,
+  iconClassName,
+}: TrimestreEstadoBadgeProps) {
+  const finalLabel = label ?? TRIMESTRE_ESTADO_LABEL[estado] ?? "";
+  const circleClasses = cn(
+    "flex h-6 w-6 items-center justify-center rounded-full border text-current",
+    CIRCLE_STYLES[estado],
+    circleClassName,
+  );
+  const iconClasses = cn("h-3.5 w-3.5", iconClassName);
+
+  let icon = null;
+  switch (estado) {
+    case "activo":
+      icon = <Dot className={iconClasses} strokeWidth={6} fill="currentColor" />;
+      break;
+    case "inactivo":
+      icon = <Minus className={iconClasses} strokeWidth={3} />;
+      break;
+    case "cerrado":
+    default:
+      icon = <Lock className={iconClasses} strokeWidth={2.5} />;
+      break;
+  }
+
+  return (
+    <span className={cn("inline-flex items-center gap-2 text-xs font-medium", className)}>
+      <span className={circleClasses} aria-hidden="true">
+        {icon}
+      </span>
+      {showLabel ? (
+        <span>{finalLabel}</span>
+      ) : finalLabel ? (
+        <span className="sr-only">{finalLabel}</span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend-ecep/src/lib/trimestres.ts
+++ b/frontend-ecep/src/lib/trimestres.ts
@@ -76,15 +76,6 @@ export const TRIMESTRE_ESTADO_LABEL: Record<TrimestreEstado, string> = {
   cerrado: "Cerrado",
 };
 
-export const TRIMESTRE_ESTADO_BADGE_VARIANT: Record<
-  TrimestreEstado,
-  "default" | "secondary" | "destructive" | "outline"
-> = {
-  activo: "default",
-  inactivo: "secondary",
-  cerrado: "destructive",
-};
-
 const formatSimpleDate = (iso?: string) => {
   if (!iso) return null;
   const [year, month, day] = iso.split("-");


### PR DESCRIPTION
## Summary
- add a reusable `TrimestreEstadoBadge` that renders lucide icons inside a colored circle for each trimestre estado
- replace previous badge labels in configuration, asistencia and calificaciones views (including the active trimestre chip) to use the new indicator and styling
- drop the unused badge variant mapping from the trimestre helpers now that the custom indicator controls its own colors

## Testing
- bun run lint *(fails: `next` command missing because dependencies cannot be installed without registry access)*
- bun install *(fails: npm registry returns HTTP 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d29d320858832784e415cb5868cb67