### PR TITLE
Avoid passing null styles to react-pdf components

### DIFF
--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
@@ -270,27 +270,26 @@ export default function VistaDireccion() {
                   </Text>
                   <Text style={cierrePdfStyles.tableCell}>Valor</Text>
                 </View>
-                {detailRows.map((row, index) => (
-                  <View
-                    key={row.label}
-                    style={[
-                      cierrePdfStyles.tableRow,
-                      index === detailRows.length - 1
-                        ? { borderBottomWidth: 0 }
-                        : null,
-                    ]}
-                  >
-                    <Text
-                      style={[
-                        cierrePdfStyles.tableCell,
-                        cierrePdfStyles.tableCellLabel,
-                      ]}
-                    >
-                      {row.label}
-                    </Text>
-                    <Text style={cierrePdfStyles.tableCell}>{row.value}</Text>
-                  </View>
-                ))}
+                {detailRows.map((row, index) => {
+                  const rowStyles =
+                    index === detailRows.length - 1
+                      ? [cierrePdfStyles.tableRow, { borderBottomWidth: 0 }]
+                      : [cierrePdfStyles.tableRow];
+
+                  return (
+                    <View key={row.label} style={rowStyles}>
+                      <Text
+                        style={[
+                          cierrePdfStyles.tableCell,
+                          cierrePdfStyles.tableCellLabel,
+                        ]}
+                      >
+                        {row.label}
+                      </Text>
+                      <Text style={cierrePdfStyles.tableCell}>{row.value}</Text>
+                    </View>
+                  );
+                })}
               </View>
               <Text style={cierrePdfStyles.note}>
                 Elaborado automáticamente por el sistema de gestión institucional.

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -444,18 +444,19 @@ const reportPdfStyles = StyleSheet.create({
 
 const renderKeyValueList = (pairs: { label: string; value: string }[]) => (
   <View style={reportPdfStyles.keyValueList}>
-    {pairs.map((pair, index) => (
-      <View
-        key={pair.label}
-        style={[
-          reportPdfStyles.keyValueRow,
-          index === pairs.length - 1 ? { borderBottomWidth: 0 } : null,
-        ]}
-      >
-        <Text style={reportPdfStyles.keyValueLabel}>{pair.label}</Text>
-        <Text style={reportPdfStyles.keyValueValue}>{pair.value}</Text>
-      </View>
-    ))}
+    {pairs.map((pair, index) => {
+      const rowStyles =
+        index === pairs.length - 1
+          ? [reportPdfStyles.keyValueRow, { borderBottomWidth: 0 }]
+          : [reportPdfStyles.keyValueRow];
+
+      return (
+        <View key={pair.label} style={rowStyles}>
+          <Text style={reportPdfStyles.keyValueLabel}>{pair.label}</Text>
+          <Text style={reportPdfStyles.keyValueValue}>{pair.value}</Text>
+        </View>
+      );
+    })}
   </View>
 );
 
@@ -470,42 +471,46 @@ const renderTable = (
 ) => (
   <View style={reportPdfStyles.table}>
     <View style={[reportPdfStyles.tableRow, reportPdfStyles.tableHeader]}>
-      {columns.map((column) => (
-        <Text
-          key={column.label}
-          style={[
-            reportPdfStyles.tableCell,
-            reportPdfStyles.tableCellBold,
-            column.width === "wide" ? reportPdfStyles.tableCellWide : null,
-          ]}
-        >
-          {column.label}
-        </Text>
-      ))}
-    </View>
-    {rows.map((row, rowIndex) => (
-      <View
-        key={rowIndex}
-        style={[
-          reportPdfStyles.tableRow,
-          rowIndex === rows.length - 1 ? { borderBottomWidth: 0 } : null,
-        ]}
-      >
-        {row.map((value, colIndex) => (
-          <Text
-            key={`${rowIndex}-${colIndex}`}
-            style={[
-              reportPdfStyles.tableCell,
-              columns[colIndex]?.width === "wide"
-                ? reportPdfStyles.tableCellWide
-                : null,
-            ]}
-          >
-            {String(value)}
+      {columns.map((column) => {
+        const headerStyles =
+          column.width === "wide"
+            ? [
+                reportPdfStyles.tableCell,
+                reportPdfStyles.tableCellBold,
+                reportPdfStyles.tableCellWide,
+              ]
+            : [reportPdfStyles.tableCell, reportPdfStyles.tableCellBold];
+
+        return (
+          <Text key={column.label} style={headerStyles}>
+            {column.label}
           </Text>
-        ))}
-      </View>
-    ))}
+        );
+      })}
+    </View>
+    {rows.map((row, rowIndex) => {
+      const rowStyles =
+        rowIndex === rows.length - 1
+          ? [reportPdfStyles.tableRow, { borderBottomWidth: 0 }]
+          : [reportPdfStyles.tableRow];
+
+      return (
+        <View key={rowIndex} style={rowStyles}>
+          {row.map((value, colIndex) => {
+            const cellStyles =
+              columns[colIndex]?.width === "wide"
+                ? [reportPdfStyles.tableCell, reportPdfStyles.tableCellWide]
+                : [reportPdfStyles.tableCell];
+
+            return (
+              <Text key={`${rowIndex}-${colIndex}`} style={cellStyles}>
+                {String(value)}
+              </Text>
+            );
+          })}
+        </View>
+      );
+    })}
   </View>
 );
 

--- a/frontend-ecep/src/lib/pdf/accident-act.tsx
+++ b/frontend-ecep/src/lib/pdf/accident-act.tsx
@@ -310,10 +310,11 @@ export const createAccidentActDocument = (
               </View>
             </View>
             <Text
-              style={[
-                actaPdfStyles.statusPill,
-                statusIsCerrada ? actaPdfStyles.statusCerrada : null,
-              ]}
+              style={
+                statusIsCerrada
+                  ? [actaPdfStyles.statusPill, actaPdfStyles.statusCerrada]
+                  : [actaPdfStyles.statusPill]
+              }
             >
               {effectiveStatusLabel}
             </Text>


### PR DESCRIPTION
### Summary
- avoid passing `null` entries to `style` props in react-pdf documents so flattening never receives an undefined value
- adjust table render helpers to build style arrays without conditional nulls
- update the accident act export pill styling to branch on the closed state instead of appending a null style

### Testing
- not run (npm registry returns HTTP 403 during `bun install`)


------
https://chatgpt.com/codex/tasks/task_e_68d53857f79883279766e0bc59c6575f