### PR TITLE
Fix hover states for dark theme

### DIFF
--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -472,7 +472,7 @@ export default function SeccionHistorialPage() {
                                       : "Trimestre no activo. Solo lectura"
                                   }
                                 >
-                                  <div className="flex items-center justify-between border rounded p-2 hover:bg-gray-50">
+                                  <div className="flex items-center justify-between border border-border rounded p-2 transition-colors hover:bg-muted">
                                     <div className="flex items-center gap-3">
                                       <Badge variant="outline">{fmt(d.fecha)}</Badge>
                                       <span className="text-sm">

--- a/frontend-ecep/src/app/page.tsx
+++ b/frontend-ecep/src/app/page.tsx
@@ -165,7 +165,7 @@ export default function LoginPage() {
               <div className="space-y-2">
                 <Label htmlFor="email">Correo Electrónico</Label>
                 <div className="relative">
-                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   <Input
                     id="email"
                     type="email"
@@ -183,7 +183,7 @@ export default function LoginPage() {
                   <div className="space-y-2">
                     <Label htmlFor="password">Contraseña</Label>
                     <div className="relative">
-                      <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                      <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                       <Input
                         id="password"
                         type={showPassword ? "text" : "password"}
@@ -196,7 +196,7 @@ export default function LoginPage() {
                       <button
                         type="button"
                         onClick={() => setShowPassword(!showPassword)}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
                       >
                         {showPassword ? (
                           <EyeOff className="h-4 w-4" />
@@ -205,7 +205,7 @@ export default function LoginPage() {
                         )}
                       </button>
                     </div>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-muted-foreground">
                       Mínimo 8 caracteres, 2 números y 1 símbolo especial
                     </p>
                   </div>


### PR DESCRIPTION
## Summary
- adjust login form icon and password toggle colors to use theme tokens in both light and dark modes
- update attendance list hover state to rely on design tokens instead of hard-coded light colors

## Testing
- npm run lint *(fails: missing Next.js binary because dependencies cannot be installed in the sandbox – npm install returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d5607f55cc8327b1f52c0b98db003d