### PR TITLE
Match trimester styling to tabs

### DIFF
--- a/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
@@ -460,7 +460,7 @@ export default function FamilyCalificacionesView({
                                 return (
                                   <div
                                     key={`${materia.seccionMateriaId}-${tri.id}`}
-                                    className="rounded border p-3"
+                                    className="rounded-full border p-3"
                                   >
                                     <div className="flex flex-wrap items-center justify-between gap-2">
                                       <span className="font-semibold">
@@ -503,7 +503,7 @@ export default function FamilyCalificacionesView({
                         return (
                           <div
                             key={`informe-${tri.id}`}
-                            className="rounded border p-3"
+                            className="rounded-full border p-3"
                           >
                             <div className="flex items-center justify-between gap-2">
                               <span className="font-semibold">

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -584,7 +584,7 @@ export default function CierrePrimarioView({
                         type="button"
                         variant={active ? "default" : "outline"}
                         className={cn(
-                          "w-full justify-between gap-2 text-left",
+                          "w-full justify-between gap-2 rounded-full text-left",
                           !active && "bg-muted/40 hover:bg-muted",
                         )}
                         onClick={() => setTriId(String(o.id))}


### PR DESCRIPTION
## Summary
- adjust the trimester cards in the family calificaciones view to use the same rounded border radius as the tabs
- update the trimester selector buttons in the cierre primario view to also use the rounded border radius used by the tabs

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44d11af4c8327bb37e75a5e8b7f0d