### PR TITLE
Fix accident acta names and include DNI details

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/_components/ViewActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/ViewActaDialog.tsx
@@ -17,6 +17,9 @@ import { toast } from "sonner";
 type ActaVM = {
   id: number;
   alumno: string;
+  alumnoDni?: string | null;
+  familiar?: string | null;
+  familiarDni?: string | null;
   seccion?: string | null;
   fecha: string;
   hora?: string | null;
@@ -64,11 +67,11 @@ export default function ViewActaDialog({
         `acta-accidente-${acta.id}-${acta.alumno}`,
         `acta-accidente-${acta.id}`,
       );
-      await downloadPdfDocument({
-        create: (doc) =>
-          renderAccidentActPdf(
-            doc,
-            acta,
+          await downloadPdfDocument({
+            create: (doc) =>
+              renderAccidentActPdf(
+                doc,
+                acta,
             {
               statusLabel: isCerrada ? "Cerrada" : "Borrador",
             },
@@ -108,7 +111,16 @@ export default function ViewActaDialog({
               <b>Alumno:</b> {acta.alumno}
             </div>
             <div>
+              <b>DNI del alumno:</b> {acta.alumnoDni ?? "—"}
+            </div>
+            <div>
               <b>Sección:</b> {acta.seccion ?? "—"}
+            </div>
+            <div>
+              <b>Familiar responsable:</b> {acta.familiar ?? "—"}
+            </div>
+            <div>
+              <b>DNI del familiar:</b> {acta.familiarDni ?? "—"}
             </div>
             <div>
               <b>Fecha:</b> {acta.fecha}

--- a/frontend-ecep/src/app/dashboard/actas/_utils/alumno-info.ts
+++ b/frontend-ecep/src/app/dashboard/actas/_utils/alumno-info.ts
@@ -1,0 +1,174 @@
+import { identidad } from "@/services/api/modules";
+import type {
+  AlumnoDTO,
+  AlumnoFamiliarDTO,
+  PersonaDTO,
+} from "@/types/api-generated";
+
+export type AlumnoExtendedInfo = {
+  name: string;
+  dni?: string | null;
+  familiarName?: string | null;
+  familiarDni?: string | null;
+  section?: string | null;
+  level?: "Inicial" | "Primario" | null;
+};
+
+const buildFullName = (
+  apellido?: string | null,
+  nombre?: string | null,
+) => {
+  const lastName = (apellido ?? "").trim();
+  const firstName = (nombre ?? "").trim();
+  if (lastName && firstName) return `${lastName}, ${firstName}`;
+  return (lastName || firstName || "").trim();
+};
+
+const groupFamiliaresPorAlumno = (items: AlumnoFamiliarDTO[]) => {
+  const map = new Map<number, AlumnoFamiliarDTO[]>();
+  for (const item of items) {
+    if (!item) continue;
+    const alumnoId = item.alumnoId;
+    if (alumnoId == null) continue;
+    const list = map.get(alumnoId) ?? [];
+    list.push(item);
+    map.set(alumnoId, list);
+  }
+  return map;
+};
+
+const fetchPersonaMap = async (personaIds: number[]) => {
+  const uniqueIds = Array.from(new Set(personaIds.filter((id) => Number.isFinite(id))));
+  const map = new Map<number, PersonaDTO | null>();
+  if (!uniqueIds.length) return map;
+
+  try {
+    const { data } = await identidad.personasCore.getManyById(uniqueIds);
+    const list = Array.isArray(data) ? data : [];
+    for (const persona of list as PersonaDTO[]) {
+      if (persona?.id != null) {
+        map.set(persona.id, persona);
+      }
+    }
+    const missing = uniqueIds.filter((id) => !map.has(id));
+    if (!missing.length) return map;
+    const fallback = await Promise.all(
+      missing.map(async (id) => {
+        try {
+          const res = await identidad.personasCore.getById(id);
+          return [id, res.data ?? null] as const;
+        } catch {
+          return [id, null] as const;
+        }
+      }),
+    );
+    for (const [id, persona] of fallback) {
+      map.set(id, persona);
+    }
+    return map;
+  } catch {
+    const singles = await Promise.all(
+      uniqueIds.map(async (id) => {
+        try {
+          const res = await identidad.personasCore.getById(id);
+          return [id, res.data ?? null] as const;
+        } catch {
+          return [id, null] as const;
+        }
+      }),
+    );
+    for (const [id, persona] of singles) {
+      map.set(id, persona);
+    }
+    return map;
+  }
+};
+
+export const fetchAlumnoExtendedInfo = async (
+  alumnoIds: number[],
+): Promise<Map<number, AlumnoExtendedInfo>> => {
+  const uniqueAlumnoIds = Array.from(
+    new Set(alumnoIds.filter((id) => Number.isFinite(id))) as number[],
+  );
+  const result = new Map<number, AlumnoExtendedInfo>();
+  if (!uniqueAlumnoIds.length) return result;
+
+  const [familiares, alumnoPairs] = await Promise.all([
+    identidad.alumnoFamiliares
+      .list()
+      .then((res) =>
+        Array.isArray(res.data) ? (res.data as AlumnoFamiliarDTO[]) : [],
+      )
+      .catch(() => [] as AlumnoFamiliarDTO[]),
+    Promise.all(
+      uniqueAlumnoIds.map(async (alumnoId) => {
+        try {
+          const res = await identidad.alumnos.byId(alumnoId);
+          return [alumnoId, res.data ?? null] as const;
+        } catch {
+          return [alumnoId, null] as const;
+        }
+      }),
+    ),
+  ]);
+
+  const alumnoMap = new Map<number, AlumnoDTO | null>(alumnoPairs);
+  const familiaresPorAlumno = groupFamiliaresPorAlumno(familiares);
+
+  const personaIds = new Set<number>();
+  const familiarSeleccionadoPorAlumno = new Map<number, number>();
+
+  for (const [alumnoId, alumno] of alumnoMap.entries()) {
+    const personaId = alumno?.personaId ?? alumno?.id ?? null;
+    if (personaId != null) personaIds.add(personaId);
+    const familiaresAlumno = familiaresPorAlumno.get(alumnoId) ?? [];
+    const elegido = familiaresAlumno.find((f) => f?.convive) ?? familiaresAlumno[0];
+    if (elegido?.familiarId != null) {
+      familiarSeleccionadoPorAlumno.set(alumnoId, elegido.familiarId);
+      personaIds.add(elegido.familiarId);
+    }
+  }
+
+  const personaMap = await fetchPersonaMap(Array.from(personaIds));
+
+  for (const alumnoId of uniqueAlumnoIds) {
+    const alumno = alumnoMap.get(alumnoId) ?? null;
+    const personaId = alumno?.personaId ?? alumno?.id ?? null;
+    const persona = personaId != null ? personaMap.get(personaId) ?? null : null;
+    const nombre = buildFullName(
+      persona?.apellido ?? alumno?.apellido,
+      persona?.nombre ?? alumno?.nombre,
+    );
+    const dni = persona?.dni ?? alumno?.dni ?? null;
+
+    const familiarPersonaId = familiarSeleccionadoPorAlumno.get(alumnoId);
+    const familiarPersona =
+      familiarPersonaId != null ? personaMap.get(familiarPersonaId) ?? null : null;
+    const familiarNombre =
+      familiarPersonaId != null
+        ? buildFullName(familiarPersona?.apellido, familiarPersona?.nombre) ||
+          `Familiar #${familiarPersonaId}`
+        : null;
+    const familiarDni =
+      familiarPersonaId != null ? familiarPersona?.dni ?? null : null;
+
+    const sectionName = (alumno?.seccionActualNombre ?? "").trim();
+    const normalized = sectionName.toLowerCase();
+    const level: "Inicial" | "Primario" | null = sectionName
+      ? normalized.includes("inicial") || normalized.includes("sala")
+        ? "Inicial"
+        : "Primario"
+      : null;
+
+    result.set(alumnoId, {
+      name: nombre || `Alumno #${alumnoId}`,
+      dni: dni ?? null,
+      familiarName: familiarNombre ?? null,
+      familiarDni,
+      section: sectionName || null,
+      level,
+    });
+  }
+
+  return result;
+};

--- a/frontend-ecep/src/lib/pdf/accident-act.ts
+++ b/frontend-ecep/src/lib/pdf/accident-act.ts
@@ -4,6 +4,7 @@ import autoTable from "jspdf-autotable";
 export type AccidentActPdfData = {
   id: number | string | null | undefined;
   alumno?: string | null;
+  alumnoDni?: string | null;
   seccion?: string | null;
   fecha?: string | null;
   hora?: string | null;
@@ -13,6 +14,8 @@ export type AccidentActPdfData = {
   creadoPor?: string | null;
   informante?: string | null;
   firmante?: string | null;
+  familiar?: string | null;
+  familiarDni?: string | null;
 };
 
 export type AccidentActPdfOptions = {
@@ -276,7 +279,11 @@ export const renderAccidentActPdf = (
   cursorY = drawHighlightedBox(
     doc,
     "Alumno involucrado",
-    fallback(acta.alumno, "Alumno sin registrar"),
+    (() => {
+      const nombre = fallback(acta.alumno, "Alumno sin registrar");
+      const dni = formatText(acta.alumnoDni);
+      return dni ? `${nombre} • DNI ${dni}` : nombre;
+    })(),
     marginX,
     cursorY + 30,
     contentWidth,
@@ -284,6 +291,7 @@ export const renderAccidentActPdf = (
 
   const primaryDetails = [
     { label: "Alumno", value: fallback(acta.alumno, "Alumno sin registrar") },
+    { label: "DNI del alumno", value: fallback(acta.alumnoDni) },
     { label: "Sección", value: fallback(acta.seccion) },
     { label: "Fecha del suceso", value: fallback(acta.fecha) },
     { label: "Hora", value: fallback(acta.hora) },
@@ -305,6 +313,21 @@ export const renderAccidentActPdf = (
       participantDetails,
       cursorY,
       "Referentes del acta",
+      marginX,
+      contentWidth,
+    );
+  }
+
+  const familyDetails = [
+    { label: "Familiar responsable", value: fallback(acta.familiar) },
+    { label: "DNI del familiar", value: fallback(acta.familiarDni) },
+  ];
+  if (familyDetails.some((entry) => entry.value !== "—")) {
+    cursorY = autoTableFromEntries(
+      doc,
+      familyDetails,
+      cursorY,
+      "Información del familiar",
       marginX,
       contentWidth,
     );


### PR DESCRIPTION
## Summary
- add a reusable helper to fetch alumno and familiar metadata (nombre y DNI) for actas
- surface alumno/familiar DNI information across actas listings, dialogs and report exports
- update the accident act PDF so it prints alumno and familiar identification data

## Testing
- npm install *(fails: 403 Forbidden when downloading @hookform/resolvers from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d558889f48832786d4d5006b761743