### PR TITLE
Evitar recarga de datos cuando la BD ya tiene información

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/bootstrap/DataLoader.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/bootstrap/DataLoader.java
@@ -85,6 +85,11 @@ public class DataLoader implements org.springframework.boot.CommandLineRunner {
     public void run(String... args) {
         log.info("Iniciando carga de datos de prueba...");
 
+        if (personaRepository.count() > 0) {
+            log.info("La base de datos ya contiene información. Se omite la carga inicial de datos.");
+            return;
+        }
+
         ensureAdminAndUser();
 
         PeriodoEscolar periodo2025 = ensurePeriodoEscolar(2025);


### PR DESCRIPTION
## Resumen
- Evita ejecutar el DataLoader cuando la base de datos ya contiene registros en el repositorio de personas.
- Se agrega un log para indicar que la carga inicial fue omitida.

## Pruebas
- No se ejecutaron pruebas; el cambio solo afecta la inicialización condicional de datos.

------
https://chatgpt.com/codex/tasks/task_e_68d56f3f21e08327975959de88d41c52