### PR TITLE
Fix accident act PDF parameter syntax

### DIFF
--- a/frontend-ecep/src/lib/pdf/accident-act.ts
+++ b/frontend-ecep/src/lib/pdf/accident-act.ts
@@ -159,8 +159,8 @@ const drawTextBox = (
 
 const drawDualSignatureRow = (
   doc: jsPDF,
-  left: { title: string; name: string; dni?: string | null; note?: string };
-  right: { title: string; name: string; dni?: string | null; note?: string };
+  left: { title: string; name: string; dni?: string | null; note?: string },
+  right: { title: string; name: string; dni?: string | null; note?: string },
   x: number,
   y: number,
   width: number,


### PR DESCRIPTION
## Summary
- replace semicolons with commas in the drawDualSignatureRow parameter list to produce valid TypeScript

## Testing
- npm test *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d56a0b003883279abc4c6cbeb2c46c