### PR TITLE
Convert genero inputs to gender select options

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -41,6 +41,11 @@ import { useAuth } from "@/hooks/useAuth";
 import { formatDni } from "@/lib/form-utils";
 import { displayRole } from "@/lib/auth-roles";
 import {
+  DEFAULT_GENERO_VALUE,
+  GENERO_OPTIONS,
+  normalizeGenero,
+} from "@/lib/genero";
+import {
   gestionAcademica,
   identidad,
   vidaEscolar,
@@ -160,7 +165,7 @@ export default function AlumnoPerfilPage() {
     apellido: "",
     dni: "",
     fechaNacimiento: "",
-    genero: "",
+    genero: DEFAULT_GENERO_VALUE,
     nacionalidad: "",
     domicilio: "",
     telefono: "",
@@ -419,7 +424,7 @@ export default function AlumnoPerfilPage() {
       apellido: persona?.apellido ?? "",
       dni: formatDni(persona?.dni ?? ""),
       fechaNacimiento: persona?.fechaNacimiento ?? "",
-      genero: persona?.genero ?? "",
+      genero: normalizeGenero(persona?.genero) || DEFAULT_GENERO_VALUE,
       nacionalidad: persona?.nacionalidad ?? "",
       domicilio: persona?.domicilio ?? "",
       telefono: persona?.telefono ?? "",
@@ -1015,15 +1020,26 @@ export default function AlumnoPerfilPage() {
                       </div>
                       <div className="space-y-2">
                         <Label>Género</Label>
-                        <Input
-                          value={personaDraft.genero}
-                          onChange={(e) =>
+                        <Select
+                          value={personaDraft.genero || undefined}
+                          onValueChange={(value) =>
                             setPersonaDraft((prev) => ({
                               ...prev,
-                              genero: e.target.value,
+                              genero: value,
                             }))
                           }
-                        />
+                        >
+                          <SelectTrigger aria-required="true">
+                            <SelectValue placeholder="Seleccioná el género" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {GENERO_OPTIONS.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </div>
                       <div className="space-y-2">
                         <Label>Nacionalidad</Label>

--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -24,6 +24,18 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DEFAULT_GENERO_VALUE,
+  GENERO_OPTIONS,
+  normalizeGenero,
+} from "@/lib/genero";
 import { Loader2 } from "lucide-react";
 
 const emptyPersona: PersonaForm = {
@@ -31,7 +43,7 @@ const emptyPersona: PersonaForm = {
   apellido: "",
   dni: "",
   fechaNacimiento: "",
-  genero: "",
+  genero: DEFAULT_GENERO_VALUE,
   estadoCivil: "",
   nacionalidad: "",
   domicilio: "",
@@ -101,7 +113,7 @@ export default function AltaAlumnoPage() {
         apellido: data.apellido ?? "",
         dni: formatDni(data.dni ?? ""),
         fechaNacimiento: data.fechaNacimiento ?? "",
-        genero: data.genero ?? "",
+        genero: normalizeGenero(data.genero) || DEFAULT_GENERO_VALUE,
         estadoCivil: data.estadoCivil ?? "",
         nacionalidad: data.nacionalidad ?? "",
         domicilio: data.domicilio ?? "",
@@ -431,10 +443,21 @@ function PersonaFormFields({ values, onChange }: PersonaFormFieldsProps) {
       </div>
       <div>
         <label className="text-sm font-medium text-muted-foreground">Género</label>
-        <Input
-          value={values.genero}
-          onChange={(e) => onChange("genero", e.target.value)}
-        />
+        <Select
+          value={values.genero || undefined}
+          onValueChange={(value) => onChange("genero", value)}
+        >
+          <SelectTrigger aria-required="true">
+            <SelectValue placeholder="Seleccioná el género" />
+          </SelectTrigger>
+          <SelectContent>
+            {GENERO_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       <div>
         <label className="text-sm font-medium text-muted-foreground">Estado civil</label>

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -45,6 +45,11 @@ import { gestionAcademica, identidad } from "@/services/api/modules";
 import { isBirthDateValid, maxBirthDate } from "@/lib/form-utils";
 import { displayRole } from "@/lib/auth-roles";
 import {
+  DEFAULT_GENERO_VALUE,
+  GENERO_OPTIONS,
+  normalizeGenero,
+} from "@/lib/genero";
+import {
   RolEmpleado,
   UserRole,
   type AsignacionDocenteMateriaDTO,
@@ -96,13 +101,6 @@ const tipoLicenciaOptions = [
 const DEFAULT_SITUACION = "Activo";
 const LICENCIA_SITUACION = "En licencia";
 
-const GENERO_PRESET_OPTIONS = [
-  { value: "Femenino", label: "Femenino" },
-  { value: "Masculino", label: "Masculino" },
-  { value: "No binario", label: "No binario" },
-  { value: "Otro", label: "Otro / Prefiere no decir" },
-];
-
 const ESTADO_CIVIL_PRESET_OPTIONS = [
   { value: "Soltero/a", label: "Soltero/a" },
   { value: "Casado/a", label: "Casado/a" },
@@ -141,7 +139,7 @@ const initialPersonaForm = {
   apellido: "",
   dni: "",
   fechaNacimiento: "",
-  genero: "",
+  genero: DEFAULT_GENERO_VALUE,
   estadoCivil: "",
   nacionalidad: "",
   domicilio: "",
@@ -851,19 +849,7 @@ export default function PersonalPage() {
     return Array.from(set.values()).sort((a, b) => a.localeCompare(b));
   }, [personal]);
 
-  const generoSelectOptions = useMemo(() => {
-    const map = new Map<string, string>();
-    GENERO_PRESET_OPTIONS.forEach((option) => map.set(option.value, option.label));
-    personal.forEach((p) => {
-      const value = p.persona?.genero?.trim();
-      if (value) {
-        map.set(value, value);
-      }
-    });
-    return Array.from(map.entries())
-      .map(([value, label]) => ({ value, label }))
-      .sort((a, b) => a.label.localeCompare(b.label, "es", { sensitivity: "base" }));
-  }, [personal]);
+  const generoSelectOptions = useMemo(() => GENERO_OPTIONS, []);
 
   const estadoCivilSelectOptions = useMemo(() => {
     const map = new Map<string, string>();
@@ -1194,7 +1180,7 @@ export default function PersonalPage() {
         apellido: persona.apellido ?? "",
         dni: formatDni(persona.dni ?? ""),
         fechaNacimiento: persona.fechaNacimiento ?? "",
-        genero: persona.genero ?? "",
+        genero: normalizeGenero(persona.genero) || DEFAULT_GENERO_VALUE,
         estadoCivil: persona.estadoCivil ?? "",
         nacionalidad: persona.nacionalidad ?? "",
         domicilio: persona.domicilio ?? "",

--- a/frontend-ecep/src/lib/genero.ts
+++ b/frontend-ecep/src/lib/genero.ts
@@ -1,0 +1,20 @@
+export const GENERO_OPTIONS = [
+  { value: "Masculino", label: "Masculino" },
+  { value: "Femenino", label: "Femenino" },
+  { value: "No especifica", label: "No especifica" },
+] as const;
+
+export type GeneroOptionValue = (typeof GENERO_OPTIONS)[number]["value"];
+
+export const DEFAULT_GENERO_VALUE: GeneroOptionValue = "No especifica";
+
+export const normalizeGenero = (
+  value?: string | null,
+): GeneroOptionValue | "" => {
+  if (!value) return "";
+  const normalized = value.trim().toLowerCase();
+  const option = GENERO_OPTIONS.find(
+    (item) => item.value.toLowerCase() === normalized,
+  );
+  return option ? option.value : "";
+};


### PR DESCRIPTION
## Summary
- add shared gender option constants and helper utilities
- replace manual genero inputs in student creation and profile forms with the new dropdown
- align the personal management form with the shared gender dropdown and defaults

## Testing
- npm run lint *(fails: next not found and dependencies cannot be installed due to registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b03285c8832783043ff5bfd06c7e