### PR TITLE
Adjust configuration tabs and dark sidebar styling

### DIFF
--- a/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
+++ b/frontend-ecep/src/app/dashboard/dashboard-layout.tsx
@@ -107,7 +107,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
     <div className="flex h-screen bg-muted dark:bg-background">
       {/* Sidebar */}
       <div
-        className={`${sidebarOpen ? "translate-x-0" : "-translate-x-full"} fixed inset-y-0 left-0 z-50 w-64 bg-background border-r border-border transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0`}
+        className={`${sidebarOpen ? "translate-x-0" : "-translate-x-full"} fixed inset-y-0 left-0 z-50 w-64 bg-background transform transition-transform duration-300 ease-in-out lg:translate-x-0 lg:static lg:inset-0`}
       >
         <div className="flex flex-col h-full">
           {/* LOGO ARRIBA */}


### PR DESCRIPTION
## Summary
- remove the dark-mode sidebar border to eliminate the separating line between the menu and content
- split the director configuration into dedicated "Trimestres" and "Período escolar" tabs with reused logic

## Testing
- npm run lint *(fails: `next` binary not available because npm dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ac8688608327916615cb0a2f0758