### PR TITLE
Clarify duplicate section labels in staff assignment selector

### DIFF
--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -1821,7 +1821,30 @@ export default function PersonalPage() {
         };
       },
     );
-    return entries.sort((a, b) =>
+
+    const labelCounts = new Map<string, number>();
+    entries.forEach((entry) => {
+      labelCounts.set(entry.label, (labelCounts.get(entry.label) ?? 0) + 1);
+    });
+
+    const normalizedEntries = entries.map((entry) => {
+      if ((labelCounts.get(entry.label) ?? 0) <= 1) {
+        return entry;
+      }
+      const metadata = seccionMetadataById.get(entry.id);
+      const suffixParts: string[] = [];
+      if (metadata?.nivel) {
+        suffixParts.push(formatNivel(metadata.nivel));
+      }
+      suffixParts.push(`ID ${entry.id}`);
+      const suffix = suffixParts.join(" • ");
+      return {
+        ...entry,
+        label: `${entry.label} – ${suffix}`,
+      };
+    });
+
+    return normalizedEntries.sort((a, b) =>
       a.label.localeCompare(b.label, "es", { sensitivity: "base" }),
     );
   }, [seccionMetadataById, titularSeccionMap]);


### PR DESCRIPTION
## Summary
- make the staff assignment section selector detect duplicate labels
- append the level and identifier to duplicated section labels to disambiguate them for users

## Testing
- bun run lint *(fails: missing Next.js binary because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d597318ba8832791aa477abcc3b3b4