### PR TITLE
Mostrar nota conceptual en boletines

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -2662,10 +2662,13 @@ export default function ReportesPage() {
                                       const grade = subject.grades.find(
                                         (g) => g.trimestreId === trimester.id,
                                       );
+                                      const conceptualGrade = grade?.notaConceptual?.trim();
                                       const gradeValue =
-                                        grade && typeof grade.notaNumerica === "number"
-                                          ? grade.notaNumerica.toFixed(1)
-                                          : grade?.notaConceptual ?? "—";
+                                        conceptualGrade && conceptualGrade !== "—"
+                                          ? conceptualGrade
+                                          : grade && typeof grade.notaNumerica === "number"
+                                            ? grade.notaNumerica.toFixed(1)
+                                            : "—";
                                       const observations = grade?.observaciones?.trim();
 
                                       return (


### PR DESCRIPTION
## Summary
- Prioritize conceptual grades when rendering boletines so the report displays the qualitative mark for each subject.

## Testing
- npm run lint *(fails: next binary missing before dependencies are installed)*
- npm install *(fails: registry access forbidden in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44b5c209083279c16ae857373fe5d