### PR TITLE
Allow public persona upsert with sanitization

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/security/SecurityConfig.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/security/SecurityConfig.java
@@ -78,6 +78,7 @@ public class SecurityConfig {
 
                         .requestMatchers(
                                 HttpMethod.POST,
+                                "/api/personas",
                                 "/api/familiares",
                                 "/api/aspirantes",
                                 "/api/aspirante-familiar",
@@ -86,6 +87,7 @@ public class SecurityConfig {
 
                         .requestMatchers(
                                 HttpMethod.PUT,
+                                "/api/personas/*",
                                 "/api/familiares/*",
                                 "/api/aspirantes/*"
                         ).permitAll()


### PR DESCRIPTION
## Summary
- allow unauthenticated access to POST/PUT persona endpoints while sanitizing sensitive fields server-side
- constrain persona create/update logic to distinguish between management roles and public requests, keeping passwords and roles protected
- expand security integration tests to cover the new public upsert behaviour and ensure privileged paths remain enforced

## Testing
- `./mvnw test` *(fails: unable to download Maven wrapper distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4aa46d6108327aa8cc3eabfc46d6d