### PR TITLE
Fix PDF download initialization

### DIFF
--- a/frontend-ecep/src/lib/pdf.ts
+++ b/frontend-ecep/src/lib/pdf.ts
@@ -32,8 +32,7 @@ export const downloadPdfDocument = async ({
   }
 
   const effectiveFileName = fileName ?? suggestPdfFileName("documento");
-  const instance = pdf();
-  instance.updateContainer(pdfDocument);
+  const instance = pdf(pdfDocument);
   const blob = await instance.toBlob();
 
   const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- initialize the @react-pdf/renderer instance with the document element before generating the blob

## Testing
- npm install *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d54956df9883278846cc2d6a371e0a