### PR TITLE
Improve dark mode support and reorganize settings

### DIFF
--- a/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
+++ b/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
@@ -26,6 +26,7 @@ import { ConfiguracionDialog } from "./_components/ConfiguracionDialog";
 import { isItemActive } from "@/lib/nav";
 
 import { useVisibleMenu } from "@/hooks/useVisibleMenu";
+import { cn } from "@/lib/utils";
 interface DashboardLayoutProps {
   children: React.ReactNode;
 }
@@ -103,10 +104,10 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   }, [visibleMenu]);
 
   return (
-    <div className="flex h-screen bg-gray-100">
+    <div className="flex h-screen bg-muted dark:bg-background">
       {/* Sidebar */}
       <div
-        className={`${sidebarOpen ? "translate-x-0" : "-translate-x-full"} fixed inset-y-0 left-0 z-50 w-64 bg-gray-100 transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0`}
+        className={`${sidebarOpen ? "translate-x-0" : "-translate-x-full"} fixed inset-y-0 left-0 z-50 w-64 bg-background border-r border-border transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0`}
       >
         <div className="flex flex-col h-full">
           {/* LOGO ARRIBA */}
@@ -117,7 +118,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
               </div>
               <div>
                 <h1 className="text-lg font-bold">ECEP</h1>
-                <p className="text-xs text-gray-600">Sistema Escolar</p>
+                <p className="text-xs text-muted-foreground">Sistema Escolar</p>
               </div>
             </div>
             <Button
@@ -142,9 +143,12 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                         <Button
                           aria-current={active ? "page" : undefined}
                           variant="ghost"
-                          className={`w-full justify-start rounded-md transition-colors
-                            ${active ? "bg-gray-200 hover:bg-gray-200 font-medium" : "hover:bg-gray-200 hover:text-gray-900"}
-                            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 my-0.5`}
+                          className={cn(
+                            "w-full justify-start rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 my-0.5",
+                            active
+                              ? "bg-muted text-foreground hover:bg-muted font-medium"
+                              : "hover:bg-muted hover:text-foreground",
+                          )}
                           onClick={() => setSidebarOpen(false)}
                         >
                           <item.icon className="h-5 w-5 mr-3" />
@@ -154,7 +158,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                     );
                   })}
                   {groupIndex < groupedMenu.length - 1 && (
-                    <div className="m-2 border-t border-gray-300/70" />
+                    <div className="m-2 border-t border-border/60 dark:border-border/40" />
                   )}
                 </div>
               ))}
@@ -165,7 +169,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           <div className="p-4 lg:pr-0 mt-auto">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button className="w-full inline-flex items-center justify-between gap-3 rounded-md p-2 hover:bg-gray-200 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
+                <button className="w-full inline-flex items-center justify-between gap-3 rounded-md p-2 hover:bg-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
                   <div className="flex items-center gap-3">
                     <div className="w-9 h-9 bg-primary rounded-full flex items-center justify-center text-white font-semibold text-sm">
                       {getInitials(displayName)}
@@ -174,12 +178,12 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                       <p className="font-medium truncate max-w-[9rem]">
                         {displayName}
                       </p>
-                      <p className="text-gray-600 text-xs">
+                      <p className="text-xs text-muted-foreground">
                         {currentRole ? displayRole(currentRole) : "Sin rol"}
                       </p>
                     </div>
                   </div>
-                  <ChevronsUpDown className="h-4 w-4 text-gray-500 flex-shrink-0" />
+                  <ChevronsUpDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                 </button>
               </DropdownMenuTrigger>
 
@@ -188,7 +192,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                   {displayName}
                 </DropdownMenuLabel>
 
-                <DropdownMenuSeparator className="bg-gray-200 mx-1" />
+                <DropdownMenuSeparator className="mx-1 bg-border" />
 
                 {rolesNormalized.length === 0 && (
                   <DropdownMenuItem disabled>
@@ -204,7 +208,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                       onClick={() => !isActive && handleChangeRole(r)}
                       className={
                         isActive
-                          ? "bg-gray-100 hover:bg-gray-100 font-medium"
+                          ? "bg-muted text-foreground hover:bg-muted font-medium"
                           : ""
                       }
                     >
@@ -213,18 +217,18 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
                   );
                 })}
 
-                <DropdownMenuSeparator className="bg-gray-200 mx-1" />
+                <DropdownMenuSeparator className="mx-1 bg-border" />
 
                 <DropdownMenuItem onClick={() => setConfigOpen(true)}>
                   <Settings className="h-4 w-4 mr-2" />
                   Configuración
                 </DropdownMenuItem>
 
-                <DropdownMenuSeparator className="bg-gray-200 mx-1" />
+                <DropdownMenuSeparator className="mx-1 bg-border" />
 
                 <DropdownMenuItem
                   onClick={() => handleLogout()}
-                  className="text-red-600 focus:text-red-700"
+                  className="text-destructive focus:text-destructive dark:text-destructive dark:focus:text-destructive"
                 >
                   <LogOut className="h-4 w-4 mr-2" />
                   Cerrar sesión
@@ -251,7 +255,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           </div>
         </div>
         <div className="flex-1 p-4">
-          <div className="rounded-xl bg-white ring ring-1 ring-gray-200 overflow-hidden">
+          <div className="rounded-xl bg-card text-card-foreground ring-1 ring-border overflow-hidden">
             <main className="scrollarea  h-[calc(100vh-6rem)] lg:h-[calc(107vh-6rem)] overflow-y-auto">
               {children}
             </main>
@@ -262,7 +266,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
       {/* Overlay mobile */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 z-40 lg:hidden"
+          className="fixed inset-0 z-40 bg-black bg-opacity-50 lg:hidden"
           onClick={toggleSidebar}
         />
       )}

--- a/frontend-ecep/src/app/dashboard/page.tsx
+++ b/frontend-ecep/src/app/dashboard/page.tsx
@@ -165,11 +165,9 @@ export default function DashboardPage() {
                   <Link
                     key={index}
                     href={action.href}
-                    className="flex flex-col items-center p-4 border rounded-lg hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors"
+                    className="flex flex-col items-center rounded-lg border border-border p-4 transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                   >
-                    <div
-                      className={`p-2 rounded-full ${"bg-primary"} text-white mb-2`}
-                    >
+                    <div className={`mb-2 rounded-full bg-primary p-2 text-primary-foreground`}>
                       <action.icon className="h-5 w-5" />
                     </div>
                     <span className="text-sm font-medium text-center">
@@ -201,7 +199,7 @@ export default function DashboardPage() {
                   {recentMsgs.map((it) => (
                     <div
                       key={it.userId}
-                      className="flex items-start gap-3 p-2 rounded hover:bg-gray-50"
+                      className="flex items-start gap-3 rounded p-2 transition-colors hover:bg-muted/70"
                     >
                       <div className="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-semibold">
                         {it.nombre

--- a/frontend-ecep/src/app/postulacion/Step5.tsx
+++ b/frontend-ecep/src/app/postulacion/Step5.tsx
@@ -58,7 +58,7 @@ export function Step5({
         <h3 className="text-lg font-medium">Confirmación de Datos</h3>
       </div>
 
-      <div className="bg-gray-50 p-4 rounded-lg text-sm space-y-1">
+      <div className="rounded-lg bg-muted p-4 text-sm space-y-1">
         <p>
           <strong>Aspirante:</strong> {nombre} {apellido}
         </p>
@@ -92,7 +92,7 @@ export function Step5({
         </Label>
       </div>
 
-      <div className="bg-blue-50 p-4 rounded-lg text-sm text-blue-800">
+      <div className="rounded-lg bg-primary/10 p-4 text-sm text-primary">
         Una vez enviada la postulación, recibirá un correo electrónico con un
         resumen de la información proporcionada. El resultado de la postulación
         será comunicado en los próximos días.

--- a/frontend-ecep/src/app/select-rol/page.tsx
+++ b/frontend-ecep/src/app/select-rol/page.tsx
@@ -13,13 +13,7 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 
 export default function SelectRolPage() {
   const { user, loading, selectedRole, setSelectedRole } = useAuth();
@@ -78,7 +72,7 @@ export default function SelectRolPage() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div>
-            <label className="block text-sm mb-2">Rol</label>
+            <label className="block text-sm mb-2 text-muted-foreground">Rol</label>
 
             <div className="flex flex-wrap gap-2 items-start content-start max-w-full">
               {roles.map((r) => (
@@ -86,11 +80,12 @@ export default function SelectRolPage() {
                   key={r}
                   type="button"
                   onClick={() => setLocalRole(r as UserRole)}
-                  className={`rounded-full px-4 h-9 text-sm whitespace-nowrap shrink-0 transition-all ${
+                  className={cn(
+                    "rounded-full px-4 h-9 text-sm whitespace-nowrap shrink-0 transition-all",
                     localRole === r
                       ? "bg-primary text-primary-foreground shadow-sm"
-                      : "bg-white text-gray-700 border border-gray-200 hover:bg-gray-100"
-                  }`}
+                      : "border border-border bg-muted text-foreground/80 hover:bg-muted/80",
+                  )}
                 >
                   {displayRole(r)}
                 </Button>

--- a/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
+++ b/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
@@ -9,9 +9,10 @@ import { TRIMESTRE_ESTADO_LABEL, type TrimestreEstado } from "@/lib/trimestres";
 import { cn } from "@/lib/utils";
 
 const CIRCLE_STYLES: Record<TrimestreEstado, string> = {
-  activo: "bg-emerald-100 text-emerald-400",
-  inactivo: "bg-gray-100 text-gray-400",
-  cerrado: "bg-red-100 text-red-400",
+  activo:
+    "bg-emerald-100 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200",
+  inactivo: "bg-muted text-muted-foreground dark:bg-muted dark:text-muted-foreground",
+  cerrado: "bg-red-100 text-red-500 dark:bg-red-500/20 dark:text-red-300",
 };
 
 export interface TrimestreEstadoBadgeProps {

--- a/frontend-ecep/src/styles/globals.css
+++ b/frontend-ecep/src/styles/globals.css
@@ -81,7 +81,7 @@
 /* Firefox */
 .scrollarea {
   scrollbar-width: thin; /* thin | auto */
-  scrollbar-color: #cbd5e1 transparent; /* thumb | track */
+  scrollbar-color: hsl(var(--border)) transparent; /* thumb | track */
 }
 
 /* Chrome / Edge / Safari */
@@ -93,12 +93,12 @@
   border-radius: 9999px; /* puntas redondeadas del track */
 }
 .scrollarea::-webkit-scrollbar-thumb {
-  background-color: #cbd5e1; /* slate-300 */
+  background-color: hsl(var(--border));
   border-radius: 9999px; /* puntas redondeadas del thumb */
   border: 2px solid transparent; /* evita que “pegue” contra el borde */
   background-clip: padding-box;
 }
 .scrollarea::-webkit-scrollbar-thumb:hover {
-  background-color: #94a3b8; /* slate-400 al hover */
+  background-color: hsl(var(--border) / 0.8);
 }
 


### PR DESCRIPTION
## Summary
- move the appearance controls into a new General tab inside the configuration dialog
- update dashboard layout and key views to use theme tokens instead of hard-coded light colors
- refresh global scrollbar styles and badges so they adapt correctly in dark mode

## Testing
- `bun install` *(fails: npm registry returned HTTP 403 responses in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4aa872ba08327b7aa238237b3c849