### PR TITLE
Update role selection flow

### DIFF
--- a/frontend-ecep/src/app/select-rol/page.tsx
+++ b/frontend-ecep/src/app/select-rol/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
 import { UserRole } from "@/types/api-generated";
@@ -13,7 +13,6 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 export default function SelectRolPage() {
   const { user, loading, selectedRole, setSelectedRole } = useAuth();
@@ -22,9 +21,6 @@ export default function SelectRolPage() {
   // Roles normalizados y únicos
   const userRoles = user?.roles;
   const roles = useMemo(() => normalizeRoles(userRoles), [userRoles]);
-
-  // Estado del dropdown (pre-selecciona el rol ya elegido o el primero)
-  const [localRole, setLocalRole] = useState<UserRole | null>(null);
 
   useEffect(() => {
     if (loading) return;
@@ -44,19 +40,15 @@ export default function SelectRolPage() {
       return;
     }
 
-    // 3) inicializar dropdown
-    if (!localRole) {
-      setLocalRole(selectedRole ?? roles[0] ?? null);
-    }
-  }, [loading, user, roles, selectedRole, localRole, setSelectedRole, router]);
+    // 3) si ya tenía un rol elegido, permanecer en la pantalla para permitir cambiarlo
+  }, [loading, user, roles, selectedRole, setSelectedRole, router]);
 
   // mientras carga o redirige
   if (loading || !user) return null;
   if (roles.length <= 1) return null; // ya redirige en el effect
 
-  const handleConfirm = () => {
-    if (!localRole) return;
-    setSelectedRole(localRole);
+  const handleSelect = (role: UserRole) => {
+    setSelectedRole(role);
     router.replace("/dashboard");
   };
 
@@ -79,36 +71,13 @@ export default function SelectRolPage() {
                 <Button
                   key={r}
                   type="button"
-                  onClick={() => setLocalRole(r as UserRole)}
-                  className={cn(
-                    "rounded-full px-4 h-9 text-sm whitespace-nowrap shrink-0 transition-all",
-                    localRole === r
-                      ? "bg-primary text-primary-foreground shadow-sm"
-                      : "border border-border bg-muted text-foreground/80 hover:bg-muted/80",
-                  )}
+                  onClick={() => handleSelect(r)}
+                  className="rounded-full px-4 h-9 text-sm whitespace-nowrap shrink-0 transition-all border border-border bg-muted text-foreground/80 hover:bg-primary hover:text-primary-foreground"
                 >
                   {displayRole(r)}
                 </Button>
               ))}
             </div>
-          </div>
-
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              disabled={!selectedRole}
-              onClick={() => {
-                // Si no hab&iacute;a un rol previamente elegido,
-                // evitar loop de redirecci&oacute;n al dashboard → select-rol
-                if (!selectedRole) return;
-                router.replace("/dashboard");
-              }}
-            >
-              Cancelar
-            </Button>
-            <Button onClick={handleConfirm} disabled={!localRole}>
-              Entrar
-            </Button>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- update the role selection page to display only the available roles without a preselected option
- trigger role assignment and dashboard redirect immediately when a role is chosen
- remove the previous cancel/confirm controls and related local state

## Testing
- npm run lint *(fails: next CLI unavailable before dependency install)*
- npm install *(fails: registry access returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d59b892e288327a6da776b94fd7a43