### PR TITLE
Improve admission request management workflow

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/SolicitudAdmision.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/domain/SolicitudAdmision.java
@@ -58,6 +58,18 @@ public class SolicitudAdmision extends BaseEntity{
     @Column
     private LocalDate propuestaFecha3;
 
+    @Column(length = 100)
+    private String propuestaHorario1;
+
+    @Column(length = 100)
+    private String propuestaHorario2;
+
+    @Column(length = 100)
+    private String propuestaHorario3;
+
+    @Column(length = 2000)
+    private String propuestaNotas;
+
     @Column
     private LocalDate fechaLimiteRespuesta;
 
@@ -79,8 +91,23 @@ public class SolicitudAdmision extends BaseEntity{
     @Column(length = 1000)
     private String notasDireccion;
 
+    @Column(length = 2000)
+    private String comentariosEntrevista;
+
     @Column
     private Boolean autorizadoComunicacionesEmail;
+
+    @Column
+    private Boolean puedeSolicitarReprogramacion;
+
+    @Column
+    private Boolean reprogramacionSolicitada;
+
+    @Column(length = 2000)
+    private String comentarioReprogramacion;
+
+    @Column
+    private Integer cantidadPropuestasEnviadas;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "aspirante_id", nullable = false)

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/infrastructure/mapper/SolicitudAdmisionMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/infrastructure/mapper/SolicitudAdmisionMapper.java
@@ -17,8 +17,16 @@ public interface SolicitudAdmisionMapper {
 
     @Mapping(target = "aspiranteId", source = "aspirante.id")
     @Mapping(target = "aspirante", source = "aspirante")
+    @Mapping(target = "fechaSolicitud", source = "dateCreated")
     @Mapping(target = "fechasPropuestas", expression = "java(toFechaList(entity))")
+    @Mapping(target = "rangosHorariosPropuestos", expression = "java(toHorarioList(entity))")
+    @Mapping(target = "aclaracionesPropuesta", source = "propuestaNotas")
     @Mapping(target = "fechaEntrevistaConfirmada", source = "fechaEntrevista")
+    @Mapping(target = "comentariosEntrevista", source = "comentariosEntrevista")
+    @Mapping(target = "puedeSolicitarReprogramacion", source = "puedeSolicitarReprogramacion")
+    @Mapping(target = "reprogramacionSolicitada", source = "reprogramacionSolicitada")
+    @Mapping(target = "comentarioReprogramacion", source = "comentarioReprogramacion")
+    @Mapping(target = "cantidadPropuestasEnviadas", source = "cantidadPropuestasEnviadas")
     @Mapping(target = "adjuntosInformativos", expression = "java(splitAdjuntos(entity.getAdjuntosInformativos()))")
     SolicitudAdmisionDTO toDto(SolicitudAdmision entity);
 
@@ -37,6 +45,10 @@ public interface SolicitudAdmisionMapper {
     @Mapping(target = "propuestaFecha1", ignore = true)
     @Mapping(target = "propuestaFecha2", ignore = true)
     @Mapping(target = "propuestaFecha3", ignore = true)
+    @Mapping(target = "propuestaHorario1", ignore = true)
+    @Mapping(target = "propuestaHorario2", ignore = true)
+    @Mapping(target = "propuestaHorario3", ignore = true)
+    @Mapping(target = "propuestaNotas", ignore = true)
     @Mapping(target = "adjuntosInformativos", ignore = true)
     void updateEntityFromDto(SolicitudAdmisionDTO dto, @MappingTarget SolicitudAdmision entity);
 
@@ -47,6 +59,14 @@ public interface SolicitudAdmisionMapper {
         if (entity.getPropuestaFecha2() != null) fechas.add(entity.getPropuestaFecha2());
         if (entity.getPropuestaFecha3() != null) fechas.add(entity.getPropuestaFecha3());
         return fechas;
+    }
+
+    default java.util.List<String> toHorarioList(SolicitudAdmision entity) {
+        java.util.List<String> horarios = new java.util.ArrayList<>();
+        if (entity.getPropuestaHorario1() != null) horarios.add(entity.getPropuestaHorario1());
+        if (entity.getPropuestaHorario2() != null) horarios.add(entity.getPropuestaHorario2());
+        if (entity.getPropuestaHorario3() != null) horarios.add(entity.getPropuestaHorario3());
+        return horarios;
     }
 
     default java.util.List<String> splitAdjuntos(String raw) {
@@ -69,6 +89,17 @@ public interface SolicitudAdmisionMapper {
             entity.setPropuestaFecha1(fechas.size() > 0 ? fechas.get(0) : null);
             entity.setPropuestaFecha2(fechas.size() > 1 ? fechas.get(1) : null);
             entity.setPropuestaFecha3(fechas.size() > 2 ? fechas.get(2) : null);
+        }
+
+        java.util.List<String> horarios = dto.getRangosHorariosPropuestos();
+        if (horarios != null) {
+            entity.setPropuestaHorario1(horarios.size() > 0 ? horarios.get(0) : null);
+            entity.setPropuestaHorario2(horarios.size() > 1 ? horarios.get(1) : null);
+            entity.setPropuestaHorario3(horarios.size() > 2 ? horarios.get(2) : null);
+        }
+
+        if (dto.getAclaracionesPropuesta() != null) {
+            entity.setPropuestaNotas(dto.getAclaracionesPropuesta());
         }
 
         if (dto.getAdjuntosInformativos() != null) {

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionDTO.java
@@ -1,6 +1,7 @@
 package edu.ecep.base_app.admisiones.presentation.dto;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class SolicitudAdmisionDTO {
     private Long id;
     private Long aspiranteId;
     private AspiranteDTO aspirante;
+    private OffsetDateTime fechaSolicitud;
     private String estado;
     private String observaciones;
 
@@ -22,6 +24,8 @@ public class SolicitudAdmisionDTO {
     private Boolean cupoDisponible;
 
     private List<LocalDate> fechasPropuestas;
+    private List<String> rangosHorariosPropuestos;
+    private String aclaracionesPropuesta;
     private LocalDate fechaLimiteRespuesta;
     private LocalDate fechaRespuestaFamilia;
     private LocalDate fechaEntrevistaConfirmada;
@@ -32,5 +36,10 @@ public class SolicitudAdmisionDTO {
     private String documentosRequeridos;
     private List<String> adjuntosInformativos;
     private String notasDireccion;
+    private String comentariosEntrevista;
     private String motivoRechazo;
+    private Boolean puedeSolicitarReprogramacion;
+    private Boolean reprogramacionSolicitada;
+    private String comentarioReprogramacion;
+    private Integer cantidadPropuestasEnviadas;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionProgramarDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionProgramarDTO.java
@@ -18,4 +18,7 @@ public class SolicitudAdmisionProgramarDTO {
     private List<String> adjuntosInformativos;
     private Boolean cupoDisponible;
     private String disponibilidadCurso;
+    @NotEmpty
+    private List<String> rangosHorarios;
+    private String aclaracionesDireccion;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionReprogramacionDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionReprogramacionDTO.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.admisiones.presentation.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class SolicitudAdmisionEntrevistaDTO {
-    private Boolean realizada;
-    private String comentarios;
+public class SolicitudAdmisionReprogramacionDTO {
+    @NotBlank
+    private String comentario;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/SolicitudAdmisionController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/SolicitudAdmisionController.java
@@ -36,6 +36,13 @@ public class SolicitudAdmisionController {
         return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/{id}/reprogramar")
+    public ResponseEntity<Void> solicitarReprogramacion(@PathVariable Long id,
+            @RequestBody @Valid SolicitudAdmisionReprogramacionDTO dto) {
+        service.solicitarReprogramacion(id, dto);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/{id}/confirmar-fecha")
     public ResponseEntity<Void> confirmar(@PathVariable Long id, @RequestBody @Valid SolicitudAdmisionSeleccionDTO dto) {
         service.confirmarFecha(id, dto);

--- a/frontend-ecep/src/services/api/modules/admisiones/index.ts
+++ b/frontend-ecep/src/services/api/modules/admisiones/index.ts
@@ -37,6 +37,10 @@ const solicitudesAdmision = {
     http.post<void>(`/api/solicitudes-admision/${id}/rechazar`, body),
   programar: (id: number, body: DTO.SolicitudAdmisionProgramarDTO) =>
     http.post<void>(`/api/solicitudes-admision/${id}/programar`, body),
+  solicitarReprogramacion: (
+    id: number,
+    body: DTO.SolicitudAdmisionReprogramacionDTO,
+  ) => http.post<void>(`/api/solicitudes-admision/${id}/reprogramar`, body),
   confirmarFecha: (id: number, body: DTO.SolicitudAdmisionSeleccionDTO) =>
     http.post<void>(`/api/solicitudes-admision/${id}/confirmar-fecha`, body),
   registrarEntrevista: (id: number, body: DTO.SolicitudAdmisionEntrevistaDTO) =>

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -782,6 +782,8 @@ export interface SolicitudAdmisionDTO {
   disponibilidadCurso?: string;
   cupoDisponible?: boolean;
   fechasPropuestas?: ISODate[];
+  rangosHorariosPropuestos?: string[];
+  aclaracionesPropuesta?: string;
   fechaLimiteRespuesta?: ISODate;
   fechaRespuestaFamilia?: ISODate;
   fechaEntrevistaConfirmada?: ISODate;
@@ -790,7 +792,12 @@ export interface SolicitudAdmisionDTO {
   documentosRequeridos?: string;
   adjuntosInformativos?: string[];
   notasDireccion?: string;
+  comentariosEntrevista?: string;
   motivoRechazo?: string;
+  puedeSolicitarReprogramacion?: boolean;
+  reprogramacionSolicitada?: boolean;
+  comentarioReprogramacion?: string;
+  cantidadPropuestasEnviadas?: number;
 }
 
 export interface SolicitudAdmisionProgramarDTO {
@@ -799,6 +806,8 @@ export interface SolicitudAdmisionProgramarDTO {
   adjuntosInformativos?: string[];
   cupoDisponible?: boolean;
   disponibilidadCurso?: string;
+  rangosHorarios: string[];
+  aclaracionesDireccion?: string;
 }
 
 export interface SolicitudAdmisionRechazoDTO {
@@ -810,7 +819,12 @@ export interface SolicitudAdmisionSeleccionDTO {
 }
 
 export interface SolicitudAdmisionEntrevistaDTO {
-  realizada: boolean;
+  realizada?: boolean;
+  comentarios?: string;
+}
+
+export interface SolicitudAdmisionReprogramacionDTO {
+  comentario: string;
 }
 
 export interface SolicitudAdmisionDecisionDTO {


### PR DESCRIPTION
## Summary
- extend admission requests with interview schedule metadata, reschedule tracking, and interview comments while adjusting emails and notification targets to use the first family contact
- add a second-chance rescheduling endpoint and updated validations, including richer scheduling emails with notes and time ranges
- redesign the aspirant management tab into paginated cards, surface scheduling history and comments in the detail dialog, and enhance scheduling forms with time ranges and clarification fields
- update shared DTOs and client helpers to expose the new scheduling fields and rescheduling action

## Testing
- ⚠️ `bun install` *(fails with multiple 403 responses from registry.npmjs.org in this environment)*
- ⚠️ `bun run lint` *(fails: `next` command not found because dependencies could not be installed)*
- ⚠️ `./mvnw test` *(fails: unable to download Maven binaries due to 403 response from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d483f88d7c8327a15e9daeda898015