### PR TITLE
feat: enforce single active period and sync front

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/calendario/application/PeriodoEscolarService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/calendario/application/PeriodoEscolarService.java
@@ -1,9 +1,9 @@
 package edu.ecep.base_app.calendario.application;
 
-import edu.ecep.base_app.calendario.presentation.dto.PeriodoEscolarCreateDTO;
-import edu.ecep.base_app.calendario.presentation.dto.PeriodoEscolarDTO;
 import edu.ecep.base_app.calendario.infrastructure.mapper.PeriodoEscolarMapper;
 import edu.ecep.base_app.calendario.infrastructure.persistence.PeriodoEscolarRepository;
+import edu.ecep.base_app.calendario.presentation.dto.PeriodoEscolarCreateDTO;
+import edu.ecep.base_app.calendario.presentation.dto.PeriodoEscolarDTO;
 import edu.ecep.base_app.shared.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -15,23 +15,52 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class PeriodoEscolarService {
-    private final PeriodoEscolarRepository repo; private final PeriodoEscolarMapper mapper;
-    public List<PeriodoEscolarDTO> findAll(){ return repo.findAll(Sort.by("anio")).stream().map(mapper::toDto).toList(); }
-    public PeriodoEscolarDTO get(Long id){ return repo.findById(id).map(mapper::toDto).orElseThrow(() -> new NotFoundException("No encontrado")); }
-    public Long create(PeriodoEscolarCreateDTO dto){ if(repo.existsByAnio(dto.getAnio())) throw new IllegalArgumentException("Ya existe periodo para ese año"); return repo.save(mapper.toEntity(dto)).getId(); }
+    private final PeriodoEscolarRepository repo;
+    private final PeriodoEscolarMapper mapper;
 
-    @Transactional
-    public void cerrar(Long id){
-        var periodo = repo.findById(id).orElseThrow(() -> new NotFoundException("No encontrado"));
-        periodo.setActivo(false);
-        repo.save(periodo);
+    public List<PeriodoEscolarDTO> findAll() {
+        return repo.findAll(Sort.by("anio"))
+                .stream()
+                .map(mapper::toDto)
+                .toList();
+    }
+
+    public PeriodoEscolarDTO get(Long id) {
+        return repo.findById(id)
+                .map(mapper::toDto)
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+    }
+
+    public Long create(PeriodoEscolarCreateDTO dto) {
+        if (repo.existsByAnio(dto.getAnio())) {
+            throw new IllegalArgumentException("Ya existe periodo para ese año");
+        }
+        var entity = mapper.toEntity(dto);
+        entity.setActivo(false);
+        return repo.save(entity).getId();
     }
 
     @Transactional
-    public void abrir(Long id){
-        var periodo = repo.findById(id).orElseThrow(() -> new NotFoundException("No encontrado"));
-        periodo.setActivo(true);
-        repo.save(periodo);
+    public void cerrar(Long id) {
+        var periodo = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+        if (periodo.isActivo()) {
+            periodo.setActivo(false);
+        }
+    }
+
+    @Transactional
+    public void abrir(Long id) {
+        var periodo = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+
+        repo.findByActivoTrue().stream()
+                .filter(p -> !p.getId().equals(periodo.getId()))
+                .forEach(p -> p.setActivo(false));
+
+        if (!periodo.isActivo()) {
+            periodo.setActivo(true);
+        }
     }
 }
 

--- a/backend-ecep/src/main/java/edu/ecep/base_app/calendario/infrastructure/persistence/PeriodoEscolarRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/calendario/infrastructure/persistence/PeriodoEscolarRepository.java
@@ -3,6 +3,9 @@ package edu.ecep.base_app.calendario.infrastructure.persistence;
 import edu.ecep.base_app.calendario.domain.PeriodoEscolar;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PeriodoEscolarRepository extends JpaRepository<PeriodoEscolar, Long> {
     boolean existsByAnio(Integer anio);
+    List<PeriodoEscolar> findByActivoTrue();
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/calendario/presentation/dto/PeriodoEscolarDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/calendario/presentation/dto/PeriodoEscolarDTO.java
@@ -17,4 +17,5 @@ public class PeriodoEscolarDTO {
     @NotNull
     @Min(2000)
     Integer anio;
+    Boolean activo;
 }

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
@@ -43,6 +43,7 @@ export default function VistaDireccion() {
     diasNoHabiles,
     secciones,
     refreshBase,
+    periodoEscolarId,
   } = useAsistenciasData();
 
   const [mes, setMes] = useState<string>(
@@ -90,8 +91,12 @@ export default function VistaDireccion() {
         toast.error("La fecha de inicio no puede ser posterior a la de fin");
         return;
       }
+      if (!periodoEscolarId) {
+        toast.error("No hay un período escolar activo disponible");
+        return;
+      }
       await calendario.trimestres.create({
-        periodoEscolarId: 1,
+        periodoEscolarId,
         orden: (trimestres.length % 3) + 1,
         fechaInicio: nuevoTrimestre.inicio,
         fechaFin: nuevoTrimestre.fin,
@@ -150,9 +155,23 @@ export default function VistaDireccion() {
           <CardDescription>Trimestres escolares</CardDescription>
         </CardHeader>
         <CardContent>
+          {!periodoEscolarId ? (
+            <p className="mb-3 text-sm text-muted-foreground">
+              Abrí un período escolar desde la configuración institucional para
+              gestionar los trimestres del ciclo en curso.
+            </p>
+          ) : null}
           <div className="flex justify-between mb-3">
             <div className="text-sm">Total: {trimestres.length}</div>
-            <Button onClick={() => setModalTri(true)}>
+            <Button
+              onClick={() => setModalTri(true)}
+              disabled={!periodoEscolarId}
+              title={
+                periodoEscolarId
+                  ? undefined
+                  : "Abrí un período escolar para crear trimestres"
+              }
+            >
               <Plus className="h-4 w-4 mr-2" />
               Nuevo Trimestre
             </Button>


### PR DESCRIPTION
## Summary
- enforce a single active período escolar by exposing the activo flag, defaulting new periods to inactive, and closing siblings when one is opened
- refresh the configuración dialog so dirección can review every período, toggle its estado with inline feedback, and see the active selection reflected everywhere
- make the active-period hook and asistencia/enrolment flows depend on the director’s selection so UI actions and data fetches respect the chosen ciclo lectivo

## Testing
- mvn test *(fails: unable to download Spring Boot parent POM from Maven Central due to network restrictions)*
- bun install *(fails: registry.npmjs.org requests return HTTP 403 in this environment)*
- bun run lint *(fails: Next.js binary not available because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b8fb972483279ed47eee09bc1e00