### PR TITLE
Handle missing personal data when building accident acta mapping

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -275,7 +275,8 @@ export default function AccidentesIndexPage() {
 
   const personalDisplayById = useMemo(() => {
     const map = new Map<number, string>();
-    for (const p of personal as any[]) {
+    const items = Array.isArray(personal) ? personal : [];
+    for (const p of items as any[]) {
       const label =
         `${p.apellido ?? ""} ${p.nombre ?? ""}`.trim() ||
         p.nombreCompleto ||


### PR DESCRIPTION
## Summary
- Guard the personal roster mapping by ensuring the data is iterable before iterating

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68d47e2328588327bbecd962367b199e