### PR TITLE
Fix empleados pagination handling and alumno search sort

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/persistence/AlumnoRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/persistence/AlumnoRepository.java
@@ -43,9 +43,6 @@ public interface AlumnoRepository extends JpaRepository<Alumno, Long> {
                     or lower(p.apellido) like :search
                     or lower(p.dni) like :search
               )
-            order by lower(coalesce(p.apellido, '')),
-                     lower(coalesce(p.nombre, '')),
-                     a.id
             """)
     Page<Alumno> searchPaged(
             @Param("search") String search,

--- a/frontend-ecep/src/app/dashboard/actas/_components/EditActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/EditActaDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { identidad, vidaEscolar } from "@/services/api/modules";
+import { pageContent } from "@/lib/page-response";
 import type {
   ActaAccidenteDTO,
   EstadoActaAccidente,
@@ -62,7 +63,8 @@ export default function EditActaDialog({
     (async () => {
       try {
         setLoading(true);
-        const pers = (await identidad.empleados.list()).data ?? [];
+        const persRes = await identidad.empleados.list();
+        const pers = pageContent<EmpleadoDTO>(persRes.data);
         if (!alive) return;
 
         // Prefetch de personas para mostrar nombres correctos

--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -40,6 +40,7 @@ import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { toast } from "sonner";
 import { useScopedIndex } from "@/hooks/scope/useScopedIndex";
+import { pageContent } from "@/lib/page-response";
 import FamilyActasView from "@/app/dashboard/actas/_components/FamilyActasView";
 
 import NewActaDialog from "./_components/NewActaDialog";
@@ -177,7 +178,7 @@ export default function AccidentesIndexPage() {
         );
         setActas(actasRes.data ?? []);
         setSecciones(secs);
-        setPersonal(personalRes.data ?? []);
+        setPersonal(pageContent<EmpleadoDTO>(personalRes.data));
       } finally {
         if (alive) setLoading(false);
       }

--- a/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
   identidad,
   vidaEscolar,
 } from "@/services/api/modules";
+import { pageContent } from "@/lib/page-response";
 import type {
   ActaAccidenteDTO,
   AlumnoLiteDTO,
@@ -150,7 +151,9 @@ export default function AccidentesSeccionPage() {
           gestionAcademica.asignacionDocenteSeccion
             .list()
             .then((r) => r.data ?? []),
-          identidad.empleados.list().then((r) => r.data ?? []),
+          identidad.empleados
+            .list()
+            .then((r) => pageContent<PersonalDTO>(r.data)),
         ]);
         if (!alive) return;
         setAsignaciones(asigs);

--- a/frontend-ecep/src/app/dashboard/chat/page.tsx
+++ b/frontend-ecep/src/app/dashboard/chat/page.tsx
@@ -247,32 +247,6 @@ export default function ChatComponent() {
   }, [activeChats, refreshOnlineStatus]);
 
   useEffect(() => {
-    const personaIdParam = searchParams?.get("personaId");
-    if (!personaIdParam) return;
-    const parsed = Number.parseInt(personaIdParam, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) return;
-    if (selectedUserId === parsed) return;
-
-    let cancelled = false;
-
-    (async () => {
-      try {
-        const { data } = await identidad.personasCore.getResumen(parsed);
-        if (!data || cancelled) return;
-        await openChat(data);
-      } catch (error) {
-        if (process.env.NODE_ENV === "development") {
-          console.error("No se pudo abrir el chat solicitado", error);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [searchParams, selectedUserId, openChat]);
-
-  useEffect(() => {
     const previousTarget = typingStateRef.current.targetId;
     if (
       previousTarget &&
@@ -314,6 +288,32 @@ export default function ChatComponent() {
     },
     [loadHistory, markRead, refreshOnlineStatus],
   );
+
+  useEffect(() => {
+    const personaIdParam = searchParams?.get("personaId");
+    if (!personaIdParam) return;
+    const parsed = Number.parseInt(personaIdParam, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    if (selectedUserId === parsed) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const { data } = await identidad.personasCore.getResumen(parsed);
+        if (!data || cancelled) return;
+        await openChat(data);
+      } catch (error) {
+        if (process.env.NODE_ENV === "development") {
+          console.error("No se pudo abrir el chat solicitado", error);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams, selectedUserId, openChat]);
 
   const finalizeTyping = () => {
     if (typingTimeoutRef.current) {

--- a/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { gestionAcademica, identidad } from "@/services/api/modules";
+import { pageContent } from "@/lib/page-response";
 import type {
   AlumnoLiteDTO,
   EmpleadoDTO,
@@ -175,7 +176,7 @@ export default function FamilyMateriasView({
           if (mat.id != null) materiaNombreById.set(mat.id, mat.nombre ?? "");
         }
 
-        const empleados = empleadosRes.data ?? [];
+        const empleados = pageContent<EmpleadoDTO>(empleadosRes.data);
         const empleadoById = new Map<number, EmpleadoDTO>();
         const personaIds = new Set<number>();
         for (const emp of empleados) {

--- a/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Plus, UserPlus } from "lucide-react";
 import { gestionAcademica, identidad } from "@/services/api/modules";
+import { pageContent } from "@/lib/page-response";
 import type {
   SeccionDTO,
   SeccionMateriaDTO,
@@ -209,7 +210,7 @@ export default function MateriasSeccionPage() {
           })
           .filter((a): a is Asignacion => !!a && smIds.has(a.seccionMateriaId));
 
-        const empleados = (empRes.data ?? []) as any[];
+        const empleados = pageContent<any>(empRes.data);
         const personaIds = Array.from(
           new Set(empleados.map((e) => e.personaId).filter(Boolean)),
         ) as number[];

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
+import { pageContent } from "@/lib/page-response";
 import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { LicenseSummaryCards } from "./_components/LicenseSummaryCards";
@@ -836,7 +837,7 @@ export default function ReportesPage() {
       try {
         const res = await identidad.empleados.list();
         if (!alive) return;
-        const empleados = (res.data ?? []) as EmpleadoDTO[];
+        const empleados = pageContent<EmpleadoDTO>(res.data);
         const personaIds = Array.from(
           new Set<number>(empleados.map((emp: any) => emp.personaId).filter(Boolean)),
         );

--- a/frontend-ecep/src/lib/page-response.ts
+++ b/frontend-ecep/src/lib/page-response.ts
@@ -1,0 +1,22 @@
+import type { PageResponse } from "@/types/pagination";
+
+type PageLike<T> = PageResponse<T> | { content?: T[] } | T[] | null | undefined;
+
+export function pageContent<T>(data: PageLike<T>): T[] {
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  if (data && typeof data === "object") {
+    const maybeContent = (data as PageResponse<T>).content;
+    if (Array.isArray(maybeContent)) {
+      return maybeContent;
+    }
+  }
+
+  return [];
+}
+
+export function hasPageContent<T>(data: PageLike<T>): data is PageResponse<T> {
+  return !!data && typeof data === "object" && Array.isArray((data as PageResponse<T>).content);
+}


### PR DESCRIPTION
## Summary
- normalize employee fetches across dashboard pages using a shared pageContent helper to avoid treating paginated responses as arrays
- fix the chat page effect ordering so the openChat callback is defined before use
- adjust alumno paginated search to apply default sorting in the service while removing the problematic ORDER BY clause from the query

## Testing
- ⚠️ `npm install` *(fails: registry access returns HTTP 403 in this environment)*
- ⚠️ `./mvnw test` *(fails: Maven distribution download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c7f21960832780bbd2f9ae34ad40