### PR TITLE
Limit docente data access to assigned sections

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/application/AsistenciaQueryService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/application/AsistenciaQueryService.java
@@ -1,10 +1,14 @@
 package edu.ecep.base_app.asistencias.application;
 
 
+import edu.ecep.base_app.asistencias.presentation.dto.AsistenciaAcumuladoDTO;
+import edu.ecep.base_app.asistencias.presentation.dto.AsistenciaAlumnoResumenDTO;
+import edu.ecep.base_app.asistencias.presentation.dto.AsistenciaDiaDTO;
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService;
 import edu.ecep.base_app.gestionacademica.domain.Seccion;
 import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionDTO;
-import edu.ecep.base_app.asistencias.presentation.dto.*;
-import edu.ecep.base_app.gestionacademica.infrastructure.mapper.SeccionMapper; // si lo tenés; si no, mapeamos a mano
+import edu.ecep.base_app.gestionacademica.infrastructure.mapper.SeccionMapper;
+import edu.ecep.base_app.gestionacademica.infrastructure.persistence.AsignacionDocenteMateriaRepository;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.AsignacionDocenteSeccionRepository;
 import edu.ecep.base_app.asistencias.infrastructure.persistence.DetalleAsistenciaRepository;
 import edu.ecep.base_app.asistencias.infrastructure.persistence.JornadaAsistenciaRepository;
@@ -14,7 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 
 @Service
@@ -25,14 +31,36 @@ public class AsistenciaQueryService {
     private final JornadaAsistenciaRepository jornadaRepo;
     private final DetalleAsistenciaRepository detalleRepo;
     private final AsignacionDocenteSeccionRepository asigSecRepo;
+    private final AsignacionDocenteMateriaRepository asigMatRepo;
     private final SeccionMapper seccionMapper;
+    private final DocenteScopeService docenteScopeService;
+
+    private static final Comparator<Seccion> SECCION_COMPARATOR = Comparator
+            .comparing(Seccion::getNivel)
+            .thenComparing(Seccion::getGradoSala)
+            .thenComparing(Seccion::getDivision)
+            .thenComparing(Seccion::getTurno)
+            .thenComparing(Seccion::getId);
 
     public List<SeccionDTO> seccionesVigentesDocente(Long empleadoId, LocalDate fecha) {
-        List<Seccion> secciones = asigSecRepo.findSeccionesVigentesByEmpleado(empleadoId, fecha);
-        return secciones.stream().map(seccionMapper::toDto).toList();
+        Map<Long, Seccion> secciones = new LinkedHashMap<>();
+
+        asigSecRepo.findSeccionesVigentesByEmpleado(empleadoId, fecha)
+                .forEach(seccion -> secciones.putIfAbsent(seccion.getId(), seccion));
+
+        asigMatRepo.findVigentesByEmpleado(empleadoId, fecha)
+                .stream()
+                .map(asignacion -> asignacion.getSeccionMateria().getSeccion())
+                .forEach(seccion -> secciones.putIfAbsent(seccion.getId(), seccion));
+
+        return secciones.values().stream()
+                .sorted(SECCION_COMPARATOR)
+                .map(seccionMapper::toDto)
+                .toList();
     }
 
     public List<AsistenciaDiaDTO> historialSeccion(Long seccionId, LocalDate from, LocalDate to) {
+        docenteScopeService.ensurePuedeAccederSeccion(seccionId);
         List<AsistenciaDiaDTO> lista = jornadaRepo.resumenDiario(seccionId, from, to);
         // completar porcentaje y ordenar
         lista.forEach(d -> d.setPorcentaje(pct(d.getPresentes(), d.getTotal())));
@@ -42,6 +70,7 @@ public class AsistenciaQueryService {
     }
 
     public AsistenciaAcumuladoDTO acumuladoSeccion(Long seccionId, LocalDate from, LocalDate to) {
+        docenteScopeService.ensurePuedeAccederSeccion(seccionId);
         AsistenciaAcumuladoDTO dto = detalleRepo.acumuladoSeccion(seccionId, from, to);
         if (dto == null) dto = new AsistenciaAcumuladoDTO();
         dto.setDesde(from);
@@ -51,6 +80,7 @@ public class AsistenciaQueryService {
     }
 
     public List<AsistenciaAlumnoResumenDTO> resumenPorAlumno(Long seccionId, LocalDate from, LocalDate to) {
+        docenteScopeService.ensurePuedeAccederSeccion(seccionId);
         List<AsistenciaAlumnoResumenDTO> lista = detalleRepo.resumenPorAlumno(seccionId, from, to);
         lista.forEach(d -> d.setPorcentaje(pct(d.getPresentes(), d.getTotal())));
         return lista;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/application/DetalleAsistenciaService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/application/DetalleAsistenciaService.java
@@ -2,13 +2,14 @@ package edu.ecep.base_app.asistencias.application;
 
 import edu.ecep.base_app.asistencias.domain.DetalleAsistencia;
 import edu.ecep.base_app.asistencias.domain.JornadaAsistencia;
-import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
-import edu.ecep.base_app.asistencias.presentation.dto.DetalleAsistenciaCreateDTO;
-import edu.ecep.base_app.asistencias.presentation.dto.DetalleAsistenciaDTO;
-import edu.ecep.base_app.asistencias.presentation.dto.DetalleAsistenciaUpdateDTO;
 import edu.ecep.base_app.asistencias.infrastructure.mapper.DetalleAsistenciaMapper;
 import edu.ecep.base_app.asistencias.infrastructure.persistence.DetalleAsistenciaRepository;
 import edu.ecep.base_app.asistencias.infrastructure.persistence.JornadaAsistenciaRepository;
+import edu.ecep.base_app.asistencias.presentation.dto.DetalleAsistenciaCreateDTO;
+import edu.ecep.base_app.asistencias.presentation.dto.DetalleAsistenciaDTO;
+import edu.ecep.base_app.asistencias.presentation.dto.DetalleAsistenciaUpdateDTO;
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService;
+import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -25,24 +28,40 @@ public class DetalleAsistenciaService {
     private final DetalleAsistenciaRepository repo;
     private final JornadaAsistenciaRepository jornadaRepo;
     private final DetalleAsistenciaMapper mapper;
+    private final DocenteScopeService docenteScopeService;
 
     public List<DetalleAsistenciaDTO> findAll() {
-        return repo.findAll().stream().map(mapper::toDto).toList();
+        List<DetalleAsistencia> detalles = repo.findAll();
+        Optional<DocenteScopeService.DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            Set<Long> secciones = scopeOpt.get().seccionesAccesibles();
+            if (secciones.isEmpty()) {
+                return List.of();
+            }
+            detalles = detalles.stream()
+                    .filter(d -> secciones.contains(d.getJornada().getSeccion().getId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+        return detalles.stream().map(mapper::toDto).toList();
     }
 
     @Transactional(readOnly = true)
     public DetalleAsistenciaDTO get(Long id) {
-        return repo.findById(id)
-                .map(mapper::toDto)
+        DetalleAsistencia detalle = repo.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Detalle no encontrado"));
+        docenteScopeService.ensurePuedeAccederSeccion(detalle.getJornada().getSeccion().getId());
+        return mapper.toDto(detalle);
     }
 
     @Transactional
     public Long marcar(DetalleAsistenciaCreateDTO dto) {
-        JornadaAsistencia j = jornadaRepo.findById(dto.getJornadaId())
+        JornadaAsistencia jornada = jornadaRepo.findById(dto.getJornadaId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Jornada no encontrada"));
+        docenteScopeService.ensurePuedeAccederSeccion(jornada.getSeccion().getId());
 
-        if (j.getTrimestre() != null && j.getTrimestre().getEstado() != TrimestreEstado.ACTIVO) {
+        if (jornada.getTrimestre() != null && jornada.getTrimestre().getEstado() != TrimestreEstado.ACTIVO) {
             throw new IllegalArgumentException("El trimestre no está activo");
         }
 
@@ -57,6 +76,7 @@ public class DetalleAsistenciaService {
     public void actualizarParcial(Long id, DetalleAsistenciaUpdateDTO dto) {
         DetalleAsistencia entity = repo.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Detalle no encontrado"));
+        docenteScopeService.ensurePuedeAccederSeccion(entity.getJornada().getSeccion().getId());
         entity.setEstado(dto.getEstado());
         entity.setObs(dto.getObservacion());
         repo.save(entity);
@@ -64,10 +84,10 @@ public class DetalleAsistenciaService {
 
     @Transactional
     public void delete(Long id) {
-        if (!repo.existsById(id)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Detalle no encontrado");
-        }
-        repo.deleteById(id);
+        DetalleAsistencia entity = repo.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Detalle no encontrado"));
+        docenteScopeService.ensurePuedeAccederSeccion(entity.getJornada().getSeccion().getId());
+        repo.delete(entity);
     }
 
     @Transactional(readOnly = true)
@@ -75,12 +95,29 @@ public class DetalleAsistenciaService {
                                              LocalDate from, LocalDate to) {
         List<DetalleAsistencia> res;
         if (jornadaId != null) {
+            JornadaAsistencia jornada = jornadaRepo.findById(jornadaId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Jornada no encontrada"));
+            docenteScopeService.ensurePuedeAccederSeccion(jornada.getSeccion().getId());
             res = repo.findByJornadaId(jornadaId);
         } else if (matriculaId != null && from != null && to != null) {
             res = repo.findByMatriculaIdAndJornada_FechaBetween(matriculaId, from, to);
         } else {
             res = repo.findAll();
         }
+
+        Optional<DocenteScopeService.DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            Set<Long> secciones = scopeOpt.get().seccionesAccesibles();
+            if (secciones.isEmpty()) {
+                return List.of();
+            }
+            res = res.stream()
+                    .filter(d -> secciones.contains(d.getJornada().getSeccion().getId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+
         return res.stream().map(mapper::toDto).toList();
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/application/JornadaAsistenciaService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/asistencias/application/JornadaAsistenciaService.java
@@ -1,24 +1,26 @@
 package edu.ecep.base_app.asistencias.application;
 
+import edu.ecep.base_app.asistencias.domain.JornadaAsistencia;
 import edu.ecep.base_app.asistencias.infrastructure.mapper.JornadaAsistenciaMapper;
 import edu.ecep.base_app.asistencias.infrastructure.persistence.JornadaAsistenciaRepository;
 import edu.ecep.base_app.asistencias.presentation.dto.JornadaAsistenciaCreateDTO;
 import edu.ecep.base_app.asistencias.presentation.dto.JornadaAsistenciaDTO;
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService;
 import edu.ecep.base_app.gestionacademica.domain.Trimestre;
 import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.TrimestreRepository;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -27,22 +29,40 @@ public class JornadaAsistenciaService {
     private final JornadaAsistenciaRepository repo;
     private final JornadaAsistenciaMapper mapper;
     private final TrimestreRepository trimRepo;
+    private final DocenteScopeService docenteScopeService;
 
     public List<JornadaAsistenciaDTO> findAll() {
-        return repo.findAll(Sort.by("fecha").descending())
-                .stream().map(mapper::toDto).toList();
+        List<JornadaAsistenciaDTO> jornadas = repo.findAll(Sort.by("fecha").descending())
+                .stream()
+                .map(mapper::toDto)
+                .toList();
+        Optional<DocenteScopeService.DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            Set<Long> secciones = scopeOpt.get().seccionesAccesibles();
+            if (secciones.isEmpty()) {
+                return List.of();
+            }
+            return jornadas.stream()
+                    .filter(dto -> secciones.contains(dto.getSeccionId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+        return jornadas;
     }
+
     @Transactional(readOnly = true)
     public Optional<JornadaAsistenciaDTO> findBySeccionAndFecha(Long seccionId, LocalDate fecha) {
+        docenteScopeService.ensurePuedeAccederSeccion(seccionId);
         return repo.findBySeccionIdAndFecha(seccionId, fecha).map(mapper::toDto);
     }
 
+    @Transactional
     public Long abrir(JornadaAsistenciaCreateDTO dto) {
-        // no duplicar jornadas por sección+fecha
+        docenteScopeService.ensurePuedeAccederSeccion(dto.getSeccionId());
         if (repo.existsBySeccionIdAndFecha(dto.getSeccionId(), dto.getFecha())) {
             throw new IllegalArgumentException("Ya existe una jornada para esa sección y fecha");
         }
-        // validar trimestre y que no esté cerrado
         Trimestre tri = trimRepo.findById(dto.getTrimestreId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Trimestre no encontrado"));
         if (tri.getEstado() != TrimestreEstado.ACTIVO) {
@@ -51,31 +71,48 @@ public class JornadaAsistenciaService {
         return repo.save(mapper.toEntity(dto)).getId();
     }
 
-
     @Transactional(readOnly = true)
     public JornadaAsistenciaDTO get(Long id) {
-        var j = repo.findById(id)
+        JornadaAsistencia jornada = repo.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Jornada " + id + " no encontrada"));
-        return mapper.toDto(j);
+        docenteScopeService.ensurePuedeAccederSeccion(jornada.getSeccion().getId());
+        return mapper.toDto(jornada);
     }
+
     public List<JornadaAsistenciaDTO> findBySeccion(Long seccionId) {
+        docenteScopeService.ensurePuedeAccederSeccion(seccionId);
         return repo.findBySeccionId(seccionId).stream().map(mapper::toDto).toList();
     }
 
     public List<JornadaAsistenciaDTO> findBySeccionBetween(Long seccionId, LocalDate from, LocalDate to) {
+        docenteScopeService.ensurePuedeAccederSeccion(seccionId);
         return repo.findBySeccionIdAndFechaBetween(seccionId, from, to)
                 .stream().map(mapper::toDto).toList();
     }
 
     public List<JornadaAsistenciaDTO> findByTrimestre(Long trimestreId) {
-        return repo.findByTrimestreId(trimestreId).stream().map(mapper::toDto).toList();
+        List<JornadaAsistenciaDTO> jornadas = repo.findByTrimestreId(trimestreId)
+                .stream().map(mapper::toDto).toList();
+        Optional<DocenteScopeService.DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            Set<Long> secciones = scopeOpt.get().seccionesAccesibles();
+            if (secciones.isEmpty()) {
+                return List.of();
+            }
+            return jornadas.stream()
+                    .filter(dto -> secciones.contains(dto.getSeccionId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+        return jornadas;
     }
 
     @Transactional
     public void delete(Long id) {
-        if (!repo.existsById(id)) {
-            throw new EntityNotFoundException("Jornada " + id + " no encontrada");
-        }
+        JornadaAsistencia jornada = repo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Jornada " + id + " no encontrada"));
+        docenteScopeService.ensurePuedeAccederSeccion(jornada.getSeccion().getId());
         repo.deleteById(id);
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/CalificacionTrimestralService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/CalificacionTrimestralService.java
@@ -1,49 +1,94 @@
 package edu.ecep.base_app.gestionacademica.application;
 
+import edu.ecep.base_app.gestionacademica.domain.CalificacionTrimestral;
 import edu.ecep.base_app.gestionacademica.domain.Trimestre;
 import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
-import edu.ecep.base_app.gestionacademica.presentation.dto.CalificacionTrimestralCreateDTO;
-import edu.ecep.base_app.gestionacademica.presentation.dto.CalificacionTrimestralDTO;
 import edu.ecep.base_app.gestionacademica.infrastructure.mapper.CalificacionTrimestralMapper;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.CalificacionTrimestralRepository;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.TrimestreRepository;
+import edu.ecep.base_app.gestionacademica.presentation.dto.CalificacionTrimestralCreateDTO;
+import edu.ecep.base_app.gestionacademica.presentation.dto.CalificacionTrimestralDTO;
 import edu.ecep.base_app.shared.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
-@Service @RequiredArgsConstructor
+@Service
+@RequiredArgsConstructor
 public class CalificacionTrimestralService {
-    private final CalificacionTrimestralRepository repo; private final CalificacionTrimestralMapper mapper; private final TrimestreRepository trimRepo;
-    public List<CalificacionTrimestralDTO> findAll(){ return repo.findAll().stream().map(mapper::toDto).toList(); }
-    public CalificacionTrimestralDTO get(Long id){
-        return repo.findById(id)
-                .map(mapper::toDto)
-                .orElseThrow(() -> new NotFoundException("No encontrado"));
+
+    private final CalificacionTrimestralRepository repo;
+    private final CalificacionTrimestralMapper mapper;
+    private final TrimestreRepository trimRepo;
+    private final DocenteScopeService docenteScopeService;
+
+    public List<CalificacionTrimestralDTO> findAll() {
+        List<CalificacionTrimestral> entities = repo.findAll();
+        Optional<DocenteScopeService.DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            DocenteScopeService.DocenteScope scope = scopeOpt.get();
+            entities = entities.stream()
+                    .filter(e -> scope.puedeGestionarSeccionMateria(e.getSeccionMateria().getId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+        return entities.stream().map(mapper::toDto).toList();
     }
-    public Long create(CalificacionTrimestralCreateDTO dto){
-        Trimestre tri = trimRepo.findById(dto.getTrimestreId()).orElseThrow(() -> new NotFoundException("No encontrado"));
-        if(tri.getEstado() != TrimestreEstado.ACTIVO) {
+
+    public CalificacionTrimestralDTO get(Long id) {
+        CalificacionTrimestral entity = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+        docenteScopeService.ensurePuedeGestionarSeccionMateria(entity.getSeccionMateria().getId());
+        return mapper.toDto(entity);
+    }
+
+    @Transactional
+    public Long create(CalificacionTrimestralCreateDTO dto) {
+        Trimestre tri = trimRepo.findById(dto.getTrimestreId())
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+        if (tri.getEstado() != TrimestreEstado.ACTIVO) {
             throw new IllegalArgumentException("El trimestre no está activo");
         }
-        if(repo.existsByTrimestreIdAndSeccionMateriaIdAndMatriculaId(dto.getTrimestreId(), dto.getSeccionMateriaId(), dto.getMatriculaId()))
+        docenteScopeService.ensurePuedeGestionarSeccionMateria(dto.getSeccionMateriaId());
+        if (repo.existsByTrimestreIdAndSeccionMateriaIdAndMatriculaId(
+                dto.getTrimestreId(), dto.getSeccionMateriaId(), dto.getMatriculaId())) {
             throw new IllegalArgumentException("Calificación trimestral duplicada");
+        }
         return repo.save(mapper.toEntity(dto)).getId();
     }
 
-    public void update(Long id, CalificacionTrimestralDTO dto){
-        var entity = repo.findById(id).orElseThrow(() -> new NotFoundException("No encontrado"));
-        var trimestre = trimRepo.findById(dto.getTrimestreId()).orElseThrow(() -> new NotFoundException("No encontrado"));
-        if(trimestre.getEstado() != TrimestreEstado.ACTIVO) {
+    @Transactional
+    public void update(Long id, CalificacionTrimestralDTO dto) {
+        CalificacionTrimestral entity = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+        docenteScopeService.ensurePuedeGestionarSeccionMateria(entity.getSeccionMateria().getId());
+
+        Long targetTriId = dto.getTrimestreId() != null
+                ? dto.getTrimestreId()
+                : entity.getTrimestre().getId();
+        Trimestre tri = trimRepo.findById(targetTriId)
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+        if (tri.getEstado() != TrimestreEstado.ACTIVO) {
             throw new IllegalArgumentException("El trimestre no está activo");
         }
+        if (dto.getSeccionMateriaId() != null
+                && !dto.getSeccionMateriaId().equals(entity.getSeccionMateria().getId())) {
+            docenteScopeService.ensurePuedeGestionarSeccionMateria(dto.getSeccionMateriaId());
+        }
+
         mapper.update(entity, dto);
         repo.save(entity);
     }
 
-    public void delete(Long id){
-        if(!repo.existsById(id)) throw new NotFoundException("No encontrado");
-        repo.deleteById(id);
+    @Transactional
+    public void delete(Long id) {
+        CalificacionTrimestral entity = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("No encontrado"));
+        docenteScopeService.ensurePuedeGestionarSeccionMateria(entity.getSeccionMateria().getId());
+        repo.delete(entity);
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/DocenteScopeService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/DocenteScopeService.java
@@ -1,0 +1,178 @@
+package edu.ecep.base_app.gestionacademica.application;
+
+import edu.ecep.base_app.gestionacademica.domain.AsignacionDocenteMateria;
+import edu.ecep.base_app.gestionacademica.domain.Evaluacion;
+import edu.ecep.base_app.gestionacademica.domain.SeccionMateria;
+import edu.ecep.base_app.gestionacademica.domain.enums.RolSeccion;
+import edu.ecep.base_app.gestionacademica.infrastructure.persistence.AsignacionDocenteMateriaRepository;
+import edu.ecep.base_app.gestionacademica.infrastructure.persistence.AsignacionDocenteSeccionRepository;
+import edu.ecep.base_app.gestionacademica.infrastructure.persistence.SeccionMateriaRepository;
+import edu.ecep.base_app.identidad.domain.Persona;
+import edu.ecep.base_app.identidad.infrastructure.persistence.EmpleadoRepository;
+import edu.ecep.base_app.shared.exception.UnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DocenteScopeService {
+
+    private static final String ROLE_TEACHER = "ROLE_TEACHER";
+
+    private final EmpleadoRepository empleadoRepository;
+    private final AsignacionDocenteSeccionRepository asignacionDocenteSeccionRepository;
+    private final AsignacionDocenteMateriaRepository asignacionDocenteMateriaRepository;
+    private final SeccionMateriaRepository seccionMateriaRepository;
+
+    public boolean isTeacher() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getAuthorities() == null) {
+            return false;
+        }
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(ROLE_TEACHER::equals);
+    }
+
+    public Optional<DocenteScope> getScope() {
+        return getScope(LocalDate.now());
+    }
+
+    public Optional<DocenteScope> getScope(LocalDate fecha) {
+        if (!isTeacher()) {
+            return Optional.empty();
+        }
+        Long personaId = currentPersonaId();
+        if (personaId == null) {
+            return Optional.empty();
+        }
+        return empleadoRepository.findByPersonaId(personaId)
+                .map(empleado -> buildScope(empleado.getId(), fecha));
+    }
+
+    public void ensurePuedeAccederSeccion(Long seccionId) {
+        if (seccionId == null || !isTeacher()) {
+            return;
+        }
+        DocenteScope scope = requireScope();
+        if (!scope.puedeAccederSeccion(seccionId)) {
+            throw new UnauthorizedException("No tiene permisos para acceder a la sección solicitada.");
+        }
+    }
+
+    public void ensurePuedeGestionarSeccionMateria(Long seccionMateriaId) {
+        if (seccionMateriaId == null || !isTeacher()) {
+            return;
+        }
+        DocenteScope scope = requireScope();
+        if (!scope.puedeGestionarSeccionMateria(seccionMateriaId)) {
+            throw new UnauthorizedException("No tiene permisos para operar sobre la materia solicitada.");
+        }
+    }
+
+    public void ensurePuedeGestionarEvaluacion(Evaluacion evaluacion) {
+        if (evaluacion == null) {
+            return;
+        }
+        ensurePuedeGestionarSeccionMateria(evaluacion.getSeccionMateria().getId());
+    }
+
+    private DocenteScope requireScope() {
+        return getScope().orElseThrow(() ->
+                new UnauthorizedException("No se encontraron asignaciones vigentes para el docente."));
+    }
+
+    private DocenteScope buildScope(Long empleadoId, LocalDate fecha) {
+        var seccionAssignments = asignacionDocenteSeccionRepository.findVigentesByEmpleado(empleadoId, fecha);
+        var materiaAssignments = asignacionDocenteMateriaRepository.findVigentesByEmpleado(empleadoId, fecha);
+
+        Set<Long> seccionesTitular = seccionAssignments.stream()
+                .filter(a -> a.getRol() == RolSeccion.MAESTRO_TITULAR)
+                .map(a -> a.getSeccion().getId())
+                .collect(Collectors.toCollection(HashSet::new));
+
+        Set<Long> seccionesConMateria = materiaAssignments.stream()
+                .map(a -> a.getSeccionMateria().getSeccion().getId())
+                .collect(Collectors.toCollection(HashSet::new));
+
+        Set<Long> seccionesAccesibles = new HashSet<>(seccionesConMateria);
+        seccionesAccesibles.addAll(seccionesTitular);
+
+        Set<Long> seccionMateriasGestionables = new HashSet<>();
+        Map<Long, Long> seccionPorSeccionMateria = new HashMap<>();
+
+        for (AsignacionDocenteMateria asignacion : materiaAssignments) {
+            Long seccionMateriaId = asignacion.getSeccionMateria().getId();
+            Long seccionId = asignacion.getSeccionMateria().getSeccion().getId();
+            seccionMateriasGestionables.add(seccionMateriaId);
+            seccionPorSeccionMateria.put(seccionMateriaId, seccionId);
+        }
+
+        if (!seccionesTitular.isEmpty()) {
+            for (Long seccionId : seccionesTitular) {
+                for (SeccionMateria seccionMateria : seccionMateriaRepository.findBySeccionId(seccionId)) {
+                    seccionMateriasGestionables.add(seccionMateria.getId());
+                    seccionPorSeccionMateria.putIfAbsent(seccionMateria.getId(), seccionId);
+                }
+            }
+        }
+
+        return new DocenteScope(
+                empleadoId,
+                Set.copyOf(seccionesTitular),
+                Set.copyOf(seccionesConMateria),
+                Set.copyOf(seccionesAccesibles),
+                Set.copyOf(seccionMateriasGestionables),
+                Map.copyOf(seccionPorSeccionMateria)
+        );
+    }
+
+    private Long currentPersonaId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            return null;
+        }
+        Object details = auth.getDetails();
+        if (details instanceof Persona persona) {
+            return persona.getId();
+        }
+        try {
+            return Long.valueOf(auth.getName());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    public record DocenteScope(Long empleadoId,
+                               Set<Long> seccionesTitular,
+                               Set<Long> seccionesConMateria,
+                               Set<Long> seccionesAccesibles,
+                               Set<Long> seccionMateriasGestionables,
+                               Map<Long, Long> seccionPorSeccionMateria) {
+
+        public boolean puedeAccederSeccion(Long seccionId) {
+            return seccionesAccesibles.contains(seccionId);
+        }
+
+        public boolean puedeGestionarSeccionMateria(Long seccionMateriaId) {
+            return seccionMateriasGestionables.contains(seccionMateriaId);
+        }
+
+        public Long seccionDeSeccionMateria(Long seccionMateriaId) {
+            return seccionPorSeccionMateria.get(seccionMateriaId);
+        }
+    }
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/EvaluacionService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/EvaluacionService.java
@@ -1,5 +1,7 @@
 package edu.ecep.base_app.gestionacademica.application;
 
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService;
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService.DocenteScope;
 import edu.ecep.base_app.gestionacademica.domain.Evaluacion;
 import edu.ecep.base_app.gestionacademica.domain.Trimestre;
 import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
@@ -10,17 +12,20 @@ import edu.ecep.base_app.gestionacademica.infrastructure.persistence.EvaluacionR
 import edu.ecep.base_app.vidaescolar.infrastructure.persistence.MatriculaSeccionHistorialRepository;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.TrimestreRepository;
 import edu.ecep.base_app.shared.exception.NotFoundException;
+import edu.ecep.base_app.shared.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class EvaluacionService {
-    private final EvaluacionRepository repo; private final EvaluacionMapper mapper; private final MatriculaSeccionHistorialRepository histRepo; private final TrimestreRepository trimRepo;
+    private final EvaluacionRepository repo; private final EvaluacionMapper mapper; private final MatriculaSeccionHistorialRepository histRepo; private final TrimestreRepository trimRepo; private final DocenteScopeService docenteScopeService;
 
     public List<EvaluacionDTO> findAll(){
         return findAll(null, null, null);
@@ -44,36 +49,66 @@ public class EvaluacionService {
             spec = spec == null ? Specification.where(byMateria) : spec.and(byMateria);
         }
 
-        List<Evaluacion> result = (spec == null)
+        Specification<Evaluacion> effectiveSpec = spec;
+        Optional<DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            DocenteScope scope = scopeOpt.get();
+            if (seccionId != null && !scope.puedeAccederSeccion(seccionId)) {
+                throw new UnauthorizedException("No tiene permisos para acceder a la sección indicada.");
+            }
+            Specification<Evaluacion> docenteSpec = buildDocenteSpecification(scope);
+            effectiveSpec = (effectiveSpec == null)
+                    ? Specification.where(docenteSpec)
+                    : effectiveSpec.and(docenteSpec);
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+
+        List<Evaluacion> result = (effectiveSpec == null)
                 ? repo.findAll(Sort.by("fecha").descending())
-                : repo.findAll(spec, Sort.by("fecha").descending());
+                : repo.findAll(effectiveSpec, Sort.by("fecha").descending());
 
         return result.stream().map(mapper::toDto).toList();
     }
     public EvaluacionDTO get(Long id){
-        return repo.findById(id)
-                .map(mapper::toDto)
+        Evaluacion evaluacion = repo.findById(id)
                 .orElseThrow(() -> new NotFoundException("No encontrado"));
+        docenteScopeService.ensurePuedeGestionarEvaluacion(evaluacion);
+        return mapper.toDto(evaluacion);
     }
     public Long create(EvaluacionCreateDTO dto){
         Trimestre tri = trimRepo.findById(dto.getTrimestreId()).orElseThrow(() -> new NotFoundException("No encontrado"));
         if(tri.getEstado() != TrimestreEstado.ACTIVO) {
             throw new IllegalArgumentException("El trimestre no está activo");
         }
+        docenteScopeService.ensurePuedeGestionarSeccionMateria(dto.getSeccionMateriaId());
         return repo.save(mapper.toEntity(dto)).getId();
     }
     public void update(Long id, EvaluacionDTO dto){
         var entity = repo.findById(id).orElseThrow(() -> new NotFoundException("No encontrado"));
+        docenteScopeService.ensurePuedeGestionarEvaluacion(entity);
         Long targetTriId = dto.getTrimestreId() != null ? dto.getTrimestreId() : entity.getTrimestre().getId();
         Trimestre tri = trimRepo.findById(targetTriId).orElseThrow(() -> new NotFoundException("No encontrado"));
         if(tri.getEstado() != TrimestreEstado.ACTIVO) {
             throw new IllegalArgumentException("El trimestre no está activo");
         }
+        if (dto.getSeccionMateriaId() != null && !dto.getSeccionMateriaId().equals(entity.getSeccionMateria().getId())) {
+            docenteScopeService.ensurePuedeGestionarSeccionMateria(dto.getSeccionMateriaId());
+        }
         mapper.update(entity, dto);
         repo.save(entity);
     }
     public void delete(Long id){
-        if(!repo.existsById(id)) throw new NotFoundException("No encontrado");
-        repo.deleteById(id);
+        var entity = repo.findById(id).orElseThrow(() -> new NotFoundException("No encontrado"));
+        docenteScopeService.ensurePuedeGestionarEvaluacion(entity);
+        repo.delete(entity);
+    }
+
+    private Specification<Evaluacion> buildDocenteSpecification(DocenteScope scope) {
+        Set<Long> seccionMateriaIds = scope.seccionMateriasGestionables();
+        if (seccionMateriaIds.isEmpty()) {
+            return (root, query, cb) -> cb.disjunction();
+        }
+        return (root, query, cb) -> root.join("seccionMateria").get("id").in(seccionMateriaIds);
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/AsignacionDocenteMateriaRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/AsignacionDocenteMateriaRepository.java
@@ -37,4 +37,20 @@ public interface AsignacionDocenteMateriaRepository extends JpaRepository<Asigna
     """)
     List<AsignacionDocenteMateria> findTitularesVigentesEn(@Param("smId") Long seccionMateriaId,
                                                            @Param("fecha") LocalDate fecha);
+
+    @EntityGraph(attributePaths = {
+            "seccionMateria",
+            "seccionMateria.seccion",
+            "seccionMateria.materia",
+            "empleado"
+    })
+    @Query("""
+        select a
+        from AsignacionDocenteMateria a
+        where a.empleado.id = :empleadoId
+          and a.vigenciaDesde <= :fecha
+          and (a.vigenciaHasta is null or a.vigenciaHasta >= :fecha)
+    """)
+    List<AsignacionDocenteMateria> findVigentesByEmpleado(@Param("empleadoId") Long empleadoId,
+                                                          @Param("fecha") LocalDate fecha);
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/EvaluacionRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/EvaluacionRepository.java
@@ -6,9 +6,10 @@ import edu.ecep.base_app.gestionacademica.domain.Seccion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.Collection;
 import java.util.List;
 
 
 public interface EvaluacionRepository extends JpaRepository<Evaluacion, Long>, JpaSpecificationExecutor<Evaluacion> {
-    //List<Evaluacion> findBySeccionMateriaIdAndTrimestreId(Long seccionMateriaId, Long trimestreId);
+    List<Evaluacion> findBySeccionMateria_IdIn(Collection<Long> seccionMateriaIds);
 }


### PR DESCRIPTION
## Summary
- add a dedicated `DocenteScopeService` that resolves docente assignments and validates section or subject level permissions before accessing academic data
- guard calificaciones, evaluaciones and resultados services so docentes only manage records for sections or materias they own and return filtered listings for scoped views
- restrict asistencia queries and maintenance endpoints to the docente scope and reuse repository helpers for vigente subject assignments
- include docente subject assignments when listing secciones vigentes so they can view sections they teach even if they are not the titular docente

## Testing
- ⚠️ `./mvnw test` *(fails: Maven wrapper cannot download Maven distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d59161b7d88327afa7adb7723d1bdf