### PR TITLE
Filter personal secciones by active period

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/SeccionService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/SeccionService.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.gestionacademica.application;
 
+import edu.ecep.base_app.gestionacademica.domain.Seccion;
 import edu.ecep.base_app.gestionacademica.infrastructure.mapper.SeccionMapper;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.SeccionRepository;
 import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionCreateDTO;
@@ -10,12 +11,20 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service @RequiredArgsConstructor
+@Service
+@RequiredArgsConstructor
 public class SeccionService {
-    private final SeccionRepository repo; private final SeccionMapper mapper;
-    public List<SeccionDTO> findAll(){ return repo.findAll(Sort.by("periodoEscolar.id","nivel","gradoSala","division")).stream().map(mapper::toDto).toList(); }
+    private final SeccionRepository repo;
+    private final SeccionMapper mapper;
+
+    public List<SeccionDTO> findAll() {
+        Sort sort = Sort.by("periodoEscolar.id", "nivel", "gradoSala", "division");
+        List<Seccion> activas = repo.findAllByPeriodoEscolarActivoTrue(sort);
+        List<Seccion> source = activas.isEmpty() ? repo.findAll(sort) : activas;
+        return source.stream().map(mapper::toDto).toList();
+    }
+
     public Long create(SeccionCreateDTO dto){
         if(repo.existsByPeriodoEscolarIdAndNivelAndGradoSalaAndDivisionAndTurno(dto.getPeriodoEscolarId(), dto.getNivel(), dto.getGradoSala(), dto.getDivision(), dto.getTurno()))
             throw new IllegalArgumentException("La sección ya existe en ese periodo");

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/SeccionRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/SeccionRepository.java
@@ -1,14 +1,16 @@
 package edu.ecep.base_app.gestionacademica.infrastructure.persistence;
 
-import edu.ecep.base_app.gestionacademica.domain.Materia;
 import edu.ecep.base_app.gestionacademica.domain.Seccion;
 import java.util.List;
 
 import edu.ecep.base_app.shared.domain.enums.NivelAcademico;
 import edu.ecep.base_app.shared.domain.enums.Turno;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface SeccionRepository extends JpaRepository<Seccion, Long> {
     boolean existsByPeriodoEscolarIdAndNivelAndGradoSalaAndDivisionAndTurno(Long periodoId, NivelAcademico nivel, String gradoSala, String division, Turno turno);
+
+    List<Seccion> findAllByPeriodoEscolarActivoTrue(Sort sort);
 }


### PR DESCRIPTION
## Summary
- scope the personal secciones selector to the active school period to eliminate duplicate entries
- filter the related seccion-materia options against the active period while preserving a fallback when no period is resolved

## Testing
- `npm install` *(fails: 403 Forbidden fetching packages from the npm registry in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d59b770b4c8327810a825142af7987