### PR TITLE
feat: completar familiares existentes en postulaciones

### DIFF
--- a/frontend-ecep/src/app/postulacion/ExistingFamiliarDialog.tsx
+++ b/frontend-ecep/src/app/postulacion/ExistingFamiliarDialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { AlertCircle, Loader2 } from "lucide-react";
+import type * as DTO from "@/types/api-generated";
+
+interface Props {
+  open: boolean;
+  persona?: DTO.PersonaDTO | null;
+  dni?: string;
+  loading?: boolean;
+  error?: string | null;
+  onConfirm: (email: string, password: string) => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export function ExistingFamiliarDialog({
+  open,
+  persona,
+  dni,
+  loading,
+  error,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setEmail(persona?.email ?? "");
+      setPassword("");
+    }
+  }, [open, persona?.email]);
+
+  const submit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (loading) return;
+    await onConfirm(email.trim(), password);
+  };
+
+  const cancel = () => {
+    if (loading) return;
+    onCancel();
+  };
+
+  const fullName = [persona?.nombre, persona?.apellido].filter(Boolean).join(" ");
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (!v ? cancel() : undefined)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Confirmá tu identidad</DialogTitle>
+          <DialogDescription>
+            {fullName
+              ? `Encontramos un familiar registrado como ${fullName}.`
+              : "Encontramos un familiar registrado."}{" "}
+            Ingresá el usuario y la contraseña asociados para completar los datos
+            automáticamente.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={submit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="existing-familiar-email">Usuario (email)</Label>
+            <Input
+              id="existing-familiar-email"
+              type="email"
+              required
+              value={email}
+              autoComplete="email"
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="correo@ejemplo.com"
+              disabled={loading}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="existing-familiar-password">Contraseña</Label>
+            <Input
+              id="existing-familiar-password"
+              type="password"
+              required
+              value={password}
+              autoComplete="current-password"
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              disabled={loading}
+            />
+          </div>
+
+          {dni ? (
+            <p className="text-xs text-muted-foreground">
+              DNI detectado: <span className="font-medium">{dni}</span>
+            </p>
+          ) : null}
+
+          {error ? (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle className="mt-0.5 h-4 w-4" />
+              <span>{error}</span>
+            </div>
+          ) : null}
+
+          <DialogFooter className="pt-2">
+            <Button type="button" variant="outline" onClick={cancel} disabled={loading}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Verificando
+                </>
+              ) : (
+                "Confirmar"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Resumen
- Guarda un resumen de la postulación en la solicitud creada.
- Detecta cuando el DNI de un familiar ya existe y pide sus credenciales.
- Completa automáticamente los datos del familiar validado y continúa el flujo.

## Pruebas
- `pnpm lint` *(falla: faltan dependencias, el registro npm devuelve 403 en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d432c744888327ac22496b8514e421