### PR TITLE
Optimize personal page data loading

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/PersonaController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/PersonaController.java
@@ -24,9 +24,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/personas")
@@ -41,6 +44,19 @@ public class PersonaController {
     private final AspiranteRepository aspiranteRepository;
     private final PersonaMapper personaMapper;
     private final PasswordEncoder passwordEncoder;
+
+    @GetMapping
+    public ResponseEntity<List<PersonaDTO>> findAllById(@RequestParam(name = "ids", required = false) List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return ResponseEntity.ok(List.of());
+        }
+
+        List<PersonaDTO> personas = personaRepository.findAllById(ids).stream()
+                .map(personaMapper::toDto)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(personas);
+    }
 
     @GetMapping("/{personaId}")
     public ResponseEntity<PersonaDTO> get(@PathVariable Long personaId) {

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -681,21 +681,27 @@ export default function PersonalPage() {
         ),
       );
 
-      const personaEntries = await Promise.all(
-        personaIds.map(async (id) => {
-          try {
-            const res = await identidad.personasCore.getById(id);
-            return [id, res.data ?? null] as const;
-          } catch (error) {
-            console.error("No se pudo obtener la persona", id, error);
-            return [id, null] as const;
-          }
-        }),
-      );
+      const personaMap = new Map<number, PersonaDTO | null>();
+      if (personaIds.length > 0) {
+        const personas = await safeRequest<PersonaDTO[]>(
+          identidad.personasCore.getManyById(personaIds),
+          [] as PersonaDTO[],
+          "No se pudo obtener la información personal",
+        );
 
-      const personaMap = new Map<number, PersonaDTO | null>(
-        personaEntries as Array<readonly [number, PersonaDTO | null]>,
-      );
+        personas.forEach((persona) => {
+          const personaId = persona?.id;
+          if (typeof personaId === "number") {
+            personaMap.set(personaId, persona);
+          }
+        });
+
+        personaIds.forEach((id) => {
+          if (!personaMap.has(id)) {
+            personaMap.set(id, null);
+          }
+        });
+      }
 
       const seccionMap = new Map<number, SeccionDTO>();
       for (const seccion of secciones) {

--- a/frontend-ecep/src/services/api/modules/identidad/personas-core.ts
+++ b/frontend-ecep/src/services/api/modules/identidad/personas-core.ts
@@ -5,6 +5,10 @@ import type * as DTO from "@/types/api-generated";
 export const personasCore = {
   findIdByDni: (dni: string) => http.get<number>(`/api/personas/dni/${dni}`),
   create: (body: DTO.PersonaCreateDTO) => http.post<number>(`/api/personas`, body),
+  getManyById: (ids: number[]) =>
+    http.get<DTO.PersonaDTO[]>(`/api/personas`, {
+      params: { ids: ids.join(",") },
+    }),
   getById: (id: number) => http.get<DTO.PersonaDTO>(`/api/personas/${id}`),
   update: (id: number, patch: Partial<DTO.PersonaUpdateDTO>) =>
     http.put<void>(`/api/personas/${id}`, patch),


### PR DESCRIPTION
## Summary
- add a bulk persona lookup endpoint to the backend so multiple personas can be fetched with a single request
- update the personal dashboard page to request persona data in one batch and avoid dozens of sequential requests
- expose a helper in the frontend API client for the new bulk persona request

## Testing
- `./mvnw test` *(fails: Maven distribution download blocked in the execution environment)*
- `npm install` *(fails: npm registry returns HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d34b53bd0c8327b323d42a30a69b73