### PR TITLE
Fix employee list mapping in pagos page

### DIFF
--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -62,6 +62,7 @@ import {
   vidaEscolar,
 } from "@/services/api/modules";
 import { normalizeRole } from "@/lib/auth-roles";
+import { pageContent } from "@/lib/page-response";
 import type {
   AlumnoDTO,
   AlumnoLiteDTO,
@@ -319,7 +320,7 @@ export default function PagosPage() {
     if (!shouldLoadEmpleados) return;
     identidad.empleados
       .list()
-      .then((res) => setEmpleados(res.data ?? []))
+      .then((res) => setEmpleados(pageContent<EmpleadoDTO>(res.data)))
       .catch(() => setEmpleados([]));
   }, [shouldLoadEmpleados]);
 


### PR DESCRIPTION
## Summary
- load employees in the payments dashboard using the pageContent helper so the state always stores an array
- import the shared page response utility to avoid runtime errors when filtering receipts for the current employee

## Testing
- npm run lint *(fails: `next` command not found because dependencies are unavailable without installing packages)*
- npm install *(fails: registry returned 403 Forbidden for @hookform/resolvers)*

------
https://chatgpt.com/codex/tasks/task_e_68d304141bfc83279cc712c542e7ff1a