### PR TITLE
Allow admins to view personal menu

### DIFF
--- a/frontend-ecep/src/lib/menu.ts
+++ b/frontend-ecep/src/lib/menu.ts
@@ -85,7 +85,7 @@ export const MENU: MenuItem[] = [
     icon: UserCheck,
     label: "Personal",
     href: "/dashboard/personal",
-    roles: [UserRole.DIRECTOR, UserRole.SECRETARY],
+    roles: [UserRole.DIRECTOR, UserRole.ADMIN, UserRole.SECRETARY],
     color: "bg-teal-500",
     group: "third",
   },


### PR DESCRIPTION
## Summary
- allow administrators to see the Personal dashboard card by adding the ADMIN role to its menu entry

## Testing
- npm install --package-lock=false *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e660e85883278d8da0e029039cb8