### PR TITLE
Improve mobile responsiveness across UI

### DIFF
--- a/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
+++ b/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
@@ -131,7 +131,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           </div>
 
           {/* MENÚ por grupos + separador entre grupos */}
-          <div className="flex-1 px-4 lg:pr-0 lg:pl-4 space-y-4 flex justify-center items-center">
+          <div className="flex-1 px-4 lg:pr-0 lg:pl-4 py-4 overflow-y-auto">
             <nav className="space-y-1">
               {groupedMenu.map(([groupKey, items], groupIndex) => (
                 <div key={groupKey} className="space-y-1">

--- a/frontend-ecep/src/app/dashboard/page.tsx
+++ b/frontend-ecep/src/app/dashboard/page.tsx
@@ -59,7 +59,7 @@ export default function DashboardPage() {
     <DashboardLayout>
       <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
         {/* Header */}
-        <div className="flex items-center justify-between space-y-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">Dashboard</h2>
             <p className="text-muted-foreground">

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -1454,12 +1454,22 @@ export default function ReportesPage() {
         </div>
 
         <Tabs value={tab} onValueChange={setTab} className="space-y-5">
-          <TabsList className="grid w-full grid-cols-5">
-            <TabsTrigger value="boletines">Boletines</TabsTrigger>
-            <TabsTrigger value="aprobacion">Aprobación</TabsTrigger>
-            <TabsTrigger value="asistencias">Asistencias</TabsTrigger>
-            <TabsTrigger value="licencias">Licencias</TabsTrigger>
-            <TabsTrigger value="actas">Actas</TabsTrigger>
+          <TabsList className="w-full h-auto flex-wrap gap-2">
+            <TabsTrigger value="boletines" className="flex flex-1 min-w-[8rem]">
+              Boletines
+            </TabsTrigger>
+            <TabsTrigger value="aprobacion" className="flex flex-1 min-w-[8rem]">
+              Aprobación
+            </TabsTrigger>
+            <TabsTrigger value="asistencias" className="flex flex-1 min-w-[8rem]">
+              Asistencias
+            </TabsTrigger>
+            <TabsTrigger value="licencias" className="flex flex-1 min-w-[8rem]">
+              Licencias
+            </TabsTrigger>
+            <TabsTrigger value="actas" className="flex flex-1 min-w-[8rem]">
+              Actas
+            </TabsTrigger>
           </TabsList>
 
           {/* -------------------------- Reporte de Boletines ------------------ */}

--- a/frontend-ecep/src/app/page.tsx
+++ b/frontend-ecep/src/app/page.tsx
@@ -249,7 +249,7 @@ export default function LoginPage() {
 
         {/* Información adicional */}
         <div className="text-center text-sm text-gray-600 space-y-2">
-          <div className="flex items-center justify-center space-x-4">
+          <div className="flex flex-wrap items-center justify-center gap-4">
             <div className="flex items-center">
               <GraduationCap className="h-4 w-4 mr-1" />
               <span>Nivel Inicial</span>


### PR DESCRIPTION
## Summary
- allow login page footer details to wrap on small screens
- enable dashboard navigation panel and header to adapt on mobile
- make report tabs flexible so they wrap on compact viewports

## Testing
- `bun run lint` *(fails: missing Next.js binary because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d444aa6ccc832795757636105737c7