### PR TITLE
Adjust pending admissions count in quick stats

### DIFF
--- a/frontend-ecep/src/hooks/useQuickStats.ts
+++ b/frontend-ecep/src/hooks/useQuickStats.ts
@@ -96,11 +96,14 @@ export function useQuickStats() {
           const sol =
             (await admisiones.solicitudesAdmision.list().catch(() => ({ data: [] })))
               .data ?? [];
-          postulPend = sol.filter((s: any) =>
-            String(s.estado ?? "")
-              .toUpperCase()
-              .includes("PEND"),
-          ).length;
+          const estadosFinales = new Set(["ACEPTADA", "RECHAZADA"]);
+          postulPend = sol.filter((s: any) => {
+            const estado = String(s.estado ?? "")
+              .trim()
+              .toUpperCase();
+            if (!estado) return true;
+            return !estadosFinales.has(estado);
+          }).length;
         }
 
         // ========= Licencias activas hoy =========


### PR DESCRIPTION
## Summary
- update the quick stats hook to consider admissions requests pending unless they are accepted or rejected
- treat empty or unknown states as pending while keeping the existing error handling

## Testing
- `npm run lint` *(fails: next executable not found in environment)*
- `npm install` *(fails: npm registry forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d47e6ae16883278e58baa62464c1d9