### PR TITLE
Update card hover styles to use primary border highlight

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/_components/FamilyView.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/FamilyView.tsx
@@ -41,7 +41,7 @@ export default function FamilyView({
           return (
             <Card
               key={`${hijo.matriculaId}-${hijo.alumnoId}`}
-              className="hover:shadow-md transition-shadow"
+              className="transition-colors hover:border-primary"
             >
               <CardHeader className="pb-3 space-y-2">
                 <CardTitle className="text-lg">{hijo.nombreCompleto}</CardTitle>

--- a/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
@@ -61,7 +61,7 @@ export default function SeccionAlumnosPage() {
             {alumnos.map((a) => (
               <Card
                 key={a.matriculaId ?? `${a.alumnoId}-mat`}
-                className="hover:shadow-md transition-shadow"
+                className="transition-colors hover:border-primary"
               >
                 <CardHeader className="pb-3">
                   <div className="flex items-center justify-between">

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDocente.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDocente.tsx
@@ -149,7 +149,7 @@ export default function VistaDocente() {
           const promedio = 100; // placeholder si no abriste historial
 
           return (
-            <Card key={sec.id} className="hover:shadow-md transition-shadow">
+            <Card key={sec.id} className="transition-colors hover:border-primary">
               <CardHeader className="pb-3">
                 <div className="flex items-center justify-between">
                   <CardTitle className="text-lg">

--- a/frontend-ecep/src/app/dashboard/asistencia/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/page.tsx
@@ -178,7 +178,7 @@ function TeacherView() {
         const turnoLabel = formatTurnoLabel(seccion.turno);
 
         return (
-          <Card key={seccion.id} className="hover:shadow-md transition-shadow">
+          <Card key={seccion.id} className="transition-colors hover:border-primary">
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <CardTitle className="text-lg">

--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -159,7 +159,7 @@ export default function CalificacionesIndexPage() {
                 {primario.map((seccion) => (
                   <Card
                     key={seccion.id}
-                    className="cursor-pointer transition-shadow hover:border-primary/60 hover:shadow-md"
+                    className="cursor-pointer transition-colors hover:border-primary"
                     onClick={() =>
                       router.push(`/dashboard/calificaciones/seccion/${seccion.id}`)
                     }
@@ -195,7 +195,7 @@ export default function CalificacionesIndexPage() {
                 {inicial.map((seccion) => (
                   <Card
                     key={seccion.id}
-                    className="cursor-pointer transition-shadow hover:border-primary/60 hover:shadow-md"
+                    className="cursor-pointer transition-colors hover:border-primary"
                     onClick={() =>
                       router.push(`/dashboard/calificaciones/seccion/${seccion.id}`)
                     }

--- a/frontend-ecep/src/app/dashboard/comunicados/page.tsx
+++ b/frontend-ecep/src/app/dashboard/comunicados/page.tsx
@@ -431,7 +431,7 @@ function FeedList({
       {items.map((c) => {
         const fecha = fechaVisible(c);
         return (
-          <Card key={c.id} className="hover:shadow-sm transition">
+          <Card key={c.id} className="transition-colors hover:border-primary">
             <CardHeader>
               <div className="flex items-start justify-between gap-4">
                 <div className="space-y-1">

--- a/frontend-ecep/src/app/dashboard/materias/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/page.tsx
@@ -146,7 +146,7 @@ export default function MateriasPage() {
               return (
                 <Card
                   key={s.id}
-                  className="cursor-pointer transition-shadow hover:border-primary/60 hover:shadow-md"
+                  className="cursor-pointer transition-colors hover:border-primary"
                   onClick={() => router.push(`/dashboard/materias/seccion/${s.id}`)}
                 >
                   <CardHeader className="pb-3">

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -1522,7 +1522,7 @@ export default function ReportesPage() {
                     {boletinStudents.map((student) => (
                       <Card
                         key={student.id}
-                        className="cursor-pointer transition hover:shadow-md"
+                        className="cursor-pointer transition-colors hover:border-primary"
                         onClick={() => setActiveBoletin(student)}
                       >
                         <CardHeader className="space-y-1">


### PR DESCRIPTION
## Summary
- replace hover shadow effects on dashboard cards with a primary-colored border when hovering to match the requested design

## Testing
- npm install *(fails: 403 Forbidden fetching @hookform/resolvers)*

------
https://chatgpt.com/codex/tasks/task_e_68d3075f4f248327b66fe169e38ddd10