### PR TITLE
Fix warning alerts styling in dark mode

### DIFF
--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -413,7 +413,7 @@ export default function SeccionHistorialPage() {
 
                             <CardContent className="space-y-2">
                               {!canEdit && (
-                                <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                                <Alert className="border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
                                   <AlertTitle>{estadoLabel}</AlertTitle>
                                   <AlertDescription>
                                     {estadoMessage}

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -648,7 +648,7 @@ export default function CierrePrimarioView({
                         </p>
                       )}
                       {triSoloLectura && (
-                        <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                        <Alert className="border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
                           <AlertTitle>
                             {activeTrimestreLabel || "Estado del trimestre"}
                           </AlertTitle>

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/NotasExamenDialog.tsx
@@ -262,7 +262,7 @@ export default function NotasExamenDialog({
         ) : (
           <>
             {trimestreSoloLectura && (
-              <div className="rounded-md bg-amber-50 border border-amber-200 text-amber-800 text-sm p-2 mb-2">
+              <div className="rounded-md bg-amber-50 border border-amber-200 text-amber-800 dark:bg-amber-950/40 dark:border-amber-400/40 dark:text-amber-100 text-sm p-2 mb-2">
                 {trimestreEstado === "cerrado"
                   ? "Este trimestre está cerrado. Solo lectura."
                   : "Este trimestre está inactivo. Solo lectura."}

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -657,7 +657,7 @@ export default function SeccionEvaluacionesPage() {
                             ) : (
                               <>
                                 {!canEdit && (
-                                  <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                                  <Alert className="border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-100">
                                     <AlertTitle>{estadoLabel}</AlertTitle>
                                     <AlertDescription>{estadoMessage}</AlertDescription>
                                   </Alert>


### PR DESCRIPTION
## Summary
- adjust trimester warning alerts to include dark theme colors so they are legible in dark mode

## Testing
- npm run lint *(fails: `next: not found` before dependencies could be installed due to registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d58e8700e08327a2ea7025410fdb37