### PR TITLE
Fix loading behaviour on dashboard personal page

### DIFF
--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -870,8 +870,12 @@ export default function PersonalPage() {
   );
 
   useEffect(() => {
+    if (loading || !user) {
+      return;
+    }
+
     refreshData({ search: debouncedSearchTerm, page: 1 });
-  }, [debouncedSearchTerm, refreshData]);
+  }, [loading, user, debouncedSearchTerm, refreshData]);
 
   useEffect(() => {
     setCurrentPage(1);


### PR DESCRIPTION
## Summary
- avoid triggering personal data refresh until the authenticated user is ready
- prevent the personal dashboard view from staying stuck in the loading state after navigation from other sections

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3564551708327b8fcbabd020f6459