### PR TITLE
Integrate HTMLDocs PDF generation

### DIFF
--- a/frontend-ecep/src/app/api/pdf/route.ts
+++ b/frontend-ecep/src/app/api/pdf/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const DEFAULT_HTMLDOCS_ENDPOINT = "https://api.htmldocs.com/v1/documents";
+
+const getEnv = (name: string) => process.env[name];
+
+const getHtmlDocsHeaders = () => {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/pdf",
+  };
+  const apiKey = getEnv("HTMLDOCS_API_KEY") ?? getEnv("NEXT_PUBLIC_HTMLDOCS_API_KEY");
+  const bearer = getEnv("HTMLDOCS_BEARER_TOKEN");
+  const workspace = getEnv("HTMLDOCS_WORKSPACE_ID");
+
+  if (apiKey) {
+    headers["X-API-Key"] = apiKey;
+  }
+
+  if (bearer) {
+    headers.Authorization = `Bearer ${bearer}`;
+  } else if (!apiKey) {
+    throw new Error(
+      "No se encontró una clave de acceso para HTMLDocs (variable HTMLDOCS_API_KEY o HTMLDOCS_BEARER_TOKEN).",
+    );
+  }
+
+  if (workspace) {
+    headers["X-Workspace-Id"] = workspace;
+  }
+
+  return headers;
+};
+
+type RequestPayload = {
+  html?: string;
+  title?: string;
+  fileName?: string;
+};
+
+export async function POST(request: NextRequest) {
+  let payload: RequestPayload;
+  try {
+    payload = (await request.json()) as RequestPayload;
+  } catch {
+    return NextResponse.json(
+      { error: "No se pudo interpretar la solicitud enviada." },
+      { status: 400 },
+    );
+  }
+
+  const { html, title, fileName } = payload;
+
+  if (!html || typeof html !== "string") {
+    return NextResponse.json(
+      { error: "El contenido HTML es obligatorio para generar el PDF." },
+      { status: 400 },
+    );
+  }
+
+  const resolvedTitle = typeof title === "string" && title.trim().length > 0 ? title : "Documento";
+  const resolvedFileName =
+    typeof fileName === "string" && fileName.trim().length > 0 ? fileName : "documento.pdf";
+
+  let headers: Record<string, string>;
+  try {
+    headers = getHtmlDocsHeaders();
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "No se pudo preparar la autenticación con HTMLDocs.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const endpoint = (getEnv("HTMLDOCS_API_URL") ?? DEFAULT_HTMLDOCS_ENDPOINT).replace(/\/$/, "");
+  const pipeline = getEnv("HTMLDOCS_PIPELINE_ID");
+
+  const upstreamBody = pipeline
+    ? {
+        pipeline,
+        input: {
+          html,
+          meta: {
+            title: resolvedTitle,
+          },
+        },
+      }
+    : {
+        document: {
+          html,
+          meta: {
+            title: resolvedTitle,
+          },
+        },
+        output: {
+          type: "pdf",
+        },
+      };
+
+  try {
+    const upstreamResponse = await fetch(`${endpoint}${pipeline ? "/pipelines/run" : ""}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(upstreamBody),
+    });
+
+    if (!upstreamResponse.ok) {
+      let errorMessage = "El servicio de HTMLDocs rechazó la solicitud.";
+      try {
+        const data = await upstreamResponse.json();
+        if (typeof data?.error === "string") {
+          errorMessage = data.error;
+        } else if (typeof data?.message === "string") {
+          errorMessage = data.message;
+        }
+      } catch {
+        const text = await upstreamResponse.text();
+        if (text) {
+          errorMessage = text;
+        }
+      }
+
+      return NextResponse.json({ error: errorMessage }, { status: upstreamResponse.status });
+    }
+
+    const buffer = await upstreamResponse.arrayBuffer();
+
+    return new NextResponse(buffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Length": String(buffer.byteLength),
+        "Cache-Control": "no-store",
+        "Content-Disposition": `attachment; filename="${resolvedFileName}"`,
+      },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "No se pudo conectar con el servicio de HTMLDocs.";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/frontend-ecep/src/lib/pdf.ts
+++ b/frontend-ecep/src/lib/pdf.ts
@@ -1,0 +1,146 @@
+const DEFAULT_STYLES = `
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    margin: 24px;
+    color: #0f172a;
+    font-size: 14px;
+    line-height: 1.6;
+    background: #ffffff;
+  }
+  h1 {
+    font-size: 24px;
+    margin-bottom: 16px;
+  }
+  h2 {
+    font-size: 18px;
+    margin-top: 24px;
+    margin-bottom: 12px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 12px;
+  }
+  th, td {
+    border: 1px solid #cbd5f5;
+    padding: 8px;
+    font-size: 13px;
+    text-align: left;
+    vertical-align: top;
+  }
+  th {
+    background: #e0e7ff;
+  }
+  .card {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    margin-top: 12px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  }
+  .muted {
+    color: #64748b;
+    font-size: 12px;
+  }
+`;
+
+const sanitizeFileName = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+    .replace(/-{2,}/g, "-");
+
+export const suggestPdfFileName = (title: string, fallback = "documento") => {
+  const clean = sanitizeFileName(title || fallback);
+  const date = new Date().toISOString().slice(0, 10);
+  return `${clean || fallback}-${date}.pdf`;
+};
+
+export const buildPdfHtml = ({
+  title,
+  body,
+  styles,
+}: {
+  title: string;
+  body: string;
+  styles?: string;
+}) => {
+  const combinedStyles = `${DEFAULT_STYLES}\n${styles ?? ""}`;
+  return `<!DOCTYPE html>
+  <html lang="es">
+    <head>
+      <meta charset="utf-8" />
+      <title>${escapeHtml(title)}</title>
+      <style>${combinedStyles}</style>
+    </head>
+    <body>
+      <h1>${escapeHtml(title)}</h1>
+      ${body}
+    </body>
+  </html>`;
+};
+
+const escapeMap: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+export const escapeHtml = (value: string | number | null | undefined): string => {
+  if (value === null || value === undefined) return "";
+  return String(value).replace(/[&<>"']/g, (char) => escapeMap[char] ?? char);
+};
+
+export type HtmlDocsDownloadParams = {
+  html: string;
+  title: string;
+  fileName?: string;
+};
+
+export const downloadPdfWithHtmlDocs = async ({
+  html,
+  title,
+  fileName,
+}: HtmlDocsDownloadParams) => {
+  if (typeof window === "undefined") {
+    throw new Error("La descarga de PDF solo está disponible en el navegador.");
+  }
+
+  const effectiveFileName = fileName ?? suggestPdfFileName(title);
+
+  const response = await fetch("/api/pdf", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ html, title, fileName: effectiveFileName }),
+  });
+
+  if (!response.ok) {
+    let message = "No se pudo generar el documento PDF.";
+    try {
+      const data = await response.json();
+      if (typeof data?.error === "string") {
+        message = data.error;
+      }
+    } catch {
+      // ignore parsing errors
+    }
+    throw new Error(message);
+  }
+
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = effectiveFileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary
- add a shared PDF helper plus an API route that proxies HTMLDocs requests for secure generation
- migrate dashboard reports to request PDFs through HTMLDocs with improved feedback and sanitisation
- enable attendance monthly closure exports to generate HTMLDocs PDFs directly from the UI

## Testing
- npm install *(fails: 403 Forbidden fetching npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ab67652483278c1d0847219e1bb0