### PR TITLE
Fix accident record view error and allow selecting informant

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/application/ActaAccidenteService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/application/ActaAccidenteService.java
@@ -50,9 +50,11 @@ public class ActaAccidenteService {
         ActaAccidente acta = repo.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Acta no encontrada: " + id));
 
+        Long currentInformanteId = acta.getInformante() != null ? acta.getInformante().getId() : null;
+
         boolean coreDataChanged =
                 !Objects.equals(acta.getAlumno().getId(), dto.alumnoId()) ||
-                !Objects.equals(acta.getInformante().getId(), dto.informanteId()) ||
+                !Objects.equals(currentInformanteId, dto.informanteId()) ||
                 !Objects.equals(acta.getFechaSuceso(), dto.fechaSuceso()) ||
                 !Objects.equals(acta.getHoraSuceso(), dto.horaSuceso()) ||
                 !Objects.equals(acta.getLugar(), dto.lugar()) ||


### PR DESCRIPTION
## Summary
- guard accident record updates against missing informants to prevent errors when viewing existing actas
- allow directors to choose the reporting teacher when registering a new acta, including UI updates for selection

## Testing
- ./mvnw test *(fails: Maven distribution download blocked in sandbox)*
- bun run lint *(fails: Next.js binary unavailable without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d588307ab083279ec4a40d6bae7f51