### PR TITLE
fix: handle invalid trimestres data

### DIFF
--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -163,11 +163,20 @@ export default function CierrePrimarioView({
     };
   }, [seccionId, hoy, periodoEscolarId, calendarVersion]);
 
+  const validTrimestres = useMemo(
+    () =>
+      (trimestres ?? []).filter(
+        (t: any): t is Record<string, unknown> & { id: number } =>
+          Boolean(t) && typeof t === "object" && typeof t.id === "number",
+      ),
+    [trimestres],
+  );
+
   const triOpts = useMemo<
     { id: number; label: string; estado: TrimestreEstado }[]
   >(
     () =>
-      (trimestres ?? [])
+      validTrimestres
         .slice()
         .sort((a: any, b: any) => (a.orden ?? 0) - (b.orden ?? 0))
         .map((t: any) => {
@@ -179,7 +188,7 @@ export default function CierrePrimarioView({
             estado,
           };
         }),
-    [trimestres],
+    [validTrimestres],
   );
 
   const materiasPorId = useMemo(() => {
@@ -213,8 +222,10 @@ export default function CierrePrimarioView({
 
   const activeTrimestre = useMemo(() => {
     if (!triId) return null;
-    return trimestres.find((x) => x.id === Number(triId)) ?? null;
-  }, [trimestres, triId]);
+    const parsedId = Number(triId);
+    if (!Number.isFinite(parsedId)) return null;
+    return validTrimestres.find((x) => x.id === parsedId) ?? null;
+  }, [validTrimestres, triId]);
 
   const activeTrimestreEstado = useMemo<TrimestreEstado>(() => {
     return getTrimestreEstado(activeTrimestre);


### PR DESCRIPTION
## Summary
- filter trimestre records without numeric identifiers before building tab options
- resolve the active trimestre using the validated collection and ignore non-numeric ids

## Testing
- npm run lint *(fails: next not found because dependencies could not be installed without npm registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d4737eb17c83278a07f9c49cf49f02