### PR TITLE
Prevent repeated access dialog resets on personal page

### DIFF
--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -558,11 +558,23 @@ export default function PersonalPage() {
   useEffect(() => {
     if (!accessDialogOpen) {
       setActiveAccess(null);
-      setAccessForm({
-        email: "",
-        password: "",
-        confirmPassword: "",
-        roles: [],
+      setAccessForm((prev) => {
+        const isAlreadyPristine =
+          prev.email === "" &&
+          prev.password === "" &&
+          prev.confirmPassword === "" &&
+          prev.roles.length === 0;
+
+        if (isAlreadyPristine) {
+          return prev;
+        }
+
+        return {
+          email: "",
+          password: "",
+          confirmPassword: "",
+          roles: [],
+        };
       });
       setSavingAccess(false);
       return;
@@ -572,12 +584,26 @@ export default function PersonalPage() {
       activeAccess?.empleado ?? null,
       activeAccess?.persona ?? null,
     );
+    const normalizedRoles = normalizeRoles(suggestedRoles);
+    const email = activeAccess?.persona?.email ?? "";
 
-    setAccessForm({
-      email: activeAccess?.persona?.email ?? "",
-      password: "",
-      confirmPassword: "",
-      roles: normalizeRoles(suggestedRoles),
+    setAccessForm((prev) => {
+      const hasSameEmail = prev.email === email;
+      const hasEmptyPasswords = prev.password === "" && prev.confirmPassword === "";
+      const hasSameRoles =
+        prev.roles.length === normalizedRoles.length &&
+        prev.roles.every((role, index) => role === normalizedRoles[index]);
+
+      if (hasSameEmail && hasEmptyPasswords && hasSameRoles) {
+        return prev;
+      }
+
+      return {
+        email,
+        password: "",
+        confirmPassword: "",
+        roles: normalizedRoles,
+      };
     });
   }, [accessDialogOpen, activeAccess]);
 


### PR DESCRIPTION
## Summary
- avoid resetting the access dialog form state on every render when the dialog is closed
- reuse the existing email and normalized roles when opening the dialog to prevent redundant updates

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cd43b28883279f5ed7c1058f7885