### PR TITLE
Fix academic formation employee assignment

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/FormacionAcademicaService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/FormacionAcademicaService.java
@@ -1,9 +1,11 @@
 package edu.ecep.base_app.identidad.application;
 
 import edu.ecep.base_app.identidad.domain.FormacionAcademica;
+import edu.ecep.base_app.identidad.domain.Empleado;
 import edu.ecep.base_app.identidad.presentation.dto.FormacionAcademicaDTO;
 import edu.ecep.base_app.identidad.infrastructure.mapper.FormacionAcademicaMapper;
 import edu.ecep.base_app.identidad.infrastructure.persistence.FormacionAcademicaRepository;
+import edu.ecep.base_app.identidad.infrastructure.persistence.EmpleadoRepository;
 import edu.ecep.base_app.shared.exception.NotFoundException;
 import java.util.List;
 import org.springframework.data.domain.Sort;
@@ -14,10 +16,15 @@ import org.springframework.stereotype.Service;
 public class FormacionAcademicaService {
     private final FormacionAcademicaRepository repository;
     private final FormacionAcademicaMapper mapper;
+    private final EmpleadoRepository empleadoRepository;
 
-    public FormacionAcademicaService(FormacionAcademicaRepository repository, FormacionAcademicaMapper mapper) {
+    public FormacionAcademicaService(
+            FormacionAcademicaRepository repository,
+            FormacionAcademicaMapper mapper,
+            EmpleadoRepository empleadoRepository) {
         this.repository = repository;
         this.mapper = mapper;
+        this.empleadoRepository = empleadoRepository;
     }
 
     public List<FormacionAcademicaDTO> findAll() {
@@ -29,12 +36,20 @@ public class FormacionAcademicaService {
     }
 
     public Long create(FormacionAcademicaDTO dto) {
-        return repository.save(mapper.toEntity(dto)).getId();
+        FormacionAcademica entity = mapper.toEntity(dto);
+        Empleado empleado = empleadoRepository.findById(dto.getEmpleadoId()).orElseThrow(NotFoundException::new);
+        entity.setEmpleado(empleado);
+        return repository.save(entity).getId();
     }
 
     public void update(Long id, FormacionAcademicaDTO dto) {
         FormacionAcademica entity = repository.findById(id).orElseThrow(NotFoundException::new);
         mapper.updateEntityFromDto(dto, entity);
+        if (dto.getEmpleadoId() != null &&
+                (entity.getEmpleado() == null || !dto.getEmpleadoId().equals(entity.getEmpleado().getId()))) {
+            Empleado empleado = empleadoRepository.findById(dto.getEmpleadoId()).orElseThrow(NotFoundException::new);
+            entity.setEmpleado(empleado);
+        }
         repository.save(entity);
     }
 


### PR DESCRIPTION
## Summary
- ensure academic formation records resolve and assign their owning employee before persisting
- refresh the employee relation when updating a formation if the submitted employee id differs

## Testing
- ./mvnw -q test *(fails: wget unable to fetch Maven distribution from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d44ae527fc8327bc37400caaed4aed