### PR TITLE
Unify pagination responses across identity endpoints

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/AlumnoController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/AlumnoController.java
@@ -1,12 +1,12 @@
 package edu.ecep.base_app.identidad.presentation.rest;
 
-import edu.ecep.base_app.identidad.presentation.dto.AlumnoDTO;
 import edu.ecep.base_app.identidad.application.AlumnoService;
+import edu.ecep.base_app.identidad.presentation.dto.AlumnoDTO;
+import edu.ecep.base_app.shared.web.PageResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -35,11 +35,11 @@ public class AlumnoController {
     }
 
     @GetMapping("/paginated")
-    public Page<AlumnoDTO> listPaged(
+    public PageResponse<AlumnoDTO> listPaged(
             @PageableDefault(size = 25) Pageable pageable,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) Long seccionId) {
-        return service.findPaged(pageable, search, seccionId);
+        return PageResponse.from(service.findPaged(pageable, search, seccionId));
     }
 
     @GetMapping("/{id}")

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/EmpleadoController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/EmpleadoController.java
@@ -5,9 +5,9 @@ import edu.ecep.base_app.identidad.domain.enums.RolEmpleado;
 import edu.ecep.base_app.identidad.presentation.dto.EmpleadoCreateDTO;
 import edu.ecep.base_app.identidad.presentation.dto.EmpleadoDTO;
 import edu.ecep.base_app.identidad.presentation.dto.EmpleadoUpdateDTO;
+import edu.ecep.base_app.shared.web.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -21,12 +21,12 @@ public class EmpleadoController {
     private final EmpleadoService service;
 
     @GetMapping
-    public Page<EmpleadoDTO> list(
+    public PageResponse<EmpleadoDTO> list(
             @RequestParam(value = "search", required = false) String search,
             @RequestParam(value = "rolEmpleado", required = false) RolEmpleado rolEmpleado,
             @PageableDefault(size = 20, sort = "id") Pageable pageable
     ) {
-        return service.findAll(search, rolEmpleado, pageable);
+        return PageResponse.from(service.findAll(search, rolEmpleado, pageable));
     }
     @GetMapping("/{id}") public EmpleadoDTO get(@PathVariable Long id){ return service.get(id); }
     @PostMapping public ResponseEntity<EmpleadoDTO> create(@RequestBody @Valid EmpleadoCreateDTO dto){ return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED); }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/web/PageResponse.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/web/PageResponse.java
@@ -1,0 +1,75 @@
+package edu.ecep.base_app.shared.web;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Simplified pagination payload to keep the contract consistent across endpoints.
+ * Mirrors the default Spring Data page structure so the frontend can
+ * consume a uniform shape without depending on the JPA specific Page implementation.
+ */
+public record PageResponse<T>(
+        List<T> content,
+        long totalElements,
+        int totalPages,
+        int size,
+        int number,
+        boolean first,
+        boolean last,
+        int numberOfElements,
+        boolean empty,
+        SortMetadata sort,
+        PageableMetadata pageable
+) {
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        SortMetadata sortMetadata = SortMetadata.from(page.getSort());
+        PageableMetadata pageableMetadata = PageableMetadata.from(page, sortMetadata);
+        return new PageResponse<>(
+                page.getContent(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getSize(),
+                page.getNumber(),
+                page.isFirst(),
+                page.isLast(),
+                page.getNumberOfElements(),
+                page.isEmpty(),
+                sortMetadata,
+                pageableMetadata
+        );
+    }
+
+    /** Lightweight representation of Spring's sort metadata. */
+    public record SortMetadata(boolean empty, boolean sorted, boolean unsorted) {
+        private static SortMetadata from(Sort sort) {
+            if (sort == null) {
+                return new SortMetadata(true, false, true);
+            }
+            boolean isEmpty = sort.isEmpty();
+            boolean isUnsorted = sort.isUnsorted();
+            boolean isSorted = !isUnsorted;
+            return new SortMetadata(isEmpty, isSorted, isUnsorted);
+        }
+    }
+
+    /** Metadata compatible with the default Spring "pageable" payload. */
+    public record PageableMetadata(
+            SortMetadata sort,
+            long offset,
+            int pageNumber,
+            int pageSize,
+            boolean paged,
+            boolean unpaged
+    ) {
+        private static PageableMetadata from(Page<?> page, SortMetadata sortMetadata) {
+            int currentSize = page.getSize();
+            int currentNumber = page.getNumber();
+            long offset = (long) currentNumber * currentSize;
+            boolean paged = currentSize != Integer.MAX_VALUE;
+            boolean unpaged = !paged;
+            return new PageableMetadata(sortMetadata, offset, currentNumber, currentSize, paged, unpaged);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `PageResponse` record that mirrors Spring's page payload so pagination responses have a single, reusable shape
- update the empleado and alumno controllers to return the new `PageResponse`, giving both endpoints the same pagination contract

## Testing
- `./mvnw -q test` *(fails: Maven wrapper could not download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c33319488327857a3c955de7567c