### PR TITLE
Alinea las pestañas de trimestres en evaluaciones y calificaciones

### DIFF
--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -15,7 +15,13 @@ import type {
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { ActiveTrimestreBadge } from "@/app/dashboard/_components/ActiveTrimestreBadge";
 import { TrimestreEstadoBadge } from "@/components/trimestres/TrimestreEstadoBadge";
-import { TRIMESTRE_ESTADO_LABEL, getTrimestreEstado } from "@/lib/trimestres";
+import {
+  TRIMESTRE_ESTADO_LABEL,
+  formatTrimestreRange,
+  getTrimestreEstado,
+  getTrimestreFin,
+  getTrimestreInicio,
+} from "@/lib/trimestres";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
 import { UserRole } from "@/types/api-generated";
@@ -23,11 +29,19 @@ import { UserRole } from "@/types/api-generated";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   Dialog,
   DialogHeader,
@@ -565,33 +579,18 @@ export default function SeccionEvaluacionesPage() {
                   onValueChange={(value) => setSelectedTrimestreId(value)}
                   className="space-y-4"
                 >
-                  <TabsList className="!w-full flex-wrap gap-2">
+                  <TabsList className="flex flex-wrap gap-2">
                     {trimestresDelPeriodo.map((tri, index) => {
                       const label =
                         tri.orden != null
                           ? `Trimestre ${tri.orden}`
                           : `Trimestre ${index + 1}`;
-                      const estado = getTrimestreEstado(tri);
-                      const estadoLabel =
-                        TRIMESTRE_ESTADO_LABEL[estado] ?? "";
                       return (
                         <TabsTrigger
                           key={tri.id}
                           value={String(tri.id)}
-                          className="flex-1 justify-between gap-2 whitespace-normal text-left"
                         >
-                          <span>{label}</span>
-                          {estadoLabel ? (
-                            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
-                              <TrimestreEstadoBadge
-                                estado={estado}
-                                showLabel={false}
-                                circleClassName="h-4 w-4"
-                                iconClassName="h-2 w-2"
-                              />
-                              <span>{estadoLabel}</span>
-                            </span>
-                          ) : null}
+                          {label}
                         </TabsTrigger>
                       );
                     })}
@@ -603,6 +602,17 @@ export default function SeccionEvaluacionesPage() {
                       tri.orden != null
                         ? `Trimestre ${tri.orden}`
                         : `Trimestre ${index + 1}`;
+                    const estado = getTrimestreEstado(tri);
+                    const estadoLabel = TRIMESTRE_ESTADO_LABEL[estado] ?? estado;
+                    const rangeLabel = formatTrimestreRange(tri);
+                    const hasRange =
+                      Boolean(getTrimestreInicio(tri)) &&
+                      Boolean(getTrimestreFin(tri));
+                    const canEdit = estado === "activo";
+                    const estadoMessage =
+                      estado === "cerrado"
+                        ? "Este trimestre está cerrado. Los exámenes son solo de lectura."
+                        : "Este trimestre está inactivo. No podés registrar ni editar exámenes.";
                     const evaluacionesTrimestre = filteredEvals.filter((e: any) => {
                       const triId =
                         e?.trimestreId ?? (e as any)?.trimestre?.id ?? null;
@@ -612,72 +622,126 @@ export default function SeccionEvaluacionesPage() {
                       <TabsContent
                         key={value}
                         value={value}
-                        className="space-y-3"
+                        className="space-y-4"
                       >
-                        {evaluacionesTrimestre.length === 0 ? (
-                          <div className="text-sm text-muted-foreground">
-                            No hay exámenes para este trimestre con el filtro
-                            seleccionado.
-                          </div>
-                        ) : (
-                          evaluacionesTrimestre.map((e) => {
-                            const sm = (secMats ?? []).find(
-                              (x) => x.id === (e as any).seccionMateriaId,
-                            ) as any;
-                            const matNom = sm
-                              ? materiaNombreById.get(sm.materiaId)
-                              : undefined;
-                            const fechaLegible = formatFecha((e as any).fecha);
-                            const tema = (e as any).tema ?? "Evaluación";
-                            return (
-                              <div
-                                key={e.id}
-                                className="space-y-3 rounded-lg border p-3 transition-colors hover:border-primary/50"
-                              >
-                                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                                  <div className="space-y-1">
-                                    <div className="text-base font-medium text-foreground">
-                                      {tema}
-                                    </div>
-                                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                                      {matNom && (
-                                        <Badge variant="outline">{matNom}</Badge>
-                                      )}
-                                      <span className="inline-flex items-center gap-1">
-                                        <Calendar className="h-3 w-3" />
-                                        {fechaLegible}
-                                      </span>
-                                      <Badge variant="secondary">{triLabel}</Badge>
-                                    </div>
-                                  </div>
-                                  <div className="flex gap-2">
-                                    <Button
-                                      size="sm"
-                                      onClick={() =>
-                                        router.push(
-                                          `/dashboard/evaluaciones/examenes/${e.id}`,
-                                        )
-                                      }
-                                    >
-                                      Ver examen
-                                    </Button>
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      onClick={() => {
-                                        setSelEval(e);
-                                        setOpenNotas(true);
-                                      }}
-                                    >
-                                      <Edit className="h-4 w-4 mr-1" />
-                                      Notas
-                                    </Button>
-                                  </div>
-                                </div>
+                        <Card>
+                          <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                            <div>
+                              <CardTitle className="flex flex-wrap items-center gap-2">
+                                <span className="flex items-center">
+                                  <School className="h-5 w-5 mr-2" />
+                                  Exámenes del trimestre
+                                </span>
+                                <TrimestreEstadoBadge
+                                  estado={estado}
+                                  className="text-xs text-muted-foreground"
+                                />
+                              </CardTitle>
+                              <CardDescription>
+                                Consultá y gestioná los exámenes registrados durante
+                                este trimestre.
+                                {rangeLabel && (
+                                  <span className="block text-xs text-muted-foreground">
+                                    {rangeLabel}
+                                  </span>
+                                )}
+                              </CardDescription>
+                            </div>
+                          </CardHeader>
+                          <CardContent className="space-y-3">
+                            {!hasRange ? (
+                              <div className="text-sm text-muted-foreground">
+                                Configurá las fechas de inicio y fin del trimestre para
+                                visualizar los exámenes.
                               </div>
-                            );
-                          })
-                        )}
+                            ) : (
+                              <>
+                                {!canEdit && (
+                                  <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                                    <AlertTitle>{estadoLabel}</AlertTitle>
+                                    <AlertDescription>{estadoMessage}</AlertDescription>
+                                  </Alert>
+                                )}
+                                {evaluacionesTrimestre.length === 0 ? (
+                                  <div className="text-sm text-muted-foreground">
+                                    No hay exámenes para este trimestre con el filtro
+                                    seleccionado.
+                                  </div>
+                                ) : (
+                                  evaluacionesTrimestre.map((e) => {
+                                    const sm = (secMats ?? []).find(
+                                      (x) => x.id === (e as any).seccionMateriaId,
+                                    ) as any;
+                                    const matNom = sm
+                                      ? materiaNombreById.get(sm.materiaId)
+                                      : undefined;
+                                    const fechaLegible = formatFecha((e as any).fecha);
+                                    const tema = (e as any).tema ?? "Evaluación";
+                                    return (
+                                      <div
+                                        key={e.id}
+                                        className="space-y-3 rounded-lg border p-3 transition-colors hover:border-primary/50"
+                                      >
+                                        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                                          <div className="space-y-1">
+                                            <div className="text-base font-medium text-foreground">
+                                              {tema}
+                                            </div>
+                                            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                              {matNom && (
+                                                <Badge variant="outline">{matNom}</Badge>
+                                              )}
+                                              <span className="inline-flex items-center gap-1">
+                                                <Calendar className="h-3 w-3" />
+                                                {fechaLegible}
+                                              </span>
+                                              <Badge variant="secondary">{triLabel}</Badge>
+                                            </div>
+                                          </div>
+                                          <div className="flex gap-2">
+                                            <Button
+                                              size="sm"
+                                              onClick={() =>
+                                                router.push(
+                                                  `/dashboard/evaluaciones/examenes/${e.id}`,
+                                                )
+                                              }
+                                            >
+                                              <Edit className="mr-2 h-4 w-4" /> Ver / editar
+                                            </Button>
+                                            <Button
+                                              size="sm"
+                                              variant="outline"
+                                              onClick={() => {
+                                                setSelEval(e);
+                                                setOpenNotas(true);
+                                              }}
+                                            >
+                                              <Plus className="mr-2 h-4 w-4" /> Notas
+                                            </Button>
+                                          </div>
+                                        </div>
+                                        <div className="space-y-2 text-xs text-muted-foreground">
+                                          <div className="flex flex-wrap items-center gap-2">
+                                            <span>
+                                              Creado el {formatFecha((e as any).fecha)}
+                                            </span>
+                                            <span>Tiempo estimado: {(e as any).duracion}</span>
+                                            {Boolean((e as any).observaciones) && (
+                                              <span>
+                                                Observaciones: {(e as any).observaciones}
+                                              </span>
+                                            )}
+                                          </div>
+                                        </div>
+                                      </div>
+                                    );
+                                  })
+                                )}
+                              </>
+                            )}
+                          </CardContent>
+                        </Card>
                       </TabsContent>
                     );
                   })}


### PR DESCRIPTION
## Summary
- unifica el diseño de las pestañas de trimestres en evaluaciones y calificaciones con la vista de asistencia
- añade encabezados con rango y estado del trimestre dentro de cada pestaña, incluyendo alerta cuando el trimestre no está activo
- muestra mensajes cuando faltan fechas configuradas o no hay información disponible para el trimestre seleccionado

## Testing
- `bun run lint` *(falla: faltan dependencias, el entorno no permite descargar paquetes)*

------
https://chatgpt.com/codex/tasks/task_e_68d46d4331e88327a3f574e01893d486