### PR TITLE
Fix boletin report table overflow

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -3151,7 +3151,7 @@ const handleExportCurrent = async () => {
                         No hay calificaciones registradas para este alumno.
                       </div>
                     ) : (
-                      <div className="w-full overflow-x-auto lg:overflow-visible">
+                      <div className="w-full max-w-full overflow-x-auto">
                         <table className="min-w-full table-auto border-collapse text-xs sm:text-sm">
                           <thead>
                             <tr>


### PR DESCRIPTION
## Summary
- ensure the boletín detail table keeps horizontal scrolling at every breakpoint to avoid clipping within the sheet

## Testing
- npm run lint *(fails: next binary missing because dependencies cannot be installed in the container)*


------
https://chatgpt.com/codex/tasks/task_e_68d577470af483279f39248099a7ec90