### PR TITLE
Fix personal refresh response handling

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -482,7 +482,7 @@ export default function AccidentesIndexPage() {
       identidad.empleados.list().catch(() => ({ data: [] })),
     ]);
     setActas(actasRes.data ?? []);
-    if (personalRes.data) setPersonal(personalRes.data);
+    setPersonal(pageContent<EmpleadoDTO>(personalRes.data));
   };
 
   const isFirmadaDto = (dto?: ActaAccidenteDTO | null) =>


### PR DESCRIPTION
## Summary
- normalize refreshed employee data using pageContent to keep the personal list as an array

## Testing
- `npm run lint` *(fails: next binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d58ce2a53c8327ba4e50098e8d5dc0