### PR TITLE
Ensure personal page refresh updates run in dev

### DIFF
--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -399,11 +399,12 @@ function isLicenseActiveOn(licencia: LicenciaDTO, referenceIso: string) {
 export default function PersonalPage() {
   const { loading, user, hasRole } = useAuth();
   const router = useRouter();
-  const mountedRef = useRef(true);
+  const mountedRef = useRef(false);
   const searchRef = useRef<string>("");
   const currentPageRef = useRef(1);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };
@@ -870,8 +871,12 @@ export default function PersonalPage() {
   );
 
   useEffect(() => {
+    if (loading || !user) {
+      return;
+    }
+
     refreshData({ search: debouncedSearchTerm, page: 1 });
-  }, [debouncedSearchTerm, refreshData]);
+  }, [loading, user, debouncedSearchTerm, refreshData]);
 
   useEffect(() => {
     setCurrentPage(1);


### PR DESCRIPTION
## Summary
- reset the personal page mounted flag on every mount so state updates are not skipped in strict-mode renders

## Testing
- npm run lint *(fails: missing Next.js binary because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d3564551708327b8fcbabd020f6459