### PR TITLE
feat: improve accident act creation, editing and pdf

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/application/ActaAccidenteService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/application/ActaAccidenteService.java
@@ -45,6 +45,8 @@ public class ActaAccidenteService {
                 .orElseThrow(() -> new EntityNotFoundException("Acta no encontrada: " + id));
 
         boolean onlyMarkSigned =
+                java.util.Objects.equals(acta.getAlumno().getId(), dto.alumnoId()) &&
+                java.util.Objects.equals(acta.getInformante().getId(), dto.informanteId()) &&
                 java.util.Objects.equals(acta.getFechaSuceso(), dto.fechaSuceso()) &&
                 java.util.Objects.equals(acta.getHoraSuceso(), dto.horaSuceso()) &&
                 java.util.Objects.equals(acta.getLugar(), dto.lugar()) &&

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/infrastructure/mapper/ActaAccidenteMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/infrastructure/mapper/ActaAccidenteMapper.java
@@ -29,6 +29,8 @@ public interface ActaAccidenteMapper {
     void update(@MappingTarget ActaAccidente e, ActaAccidenteDTO dto);
 
     @BeanMapping(ignoreByDefault = true)
+    @Mapping(target = "alumno", source = "alumnoId")
+    @Mapping(target = "informante", source = "informanteId")
     @Mapping(target = "fechaSuceso", source = "fechaSuceso")
     @Mapping(target = "horaSuceso", source = "horaSuceso")
     @Mapping(target = "lugar", source = "lugar")

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/dto/ActaAccidenteUpdateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/dto/ActaAccidenteUpdateDTO.java
@@ -8,6 +8,8 @@ import edu.ecep.base_app.vidaescolar.domain.enums.EstadoActaAccidente;
 
 
 public record ActaAccidenteUpdateDTO(
+        @NotNull Long alumnoId,
+        @NotNull Long informanteId,
         @NotNull LocalDate fechaSuceso,
         @NotNull LocalTime horaSuceso,
         @NotBlank String lugar,

--- a/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
@@ -19,7 +19,6 @@ import type {
 } from "@/types/api-generated";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -224,7 +223,8 @@ export default function NewActaDialog({
                   .getById(e.personaId)
                   .then((r) => r.data);
                 const nom = `${p?.apellido ?? ""} ${p?.nombre ?? ""}`.trim();
-                if (nom) display = nom;
+                const dni = (p?.dni ?? "").trim();
+                if (nom) display = dni ? `${nom} — DNI ${dni}` : nom;
               } catch {
                 /* noop */
               }
@@ -352,10 +352,12 @@ export default function NewActaDialog({
         {loading ? (
           <LoadingState label="Cargando información…" />
         ) : (
-          <div className="space-y-4">
+          <div className="space-y-5 text-sm">
             {/* Alumno (autocomplete) */}
-            <div>
-              <Label>Alumno *</Label>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                Alumno *
+              </label>
               <Input
                 placeholder="Buscar: Apellido, Nombre — Sección"
                 value={alumnoQuery}
@@ -364,22 +366,22 @@ export default function NewActaDialog({
                   setAlumnoId(null);
                 }}
               />
-              <div className="mt-1 border rounded max-h-44 overflow-auto">
+              <div className="border rounded max-h-40 overflow-auto text-sm">
                 {suggestions.map((s) => (
                   <div
                     key={s.id}
-                    className={`px-2 py-1 cursor-pointer hover:bg-accent text-sm ${alumnoId === s.id ? "bg-accent" : ""}`}
+                    className={`px-2 py-1 cursor-pointer hover:bg-accent ${alumnoId === s.id ? "bg-accent" : ""}`}
                     onClick={() => pickAlumno(s.id)}
                   >
                     {s.display}
                   </div>
                 ))}
                 {needsQueryHint ? (
-                  <div className="px-2 py-1 text-sm text-muted-foreground">
+                  <div className="px-2 py-1 text-muted-foreground">
                     Escribí al menos 2 letras para buscar.
                   </div>
                 ) : suggestions.length === 0 ? (
-                  <div className="px-2 py-1 text-sm text-muted-foreground">
+                  <div className="px-2 py-1 text-muted-foreground">
                     Sin resultados…
                   </div>
                 ) : null}
@@ -391,9 +393,11 @@ export default function NewActaDialog({
               )}
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <Label>Fecha del suceso *</Label>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">
+                  Fecha del suceso *
+                </label>
                 <Input
                   type="date"
                   min={min2DaysISO()}
@@ -402,8 +406,10 @@ export default function NewActaDialog({
                   onChange={(e) => setFecha(e.target.value)}
                 />
               </div>
-              <div>
-                <Label>Hora (24h) *</Label>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">
+                  Hora (24h) *
+                </label>
                 <Input
                   type="time"
                   value={hora}
@@ -412,17 +418,21 @@ export default function NewActaDialog({
               </div>
             </div>
 
-            <div>
-              <Label>Descripción del suceso *</Label>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                Descripción del suceso *
+              </label>
               <Textarea
-                rows={4}
+                rows={3}
                 value={descripcion}
                 onChange={(e) => setDescripcion(e.target.value)}
               />
             </div>
 
-            <div>
-              <Label>Lugar del suceso *</Label>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                Lugar del suceso *
+              </label>
               <Input
                 value={lugar}
                 onChange={(e) => setLugar(e.target.value)}
@@ -430,8 +440,10 @@ export default function NewActaDialog({
               />
             </div>
 
-            <div>
-              <Label>Acciones realizadas *</Label>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                Acciones realizadas *
+              </label>
               <Textarea
                 rows={3}
                 value={acciones}
@@ -440,8 +452,10 @@ export default function NewActaDialog({
             </div>
 
             {mode === "global" && (
-              <div>
-                <Label>Firmante (empleado) — opcional</Label>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground">
+                  Firmante (empleado) — opcional
+                </label>
                 <Select
                   value={
                     firmadoPorEmpleadoId ? String(firmadoPorEmpleadoId) : ""
@@ -462,7 +476,7 @@ export default function NewActaDialog({
               </div>
             )}
 
-            <div className="flex gap-2">
+            <div className="flex justify-end gap-2">
               <Button
                 variant="outline"
                 onClick={() => onOpenChange(false)}
@@ -470,21 +484,8 @@ export default function NewActaDialog({
               >
                 Cancelar
               </Button>
-              <Button
-                onClick={submit}
-                disabled={
-                  submitting ||
-                  !alumnoId ||
-                  !fecha ||
-                  fecha < min2DaysISO() ||
-                  fecha > todayISO() ||
-                  !hora.trim() ||
-                  !lugar.trim() ||
-                  !descripcion.trim() ||
-                  !acciones.trim()
-                }
-              >
-                {submitting ? "Guardando…" : "Registrar Acta"}
+              <Button onClick={submit} disabled={submitting}>
+                {submitting ? "Guardando…" : "Registrar acta"}
               </Button>
             </div>
           </div>

--- a/frontend-ecep/src/app/dashboard/actas/_components/ViewActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/ViewActaDialog.tsx
@@ -57,6 +57,14 @@ export default function ViewActaDialog({
 }) {
   const [downloading, setDownloading] = useState(false);
   const isCerrada = String(acta.estado).toUpperCase() === "CERRADA";
+  const docenteResponsable = acta.informante
+    ? `${acta.informante}${
+        acta.informanteDni ? ` (DNI ${acta.informanteDni})` : ""
+      }`
+    : "—";
+  const direccionFirmante = acta.firmante
+    ? `${acta.firmante}${acta.firmanteDni ? ` (DNI ${acta.firmanteDni})` : ""}`
+    : "Pendiente de asignación";
 
   const handleDownload = async () => {
     if (downloading) return;
@@ -106,7 +114,7 @@ export default function ViewActaDialog({
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-3 text-sm">
+          <div className="grid gap-3 text-sm sm:grid-cols-2">
             <div>
               <b>Alumno:</b> {acta.alumno}
             </div>
@@ -122,11 +130,8 @@ export default function ViewActaDialog({
             <div>
               <b>DNI del familiar:</b> {acta.familiarDni ?? "—"}
             </div>
-            <div>
-              <b>Fecha:</b> {acta.fecha}
-            </div>
-            <div>
-              <b>Hora:</b> {acta.hora ?? "—"}
+            <div className="sm:col-span-2">
+              <b>Fecha y horario:</b> {acta.fecha} • {acta.hora ?? "—"}
             </div>
             <div>
               <b>Lugar:</b> {acta.lugar ?? "—"}
@@ -134,11 +139,11 @@ export default function ViewActaDialog({
             <div>
               <b>Estado:</b> {String(acta.estado)}
             </div>
-            <div>
-              <b>Informante:</b> {acta.informante ?? "—"}
+            <div className="sm:col-span-2">
+              <b>Docente responsable:</b> {docenteResponsable}
             </div>
-            <div>
-              <b>Firmante:</b> {acta.firmante ?? "—"}
+            <div className="sm:col-span-2">
+              <b>Dirección / Firmante:</b> {direccionFirmante}
             </div>
           </div>
 

--- a/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
@@ -363,9 +363,15 @@ export default function AccidentesSeccionPage() {
       );
       return;
     }
+    if (target.alumnoId == null || target.informanteId == null) {
+      toast.error("El acta no tiene asignado un alumno o docente responsable.");
+      return;
+    }
     try {
       setMarkingId(id);
       await vidaEscolar.actasAccidente.update(id, {
+        alumnoId: target.alumnoId,
+        informanteId: target.informanteId,
         fechaSuceso: target.fechaSuceso ?? new Date().toISOString().slice(0, 10),
         horaSuceso: target.horaSuceso ?? "00:00",
         lugar: target.lugar ?? "",

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -245,7 +245,9 @@ type ActaRegistro = {
   description: string;
   actions: string;
   informant: string;
+  informantDni?: string | null;
   signer?: string;
+  signerDni?: string | null;
   signed: boolean;
   familyName?: string | null;
   familyDni?: string | null;
@@ -396,7 +398,10 @@ export default function ReportesPage() {
   const [activeBoletin, setActiveBoletin] = useState<BoletinStudent | null>(null);
   const [exportingBoletin, setExportingBoletin] = useState(false);
   const [empleadoMap, setEmpleadoMap] = useState<
-    Record<number, { name: string; cargo?: string; situacion?: string }>
+    Record<
+      number,
+      { name: string; cargo?: string; situacion?: string; dni?: string | null }
+    >
   >({});
   const [personalSummary, setPersonalSummary] = useState({
     total: 0,
@@ -967,7 +972,10 @@ export default function ReportesPage() {
         if (!alive) return;
         const personaMap = new Map<number, any>(entries as any);
 
-        const map: Record<number, { name: string; cargo?: string; situacion?: string }> = {};
+        const map: Record<
+          number,
+          { name: string; cargo?: string; situacion?: string; dni?: string | null }
+        > = {};
         let activos = 0;
         let enLicencia = 0;
 
@@ -989,6 +997,7 @@ export default function ReportesPage() {
             name: nombre || `Empleado #${emp.id}`,
             cargo: emp.cargo ?? undefined,
             situacion,
+            dni: persona?.dni ?? null,
           };
         });
 
@@ -1449,7 +1458,9 @@ export default function ReportesPage() {
             description: acta.descripcion ?? "Sin descripción registrada.",
             actions: acta.acciones ?? "Sin acciones registradas.",
             informant: informant?.name ?? "Sin informante",
+            informantDni: informant?.dni ?? null,
             signer: signer?.name,
+            signerDni: signer?.dni ?? null,
             signed: acta.estado === EstadoActaAccidente.CERRADA,
             familyName: alumnoInfo?.familyName ?? null,
             familyDni: alumnoInfo?.familyDni ?? null,
@@ -3216,13 +3227,11 @@ const handleExportCurrent = async () => {
                   </div>
                 </div>
                 <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <span className="text-muted-foreground">Fecha</span>
-                    <p className="font-medium">{activeActa.date}</p>
-                  </div>
-                  <div>
-                    <span className="text-muted-foreground">Horario</span>
-                    <p className="font-medium">{activeActa.time}</p>
+                  <div className="col-span-2">
+                    <span className="text-muted-foreground">Fecha y horario</span>
+                    <p className="font-medium">
+                      {activeActa.date} • {activeActa.time}
+                    </p>
                   </div>
                   <div>
                     <span className="text-muted-foreground">Lugar</span>
@@ -3234,13 +3243,23 @@ const handleExportCurrent = async () => {
                       {activeActa.signed ? "Firmada" : "No firmada"}
                     </Badge>
                   </div>
-                  <div>
-                    <span className="text-muted-foreground">Informante</span>
-                    <p className="font-medium">{activeActa.informant}</p>
+                  <div className="col-span-2">
+                    <span className="text-muted-foreground">Docente responsable</span>
+                    <p className="font-medium">
+                      {activeActa.informant}
+                      {activeActa.informantDni
+                        ? ` (DNI ${activeActa.informantDni})`
+                        : ""}
+                    </p>
                   </div>
-                  <div>
-                    <span className="text-muted-foreground">Firmante</span>
-                    <p className="font-medium">{activeActa.signer ?? "—"}</p>
+                  <div className="col-span-2">
+                    <span className="text-muted-foreground">Dirección / Firmante</span>
+                    <p className="font-medium">
+                      {activeActa.signer ?? "Pendiente de asignación"}
+                      {activeActa.signerDni
+                        ? ` (DNI ${activeActa.signerDni})`
+                        : ""}
+                    </p>
                   </div>
                 </div>
                 <div>
@@ -3274,9 +3293,10 @@ const handleExportCurrent = async () => {
                                 lugar: activeActa.location,
                                 descripcion: activeActa.description,
                                 acciones: activeActa.actions,
-                                creadoPor: activeActa.teacher,
                                 informante: activeActa.informant,
+                                informanteDni: activeActa.informantDni,
                                 firmante: activeActa.signer ?? undefined,
+                                firmanteDni: activeActa.signerDni,
                                 familiar: activeActa.familyName,
                                 familiarDni: activeActa.familyDni,
                               },

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -161,6 +161,8 @@ export interface ActaAccidenteDTO {
 }
 
 export interface ActaAccidenteUpdateDTO {
+  alumnoId: number;
+  informanteId: number;
   fechaSuceso: ISODate;
   horaSuceso: ISOTime;
   lugar: string;


### PR DESCRIPTION
## Summary
- restyle the accident act creation modal to match the edit dialog while keeping student selection available
- allow editing an act to reassign the student and include staff DNI data across listings, reports, and PDFs
- refresh the accident act PDF layout with school branding and dual signature blocks, and enable backend updates for alumno/informante changes

## Testing
- npm run lint *(fails: dependencies could not be installed due to 403 from npm registry)*
- ./mvnw -q test *(fails: Maven could not download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d55fc80ac48327ba09675cfde3c60d