### PR TITLE
Adjust TabsList width for calificaciones and pagos

### DIFF
--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -146,7 +146,7 @@ export default function CalificacionesIndexPage() {
             onValueChange={(value) => setTab(value as "primario" | "inicial")}
             className="space-y-4"
           >
-            <TabsList className="w-full justify-start overflow-x-auto sm:w-auto">
+            <TabsList className="justify-start overflow-x-auto">
               <TabsTrigger value="primario">Primario</TabsTrigger>
               <TabsTrigger value="inicial">Inicial</TabsTrigger>
             </TabsList>

--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -1526,7 +1526,7 @@ export default function PagosPage() {
             onValueChange={(value) => setSelectedTab(value)}
             className="space-y-6"
           >
-            <TabsList className="w-full justify-start overflow-x-auto sm:w-auto">
+            <TabsList className="justify-start overflow-x-auto">
               {availableTabs.map((tab) => (
                 <TabsTrigger key={tab.value} value={tab.value}>
                   {tab.label}


### PR DESCRIPTION
## Summary
- update the calificaciones dashboard tabs so the list only spans the width of its triggers
- apply the same tabs list sizing fix to the pagos dashboard view for consistent layout

## Testing
- bun run lint *(fails: next command not found before installing deps)*
- bun install *(fails: npm registry requests return 403 in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44d16c71c8327a84e1669910ee149