### PR TITLE
Add profile photo upload support for personas

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/PersonaPhotoStorageService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/PersonaPhotoStorageService.java
@@ -1,0 +1,109 @@
+package edu.ecep.base_app.identidad.application;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class PersonaPhotoStorageService {
+
+    private static final long MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2 MB
+    private static final String SIZE_ERROR_MESSAGE = "La imagen de perfil supera el tamaño máximo de 2 MB";
+    private static final String FORMAT_ERROR_MESSAGE = "Formato de imagen no soportado. Permitidos: JPG, PNG o WEBP";
+    private static final Map<String, String> CONTENT_TYPE_EXTENSION = Map.of(
+            "image/jpeg", ".jpg",
+            "image/png", ".png",
+            "image/webp", ".webp"
+    );
+
+    private final Path rootLocation;
+    private final Path personasLocation;
+
+    public PersonaPhotoStorageService(
+            @Value("${app.storage.root:storage}") String rootDir,
+            @Value("${app.storage.personas-subdir:personas}") String personasSubdir
+    ) {
+        this.rootLocation = Paths.get(rootDir).toAbsolutePath().normalize();
+        this.personasLocation = this.rootLocation.resolve(personasSubdir).normalize();
+        try {
+            Files.createDirectories(this.personasLocation);
+        } catch (IOException e) {
+            throw new IllegalStateException("No se pudo inicializar el almacenamiento de fotos de personas", e);
+        }
+    }
+
+    public StoredPhoto store(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("Seleccioná un archivo de imagen para continuar");
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+            throw new IllegalArgumentException(SIZE_ERROR_MESSAGE);
+        }
+
+        String extension = resolveExtension(file);
+        if (extension == null) {
+            throw new IllegalArgumentException(FORMAT_ERROR_MESSAGE);
+        }
+
+        String filename = UUID.randomUUID() + extension;
+        Path destinationFile = personasLocation.resolve(filename).normalize();
+        if (!destinationFile.getParent().equals(personasLocation)) {
+            throw new IllegalArgumentException("Ruta de almacenamiento inválida");
+        }
+
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, destinationFile, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new IllegalStateException("No se pudo guardar la imagen de perfil", e);
+        }
+
+        String relativePath = rootLocation.relativize(destinationFile).toString()
+                .replace(File.separatorChar, '/');
+
+        return new StoredPhoto(filename, relativePath, file.getSize());
+    }
+
+    private String resolveExtension(MultipartFile file) {
+        String contentType = Optional.ofNullable(file.getContentType())
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .orElse("");
+
+        String extension = CONTENT_TYPE_EXTENSION.get(contentType);
+        if (extension != null) {
+            return extension;
+        }
+
+        String originalName = Optional.ofNullable(file.getOriginalFilename())
+                .map(StringUtils::cleanPath)
+                .orElse("")
+                .toLowerCase(Locale.ROOT);
+
+        if (originalName.endsWith(".jpg") || originalName.endsWith(".jpeg")) {
+            return ".jpg";
+        }
+        if (originalName.endsWith(".png")) {
+            return ".png";
+        }
+        if (originalName.endsWith(".webp")) {
+            return ".webp";
+        }
+        return null;
+    }
+
+    public record StoredPhoto(String fileName, String relativePath, long size) {
+    }
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Persona.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Persona.java
@@ -55,6 +55,7 @@ public class Persona extends BaseEntity {
     @Email
     private String emailContacto;
 
+    @Column(length = 1024)
     private String fotoPerfilUrl;
 
     /** Contraseña codificada (BCrypt). */

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/FotoPerfilUploadResponse.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/FotoPerfilUploadResponse.java
@@ -1,0 +1,8 @@
+package edu.ecep.base_app.identidad.presentation.dto;
+
+public record FotoPerfilUploadResponse(
+        String url,
+        String fileName,
+        long size
+) {
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/PersonaCreateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/PersonaCreateDTO.java
@@ -4,6 +4,7 @@ import edu.ecep.base_app.identidad.domain.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,8 @@ public class PersonaCreateDTO {
     private String celular;
     @Email
     private String email;
+    @Size(max = 1024, message = "La URL de la foto no puede superar los 1024 caracteres")
+    private String fotoPerfilUrl;
     private String password;
     private Set<UserRole> roles;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/PersonaDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/PersonaDTO.java
@@ -32,6 +32,7 @@ public class PersonaDTO {
     private String telefono;
     private String celular;
     private String email;
+    private String fotoPerfilUrl;
     private Set<UserRole> roles;
     private boolean credencialesActivas;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/PersonaUpdateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/PersonaUpdateDTO.java
@@ -2,6 +2,7 @@ package edu.ecep.base_app.identidad.presentation.dto;
 
 import edu.ecep.base_app.identidad.domain.enums.UserRole;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,6 +28,8 @@ public class PersonaUpdateDTO {
     private String telefono;
     private String celular;
     private String email;
+    @Size(max = 1024, message = "La URL de la foto no puede superar los 1024 caracteres")
+    private String fotoPerfilUrl;
     private String password;
     private Set<UserRole> roles;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/config/MediaResourceConfig.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/config/MediaResourceConfig.java
@@ -1,0 +1,29 @@
+package edu.ecep.base_app.shared.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class MediaResourceConfig implements WebMvcConfigurer {
+
+    private final Path storageRoot;
+
+    public MediaResourceConfig(@Value("${app.storage.root:storage}") String storageRoot) {
+        this.storageRoot = Paths.get(storageRoot).toAbsolutePath().normalize();
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String location = storageRoot.toUri().toString();
+        registry.addResourceHandler("/media/**")
+                .addResourceLocations(location)
+                .setCacheControl(CacheControl.maxAge(30, TimeUnit.DAYS).cachePublic());
+    }
+}

--- a/frontend-ecep/src/services/api/modules/identidad/personas-core.ts
+++ b/frontend-ecep/src/services/api/modules/identidad/personas-core.ts
@@ -5,6 +5,13 @@ import type * as DTO from "@/types/api-generated";
 export const personasCore = {
   findIdByDni: (dni: string) => http.get<number>(`/api/personas/dni/${dni}`),
   create: (body: DTO.PersonaCreateDTO) => http.post<number>(`/api/personas`, body),
+  uploadPhoto: (file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    return http.post<DTO.PersonaFotoUploadResponse>(`/api/personas/foto`, formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+  },
   getManyById: (ids: number[]) =>
     http.get<DTO.PersonaDTO[]>(`/api/personas`, {
       params: { ids: ids.join(",") },

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -622,6 +622,7 @@ export interface PersonaDTO {
   telefono?: string;
   celular?: string;
   email?: string;
+  fotoPerfilUrl?: string;
   observacionesGenerales?: string;
   roles?: UserRole[];
   credencialesActivas?: boolean;
@@ -639,6 +640,7 @@ export interface PersonaCreateDTO {
   telefono?: string;
   celular?: string;
   email?: string;
+  fotoPerfilUrl?: string;
   password?: string;
   roles?: UserRole[];
 }
@@ -657,9 +659,16 @@ export interface PersonaUpdateDTO {
   telefono?: string;
   celular?: string;
   email?: string;
+  fotoPerfilUrl?: string;
   observacionesGenerales?: string;
   password?: string;
   roles?: UserRole[];
+}
+
+export interface PersonaFotoUploadResponse {
+  url: string;
+  fileName: string;
+  size: number;
 }
 
 export interface ReciboSueldoCreateDTO {


### PR DESCRIPTION
## Summary
- expose `fotoPerfilUrl` across persona DTOs and persist it through the persona controller
- add local media storage with a multipart upload endpoint and static resource handler
- enable profile photo upload/URL management in the staff dashboard with previews and validation, and show avatars from stored URLs

## Testing
- `./mvnw test` *(fails: Maven wrapper could not download dependencies in the sandbox)*
- `npm run lint` *(fails: Next.js dependencies are unavailable because npm install is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e68bd6688327a2ce6730bb1908bc