### PR TITLE
Fix accident act PDF generation when participant data missing

### DIFF
--- a/frontend-ecep/src/lib/pdf/accident-act.tsx
+++ b/frontend-ecep/src/lib/pdf/accident-act.tsx
@@ -287,7 +287,10 @@ export const createAccidentActDocument = (
     { label: "Creada por", value: acta.creadoPor },
     { label: "Informante", value: acta.informante },
     { label: "Firmante", value: acta.firmante },
-  ].filter((detail) => detail.value && detail.value.trim().length > 0);
+  ].filter((detail) => {
+    if (typeof detail.value !== "string") return false;
+    return detail.value.trim().length > 0;
+  });
 
   const assignedSigner = acta.firmante?.trim().length
     ? acta.firmante
@@ -337,7 +340,7 @@ export const createAccidentActDocument = (
             </View>
           </View>
 
-          {participantDetails.length > 0 && (
+          {participantDetails.length > 0 ? (
             <View style={actaPdfStyles.section}>
               <Text style={actaPdfStyles.sectionTitle}>Referentes del acta</Text>
               <View style={actaPdfStyles.detailGrid}>
@@ -351,7 +354,7 @@ export const createAccidentActDocument = (
                 ))}
               </View>
             </View>
-          )}
+          ) : null}
 
           <View style={actaPdfStyles.section}>
             <Text style={actaPdfStyles.sectionTitle}>Descripción del suceso</Text>


### PR DESCRIPTION
## Summary
- guard participant details against non-string values when generating the accident act PDF
- avoid passing boolean children to the PDF layout to prevent renderer crashes

## Testing
- Not run (dependencies unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d53f7fd98483278b489f7443e678eb