### PR TITLE
feat: refresh calendar data across modules

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -22,6 +22,7 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { calendario } from "@/services/api/modules";
+import { triggerCalendarRefresh } from "@/hooks/useCalendarRefresh";
 
 import type { PeriodoEscolarDTO, TrimestreDTO } from "@/types/api-generated";
 import { UserRole } from "@/types/api-generated";
@@ -294,6 +295,7 @@ function DireccionConfig({ open }: DireccionConfigProps) {
       });
       toast.success("Fechas del trimestre actualizadas");
       await loadData();
+      triggerCalendarRefresh("trimestres");
     } catch (error) {
       toast.error(
         resolveErrorMessage(error, "No se pudieron guardar los cambios"),
@@ -346,6 +348,7 @@ function DireccionConfig({ open }: DireccionConfigProps) {
         toast.success("Trimestre cerrado");
       }
       await loadData();
+      triggerCalendarRefresh("trimestres");
     } catch (error) {
       toast.error(
         resolveErrorMessage(
@@ -366,6 +369,7 @@ function DireccionConfig({ open }: DireccionConfigProps) {
       await calendario.periodos.cerrar(periodoActual.id);
       toast.success("Período cerrado");
       await loadData();
+      triggerCalendarRefresh("periodos");
     } catch (error) {
       toast.error(
         resolveErrorMessage(error, "No se pudo cerrar el período actual"),
@@ -382,6 +386,7 @@ function DireccionConfig({ open }: DireccionConfigProps) {
       await calendario.periodos.abrir(periodoActual.id);
       toast.success("Período reabierto");
       await loadData();
+      triggerCalendarRefresh("periodos");
     } catch (error) {
       toast.error(
         resolveErrorMessage(error, "No se pudo reabrir el período"),
@@ -407,6 +412,7 @@ function DireccionConfig({ open }: DireccionConfigProps) {
         anio: String(year + 1),
       }));
       await loadData();
+      triggerCalendarRefresh("periodos");
     } catch (error) {
       toast.error(
         resolveErrorMessage(error, "No se pudo crear el nuevo período"),

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/dialog";
 import { useAsistenciasData } from "@/hooks/useAsistenciasData";
 import { calendario } from "@/services/api/modules";
+import { triggerCalendarRefresh } from "@/hooks/useCalendarRefresh";
 import { toast } from "sonner";
 import { getTrimestreEstado, TRIMESTRE_ESTADO_LABEL } from "@/lib/trimestres";
 import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
@@ -98,6 +99,7 @@ export default function VistaDireccion() {
       toast.success("Trimestre creado");
       setModalTri(false);
       await refreshBase();
+      triggerCalendarRefresh("trimestres");
     } catch {
       toast.error("Error");
     }
@@ -116,6 +118,7 @@ export default function VistaDireccion() {
         toast.success("Trimestre activado");
       }
       await refreshBase();
+      triggerCalendarRefresh("trimestres");
     } catch {
       toast.error("No se pudo actualizar el estado del trimestre");
     } finally {

--- a/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
@@ -23,6 +23,7 @@ import type {
 } from "@/types/api-generated";
 import { NivelAcademico as NivelAcademicoEnum } from "@/types/api-generated";
 import { resolveTrimestrePeriodoId } from "@/lib/trimestres";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 
 interface FamilyCalificacionesViewProps {
   alumnos: AlumnoLiteDTO[];
@@ -95,6 +96,7 @@ export default function FamilyCalificacionesView({
   const [trimestres, setTrimestres] = useState<TrimestreDTO[]>([]);
   const [calificaciones, setCalificaciones] = useState<CalificacionDTO[]>([]);
   const [informes, setInformes] = useState<InformeInicialDTO[]>([]);
+  const calendarVersion = useCalendarRefresh("trimestres");
 
   const activePeriodId =
     typeof periodoEscolarId === "number" ? periodoEscolarId : null;
@@ -269,7 +271,7 @@ export default function FamilyCalificacionesView({
     return () => {
       alive = false;
     };
-  }, [matriculaIds, seccionIds, periodoEscolarId]);
+  }, [matriculaIds, seccionIds, periodoEscolarId, calendarVersion]);
 
   const trimestresOrdenados = useMemo(
     () => [...trimestres].sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0)),

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -40,6 +40,7 @@ import {
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 
 const CONCEPTOS = Object.values(CalificacionConceptual).filter(
   (value): value is CalificacionConceptual => typeof value === "string",
@@ -102,6 +103,7 @@ export default function CierrePrimarioView({
   const [loadingRows, setLoadingRows] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadingAttendance, setLoadingAttendance] = useState(false);
+  const calendarVersion = useCalendarRefresh("trimestres");
 
   // carga base
   useEffect(() => {
@@ -155,7 +157,7 @@ export default function CierrePrimarioView({
     return () => {
       alive = false;
     };
-  }, [seccionId, hoy, periodoEscolarId]);
+  }, [seccionId, hoy, periodoEscolarId, calendarVersion]);
 
   const triOpts = useMemo<
     { id: number; label: string; estado: TrimestreEstado }[]

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/InformeInicialView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/InformeInicialView.tsx
@@ -21,6 +21,7 @@ import {
   resolveTrimestrePeriodoId,
 } from "@/lib/trimestres";
 import { toast } from "sonner";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 
 export default function InformeInicialView({
   seccionId,
@@ -34,6 +35,7 @@ export default function InformeInicialView({
   const [alumnos, setAlumnos] = useState<any[]>([]);
   const [informes, setInformes] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const calendarVersion = useCalendarRefresh("trimestres");
 
   useEffect(() => {
     let alive = true;
@@ -74,7 +76,7 @@ export default function InformeInicialView({
     return () => {
       alive = false;
     };
-  }, [seccionId, hoy, periodoEscolarId]);
+  }, [seccionId, hoy, periodoEscolarId, calendarVersion]);
 
   const byKey = useMemo(() => {
     const m = new Map<string, any>();

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
@@ -30,6 +30,7 @@ import type {
 } from "@/types/api-generated";
 import { NivelAcademico as NivelAcademicoEnum } from "@/types/api-generated";
 import { calendario, gestionAcademica } from "@/services/api/modules";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 import { CheckCircle2, Clock, FileText, GraduationCap } from "lucide-react";
 
 interface FamilyEvaluationsViewProps {
@@ -123,6 +124,7 @@ export function FamilyEvaluationsView({
     totalEvaluaciones: number;
     evaluacionesCalificadas: number;
   }>({ promedio: null, totalEvaluaciones: 0, evaluacionesCalificadas: 0 });
+  const calendarVersion = useCalendarRefresh("trimestres");
 
   useEffect(() => {
     if (!alumnos.length) {
@@ -371,7 +373,7 @@ export function FamilyEvaluationsView({
     return () => {
       alive = false;
     };
-  }, [alumnoSeleccionado]);
+  }, [alumnoSeleccionado, calendarVersion]);
 
   if (initialLoading) {
     return <LoadingState label="Cargando evaluaciones…" />;

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { calendario, gestionAcademica } from "@/services/api/modules";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 import type {
   EvaluacionDTO,
   ResultadoEvaluacionDTO,
@@ -51,6 +52,7 @@ export default function NotasExamenDialog({
   const [rows, setRows] = useState<Row[]>([]);
   const [trimestres, setTrimestres] = useState<TrimestreDTO[]>([]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const calendarVersion = useCalendarRefresh("trimestres");
 
   const fecha = (evaluacion as any)?.fecha as string | undefined;
 
@@ -159,7 +161,7 @@ export default function NotasExamenDialog({
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, (evaluacion as any)?.id]);
+  }, [open, (evaluacion as any)?.id, calendarVersion]);
 
   const setNota = (matriculaId: number, value: string) => {
     const normalizedValue = value.replace(",", ".").trim();

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { LicenseSummaryCards } from "./_components/LicenseSummaryCards";
@@ -385,6 +386,7 @@ export default function ReportesPage() {
   const { hasRole, loading, user } = useAuth();
   const { periodoEscolarId } = useActivePeriod();
   const router = useRouter();
+  const calendarVersion = useCalendarRefresh("trimestres");
 
   useEffect(() => {
     if (loading) return;
@@ -664,7 +666,7 @@ export default function ReportesPage() {
     return () => {
       alive = false;
     };
-  }, [periodoEscolarId]);
+  }, [periodoEscolarId, calendarVersion]);
 
   // Boletines state -----------------------------------------------------------
   useEffect(() => {

--- a/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
+++ b/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
@@ -4,9 +4,9 @@ import { TRIMESTRE_ESTADO_LABEL, type TrimestreEstado } from "@/lib/trimestres";
 import { cn } from "@/lib/utils";
 
 const CIRCLE_STYLES: Record<TrimestreEstado, string> = {
-  activo: "bg-emerald-500 text-emerald-50 border-transparent",
-  inactivo: "bg-white text-foreground border-border",
-  cerrado: "bg-red-500 text-red-50 border-transparent",
+  activo: "bg-emerald-500 text-emerald-50",
+  inactivo: "bg-white text-foreground border border-border",
+  cerrado: "bg-red-500 text-red-50",
 };
 
 export interface TrimestreEstadoBadgeProps {
@@ -28,16 +28,23 @@ export function TrimestreEstadoBadge({
 }: TrimestreEstadoBadgeProps) {
   const finalLabel = label ?? TRIMESTRE_ESTADO_LABEL[estado] ?? "";
   const circleClasses = cn(
-    "flex h-6 w-6 items-center justify-center rounded-full border text-current",
+    "flex h-6 w-6 items-center justify-center rounded-full text-current",
     CIRCLE_STYLES[estado],
     circleClassName,
   );
-  const iconClasses = cn("h-3.5 w-3.5", iconClassName);
+  const iconClasses = cn("h-4 w-4", iconClassName);
 
   let icon = null;
   switch (estado) {
     case "activo":
-      icon = <Dot className={iconClasses} strokeWidth={6} fill="currentColor" />;
+      icon = (
+        <Dot
+          className={iconClasses}
+          stroke="none"
+          strokeWidth={0}
+          fill="currentColor"
+        />
+      );
       break;
     case "inactivo":
       icon = <Minus className={iconClasses} strokeWidth={3} />;

--- a/frontend-ecep/src/hooks/scope/useActivePeriod.ts
+++ b/frontend-ecep/src/hooks/scope/useActivePeriod.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { calendario } from "@/services/api/modules";
 import type { PeriodoEscolarDTO, TrimestreDTO } from "@/types/api-generated";
 import { getTrimestreEstado } from "@/lib/trimestres";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 
 type UseActivePeriodOpts = {
   today?: string; // YYYY-MM-DD
@@ -39,6 +40,7 @@ export function useActivePeriod(opts?: UseActivePeriodOpts) {
   const [today, setToday] = useState<string>(opts?.today ?? toLocalISODate());
   const preferOpen = opts?.preferOpen ?? true;
   const tickMidnight = opts?.tickMidnight ?? true;
+  const calendarVersion = useCalendarRefresh(["periodos", "trimestres"]);
 
   // Opcional: actualizar a medianoche si no viene por props
   useEffect(() => {
@@ -78,7 +80,7 @@ export function useActivePeriod(opts?: UseActivePeriodOpts) {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [calendarVersion]);
 
   const computed = useMemo(() => {
     if (!periodos.length || !trimestres.length) {

--- a/frontend-ecep/src/hooks/useAsistenciasData.ts
+++ b/frontend-ecep/src/hooks/useAsistenciasData.ts
@@ -11,6 +11,7 @@ import type {
   AlumnoLiteDTO,
 } from "@/types/api-generated";
 import { toast } from "sonner";
+import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 
 export function useAsistenciasData() {
   const [loading, setLoading] = useState(true);
@@ -27,6 +28,7 @@ export function useAsistenciasData() {
   >({});
   const [jornadas, setJornadas] = useState<JornadaAsistenciaDTO[]>([]);
   const [detalles, setDetalles] = useState<DetalleAsistenciaDTO[]>([]);
+  const calendarVersion = useCalendarRefresh("trimestres");
 
   useEffect(() => {
     (async () => {
@@ -52,7 +54,7 @@ export function useAsistenciasData() {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [calendarVersion]);
 
   const loadAlumnosSeccion = async (seccionId: number, fechaISO?: string) => {
     const key = `${seccionId}_${fechaISO ?? ""}`;

--- a/frontend-ecep/src/hooks/useCalendarRefresh.ts
+++ b/frontend-ecep/src/hooks/useCalendarRefresh.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  notifyCalendarUpdated,
+  subscribeCalendarUpdates,
+  type CalendarEventScope,
+} from "@/lib/calendar-events";
+
+/**
+ * Exposes a monotonically increasing value that changes whenever the
+ * calendario escolar se actualiza en el backend.
+ *
+ * Podés usarlo en efectos que cargan datos de trimestres o períodos para
+ * volver a consultar la API cuando Dirección realiza cambios.
+ */
+export function useCalendarRefresh(
+  scope?: CalendarEventScope | CalendarEventScope[],
+) {
+  const [version, setVersion] = useState(0);
+
+  const scopeKey = useMemo(() => {
+    if (!scope) return "";
+    const list = Array.isArray(scope) ? scope.slice() : [scope];
+    return list.sort().join("|");
+  }, [scope]);
+
+  useEffect(() => {
+    const expected = scopeKey
+      ? (scopeKey.split("|") as CalendarEventScope[])
+      : [];
+    return subscribeCalendarUpdates((scopes) => {
+      if (!expected.length) {
+        setVersion((prev) => prev + 1);
+        return;
+      }
+      const shouldUpdate = scopes.some(
+        (item) => item === "calendario" || expected.includes(item),
+      );
+      if (shouldUpdate) {
+        setVersion((prev) => prev + 1);
+      }
+    });
+  }, [scopeKey]);
+
+  return version;
+}
+
+/**
+ * Permite forzar un evento de actualización manual desde componentes que
+ * necesitan propagar cambios locales sin esperar a la respuesta del backend.
+ */
+export function triggerCalendarRefresh(
+  ...scopes: CalendarEventScope[]
+): void {
+  notifyCalendarUpdated(...scopes);
+}

--- a/frontend-ecep/src/lib/calendar-events.ts
+++ b/frontend-ecep/src/lib/calendar-events.ts
@@ -1,0 +1,31 @@
+export type CalendarEventScope = "calendario" | "periodos" | "trimestres";
+
+export type CalendarEventListener = (
+  scopes: CalendarEventScope[],
+) => void;
+
+const DEFAULT_SCOPE: CalendarEventScope = "calendario";
+
+const listeners = new Set<CalendarEventListener>();
+
+export function subscribeCalendarUpdates(listener: CalendarEventListener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function notifyCalendarUpdated(
+  ...scopes: CalendarEventScope[]
+): void {
+  const payload = (scopes.length ? scopes : [DEFAULT_SCOPE]).map((scope) =>
+    scope ?? DEFAULT_SCOPE,
+  );
+  for (const listener of Array.from(listeners)) {
+    try {
+      listener(payload);
+    } catch {
+      // ignore individual listener errors to avoid breaking the notification chain
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight calendar event bus and hook to react to trimester or period updates
- update dashboard views and hooks to reload trimester data when Dirección changes the calendar
- tweak the active trimester badge icon to remove the white border and enlarge the dot

## Testing
- bun run lint *(fails: next command not found because dependencies could not be installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b2d99ffc8327a2994b72a71b0521