### PR TITLE
Improve PDF generation to follow react-pdf usage

### DIFF
--- a/frontend-ecep/src/lib/pdf.ts
+++ b/frontend-ecep/src/lib/pdf.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { pdf } from "@react-pdf/renderer";
 import type { ReactElement } from "react";
 
@@ -30,7 +32,8 @@ export const downloadPdfDocument = async ({
   }
 
   const effectiveFileName = fileName ?? suggestPdfFileName("documento");
-  const instance = pdf(pdfDocument);
+  const instance = pdf();
+  instance.updateContainer(pdfDocument);
   const blob = await instance.toBlob();
 
   const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- mark the PDF helper as a client-side module and reuse the pdf instance API recommended by react-pdf
- update the download routine to create an empty instance, inject the document container, and then materialize the blob before triggering the download

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/@hookform%2fresolvers)*

------
https://chatgpt.com/codex/tasks/task_e_68d5424d14d4832797a035873863058e