### PR TITLE
Adjust landing page colors for dark mode

### DIFF
--- a/frontend-ecep/src/app/page.tsx
+++ b/frontend-ecep/src/app/page.tsx
@@ -129,7 +129,9 @@ export default function LoginPage() {
 
   // ---- UI de login ----
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex items-center justify-center p-4">
+    <div
+      className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-blue-50 to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900"
+    >
       <div className="w-full max-w-md space-y-8">
         {/* Logo y título */}
         <div className="text-center">
@@ -138,11 +140,13 @@ export default function LoginPage() {
               <School className="h-8 w-8" />
             </div>
           </div>
-          <h1 className="text-3xl font-bold text-gray-900">ECEP</h1>
-          <p className="text-gray-600 mt-2">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
+            ECEP
+          </h1>
+          <p className="text-gray-600 dark:text-slate-300 mt-2">
             Escuela Complejo Evangelico Pilar
           </p>
-          <p className="text-sm text-gray-500 mt-1">
+          <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">
             Sistema de Gestión Escolar
           </p>
         </div>
@@ -150,10 +154,10 @@ export default function LoginPage() {
         {/* Formulario de login */}
         <Card className="shadow-lg">
           <CardHeader>
-            <CardTitle className="text-2xl text-center">
+            <CardTitle className="text-2xl text-center dark:text-slate-100">
               Iniciar Sesión
             </CardTitle>
-            <CardDescription className="text-center">
+            <CardDescription className="text-center dark:text-slate-300">
               Ingrese sus credenciales para acceder al sistema
             </CardDescription>
           </CardHeader>
@@ -229,10 +233,12 @@ export default function LoginPage() {
               <>
                 <div className="relative my-6">
                   <div className="absolute inset-0 flex items-center">
-                    <div className="w-full border-t border-gray-300" />
+                    <div className="w-full border-t border-gray-300 dark:border-slate-700" />
                   </div>
                   <div className="relative flex justify-center text-sm">
-                    <span className="bg-white px-2 text-gray-500">o</span>
+                    <span className="bg-white dark:bg-slate-900 px-2 text-gray-500 dark:text-slate-400">
+                      o
+                    </span>
                   </div>
                 </div>
 
@@ -248,7 +254,7 @@ export default function LoginPage() {
         </Card>
 
         {/* Información adicional */}
-        <div className="text-center text-sm text-gray-600 space-y-2">
+        <div className="text-center text-sm text-gray-600 dark:text-slate-300 space-y-2">
           <div className="flex flex-wrap items-center justify-center gap-4">
             <div className="flex items-center">
               <GraduationCap className="h-4 w-4 mr-1" />


### PR DESCRIPTION
## Summary
- update the login landing page background gradient to switch to a darker palette when dark mode is active
- ensure headings, descriptions, dividers and supporting text use dark-mode friendly colors for contrast

## Testing
- npm run lint *(fails: npm install returned 403 Forbidden when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d592c95a908327ace133ec3608cd1e