### PR TITLE
Fix aspirante lookup for postulacion submissions

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/application/AspiranteService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/application/AspiranteService.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +38,14 @@ public class AspiranteService {
         return aspiranteRepository.findById(id)
                 .map(mapper::toDto)
                 .orElseThrow(() -> new NotFoundException("Aspirante no encontrado"));
+    }
+
+    public Optional<AspiranteDTO> findByPersonaId(Long personaId) {
+        if (personaId == null) {
+            return Optional.empty();
+        }
+        return aspiranteRepository.findByPersonaId(personaId)
+                .map(mapper::toDto);
     }
 
     @Transactional

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/AspiranteController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/AspiranteController.java
@@ -25,6 +25,12 @@ public class AspiranteController {
     private final AspiranteService service;
     @GetMapping public List<AspiranteDTO> list(){ return service.findAll(); }
     @GetMapping("/{id}") public AspiranteDTO get(@PathVariable Long id){ return service.get(id); }
+    @GetMapping("/persona/{personaId}")
+    public ResponseEntity<AspiranteDTO> findByPersona(@PathVariable Long personaId) {
+        return service.findByPersonaId(personaId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
     @PostMapping public ResponseEntity<AspiranteDTO> create(@RequestBody @Valid AspiranteDTO dto){ return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED); }
     @PutMapping("/{id}") public ResponseEntity<Void> update(@PathVariable Long id, @RequestBody @Valid AspiranteDTO dto){ service.update(id, dto); return ResponseEntity.noContent().build(); }
     @DeleteMapping("/{id}") public ResponseEntity<Void> delete(@PathVariable Long id){ service.delete(id); return ResponseEntity.noContent().build(); }

--- a/frontend-ecep/src/app/postulacion/page.tsx
+++ b/frontend-ecep/src/app/postulacion/page.tsx
@@ -518,16 +518,21 @@ export default function PostulacionPage() {
     };
 
     try {
-      const { data } = await admisiones.aspirantes.byId(personaId);
-      await admisiones.aspirantes.update(personaId, payload);
-      return data?.id ?? personaId;
-    } catch (error: any) {
-      if (error?.response?.status === 404) {
-        const { data } = await admisiones.aspirantes.create(payload);
-        return data?.id ?? personaId;
+      const { data } = await admisiones.aspirantes.byPersonaId(personaId);
+      const aspiranteId = data?.id;
+      if (aspiranteId == null) {
+        throw new Error("No se pudo determinar el ID del aspirante.");
       }
-      throw error;
+      await admisiones.aspirantes.update(aspiranteId, payload);
+      return aspiranteId;
+    } catch (error: any) {
+      if (error?.response?.status !== 404) {
+        throw error;
+      }
     }
+
+    const { data } = await admisiones.aspirantes.create(payload);
+    return data?.id ?? personaId;
   };
 
   const ensureFamiliarRecord = async (

--- a/frontend-ecep/src/services/api/modules/admisiones/index.ts
+++ b/frontend-ecep/src/services/api/modules/admisiones/index.ts
@@ -4,6 +4,8 @@ import type * as DTO from "@/types/api-generated";
 const aspirantes = {
   list: () => http.get<DTO.AspiranteDTO[]>("/api/aspirantes"),
   byId: (id: number) => http.get<DTO.AspiranteDTO>("/api/aspirantes/" + id),
+  byPersonaId: (personaId: number) =>
+    http.get<DTO.AspiranteDTO>("/api/aspirantes/persona/" + personaId),
   create: (body: Omit<DTO.AspiranteDTO, "id">) =>
     http.post<DTO.AspiranteDTO>("/api/aspirantes", body),
   update: (id: number, body: Partial<DTO.AspiranteDTO>) =>


### PR DESCRIPTION
## Summary
- add backend endpoint and service method to fetch aspirantes by personaId
- update postulacion flow to reuse existing aspirantes instead of recreating them
- extend frontend API module with helper for the new backend route

## Testing
- ⚠️ `./mvnw test` *(fails: Maven wrapper cannot download Maven distribution due to restricted network access)*
- ⚠️ `bun install` *(fails: npm registry not reachable from sandbox, preventing dependency installation and further frontend checks)*

------
https://chatgpt.com/codex/tasks/task_e_68d5928f6ca88327be3580fd69664e7e