### PR TITLE
Separar sección y turno actuales en DTO de alumnos

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AlumnoService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AlumnoService.java
@@ -150,6 +150,9 @@ public class AlumnoService {
     }
 
     private void applySeccionActual(AlumnoDTO dto, Long alumnoId) {
+        dto.setSeccionActualId(null);
+        dto.setSeccionActualNombre(null);
+        dto.setSeccionActualTurno(null);
         if (alumnoId == null) {
             return;
         }
@@ -163,6 +166,7 @@ public class AlumnoService {
                 if (seccion != null) {
                     dto.setSeccionActualId(seccion.getId());
                     dto.setSeccionActualNombre(buildNombreSeccion(seccion));
+                    dto.setSeccionActualTurno(seccion.getTurno() != null ? seccion.getTurno().name() : null);
                 }
                 return;
             }
@@ -177,9 +181,6 @@ public class AlumnoService {
         if (seccion.getDivision() != null) {
             if (sb.length() > 0) sb.append(" ");
             sb.append(seccion.getDivision());
-        }
-        if (seccion.getTurno() != null) {
-            sb.append(" (" + seccion.getTurno() + ")");
         }
         return sb.length() > 0 ? sb.toString() : "";
     }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoMapper.java
@@ -20,6 +20,7 @@ public interface AlumnoMapper {
     @Mapping(target = "dni", source = "persona.dni")
     @Mapping(target = "seccionActualId", ignore = true)
     @Mapping(target = "seccionActualNombre", ignore = true)
+    @Mapping(target = "seccionActualTurno", ignore = true)
     AlumnoDTO toDto(Alumno e);
 
     // DTO -> Entity

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoDTO.java
@@ -27,4 +27,5 @@ public class AlumnoDTO {
 
     Long seccionActualId;
     String seccionActualNombre;
+    String seccionActualTurno;
 }


### PR DESCRIPTION
## Summary
- exponer el turno actual como campo separado en AlumnoDTO
- actualizar el servicio de alumnos para poblar sección y turno sin concatenarlos

## Testing
- `./mvnw test` *(falla: el contenedor no puede descargar Apache Maven de internet)*

------
https://chatgpt.com/codex/tasks/task_e_68d56becf2688327b79a7ba31579791c