### PR TITLE
Fix PDF download helper to use window document

### DIFF
--- a/frontend-ecep/src/lib/pdf.ts
+++ b/frontend-ecep/src/lib/pdf.ts
@@ -22,7 +22,7 @@ export type PdfDownloadParams = {
 };
 
 export const downloadPdfDocument = async ({
-  document,
+  document: pdfDocument,
   fileName,
 }: PdfDownloadParams) => {
   if (typeof window === "undefined") {
@@ -30,15 +30,15 @@ export const downloadPdfDocument = async ({
   }
 
   const effectiveFileName = fileName ?? suggestPdfFileName("documento");
-  const instance = pdf(document);
+  const instance = pdf(pdfDocument);
   const blob = await instance.toBlob();
 
   const url = window.URL.createObjectURL(blob);
-  const link = document.createElement("a");
+  const link = window.document.createElement("a");
   link.href = url;
   link.download = effectiveFileName;
-  document.body.appendChild(link);
+  window.document.body.appendChild(link);
   link.click();
-  document.body.removeChild(link);
+  window.document.body.removeChild(link);
   window.URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
## Summary
- avoid shadowing the global document when generating and downloading PDFs so DOM helpers are taken from window.document

## Testing
- npm run lint *(fails: Next.js binary not installed because dependencies could not be installed in the container)*
- npm install *(fails: registry returned 403 for scoped packages, preventing dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68d5346f178483278422111b02b686e8