### PR TITLE
Ocultar calificaciones familiares hasta cierre de trimestre

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/CalificacionTrimestralRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/CalificacionTrimestralRepository.java
@@ -1,8 +1,13 @@
 package edu.ecep.base_app.gestionacademica.infrastructure.persistence;
 
 import edu.ecep.base_app.gestionacademica.domain.CalificacionTrimestral;
+import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface CalificacionTrimestralRepository extends JpaRepository<CalificacionTrimestral, Long> {
     boolean existsByTrimestreIdAndSeccionMateriaIdAndMatriculaId(Long trimestreId, Long seccionMateriaId, Long matriculaId);
+
+    List<CalificacionTrimestral> findByTrimestreEstado(TrimestreEstado estado);
 }


### PR DESCRIPTION
## Summary
- Restringí el servicio de calificaciones para que los familiares solo reciban registros de trimestres cerrados aprovechando los roles del usuario autenticado. 
- Añadí un método de repositorio para filtrar calificaciones por estado de trimestre.
- Actualicé la vista familiar de calificaciones en el frontend para ocultar notas y observaciones hasta que la dirección cierre el trimestre y mostrar un mensaje informativo mientras tanto.

## Testing
- `./mvnw -q test` *(falla: el wrapper no pudo descargar Maven desde repo.maven.apache.org en este entorno)*
- `npm run lint` *(falla: faltan dependencias porque la instalación vía npm obtuvo un 403 del registry en este entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d58f0d0658832780ba89bf08674672