### PR TITLE
Mostrar nombres de períodos escolares

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -108,7 +108,7 @@ export default function AlumnoPerfilPage() {
 
   const [familiares, setFamiliares] = useState<FamiliarConVinculo[]>([]);
 
-  const { periodoEscolarId: activePeriodId } = useActivePeriod();
+  const { periodoEscolarId: activePeriodId, getPeriodoNombre } = useActivePeriod();
   const { hasRole } = useAuth();
   const { type: viewerScope } = useViewerScope();
   const canManageProfile = viewerScope === "staff";
@@ -1303,6 +1303,7 @@ export default function AlumnoPerfilPage() {
                       (h) => h.matriculaId === m.id,
                     );
                     const abierta = filas.find((h) => !h.hasta);
+                    const periodoLabel = getPeriodoNombre(m.periodoEscolarId ?? null);
                     return (
                       <div
                         key={m.id}
@@ -1311,7 +1312,7 @@ export default function AlumnoPerfilPage() {
                         <div>
                           <div className="font-medium">Matrícula #{m.id}</div>
                           <div className="text-muted-foreground">
-                            Período: {m.periodoEscolarId ?? "—"}
+                            Período: {periodoLabel ?? "—"}
                             {abierta ? (
                               <>
                                 {" "}

--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -126,11 +126,14 @@ export default function AlumnosIndexPage() {
     secciones,
     hijos,
     periodoEscolarId,
+    getPeriodoNombre,
   } = useScopedIndex({ includeTitularSec: true });
   const { hasRole } = useAuth();
 
   // Mostramos período activo con el hook (evita UTC vs local)
   const { hoyISO } = useActivePeriod();
+
+  const periodoLabel = getPeriodoNombre(periodoEscolarId ?? null);
 
   useEffect(() => {
     const handler = setTimeout(() => setDebouncedSearch(searchTerm), 350);
@@ -297,7 +300,7 @@ export default function AlumnosIndexPage() {
             <h2 className="text-3xl font-bold tracking-tight">Alumnos</h2>
             <div className="text-muted-foreground">
               {scope === "staff"
-                ? `Período escolar activo: #${periodoEscolarId ?? "—"} • Hoy: ${hoyISO}`
+                ? `Período escolar activo: ${periodoLabel ?? "—"} • Hoy: ${hoyISO}`
                 : scope === "teacher"
                   ? "Gestión de alumnos por sección"
                   : scope === "student"

--- a/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
@@ -24,6 +24,7 @@ import type {
 import { NivelAcademico as NivelAcademicoEnum } from "@/types/api-generated";
 import { getTrimestreEstado, resolveTrimestrePeriodoId } from "@/lib/trimestres";
 import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
+import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 
 interface FamilyCalificacionesViewProps {
   alumnos: AlumnoLiteDTO[];
@@ -82,6 +83,7 @@ export default function FamilyCalificacionesView({
   initialError,
   periodoEscolarId,
 }: FamilyCalificacionesViewProps) {
+  const { getPeriodoNombre } = useActivePeriod();
   const [selectedMatriculaId, setSelectedMatriculaId] = useState<number | null>(
     null,
   );
@@ -353,6 +355,7 @@ export default function FamilyCalificacionesView({
             (seccion as any).periodoEscolar?.id ??
             null
           : null;
+        const periodoLabel = getPeriodoNombre(seccionPeriodoId);
         const basePorSeccion =
           typeof seccionPeriodoId === "number"
             ? trimestresPorPeriodo.get(seccionPeriodoId) ?? []
@@ -429,10 +432,8 @@ export default function FamilyCalificacionesView({
                     <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                       <Badge variant="outline">{nivelLabel(nivel)}</Badge>
                       {turno && <Badge variant="outline">Turno {turno}</Badge>}
-                      {seccion?.periodoEscolarId && (
-                        <Badge variant="outline">
-                          Período {seccion.periodoEscolarId}
-                        </Badge>
+                      {periodoLabel && (
+                        <Badge variant="outline">Período {periodoLabel}</Badge>
                       )}
                     </div>
                   </CardHeader>

--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -48,6 +48,7 @@ export default function CalificacionesIndexPage() {
     secciones,
     hijos,
     periodoEscolarId,
+    getPeriodoNombre,
   } = useScopedIndex({ includeTitularSec: true });
 
   const isAdmin = activeRole === UserRole.ADMIN;
@@ -89,6 +90,7 @@ export default function CalificacionesIndexPage() {
 
   const isTeacher = scope === "teacher";
   const isStaff = scope === "staff";
+  const periodoLabel = getPeriodoNombre(periodoEscolarId ?? null);
 
   if (!isTeacher && !isStaff) {
     return (
@@ -130,8 +132,8 @@ export default function CalificacionesIndexPage() {
             <Badge variant="outline">
               Inicial: {loading ? "—" : inicial.length}
             </Badge>
-            {periodoEscolarId && (
-              <Badge variant="outline">Período {periodoEscolarId}</Badge>
+            {periodoLabel && (
+              <Badge variant="outline">Período {periodoLabel}</Badge>
             )}
           </div>
         </div>

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
@@ -11,12 +11,14 @@ import InformeInicialView from "./_views/InformeInicialView";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
 import { UserRole } from "@/types/api-generated";
+import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 
 export default function CalificacionesSeccionPage() {
   const { id } = useParams<{ id: string }>();
   const seccionId = Number(id);
   const { type, activeRole } = useViewerScope();
   const { loading: scopedLoading, secciones: accesibles } = useScopedSecciones();
+  const { getPeriodoNombre } = useActivePeriod();
   const isAdmin = activeRole === UserRole.ADMIN;
   const isTeacher = type === "teacher";
   const isStaff = type === "staff";
@@ -123,6 +125,7 @@ export default function CalificacionesSeccionPage() {
     return `Turno ${normalized}`;
   };
   const turnoLabel = formatTurnoLabel(seccion?.turno);
+  const periodoLabel = getPeriodoNombre(seccion?.periodoEscolarId ?? null);
 
   return (
     <DashboardLayout>
@@ -132,10 +135,8 @@ export default function CalificacionesSeccionPage() {
           <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
             <Badge variant="outline">{sectionLabel}</Badge>
             {turnoLabel && <Badge variant="outline">{turnoLabel}</Badge>}
-            {seccion?.periodoEscolarId && (
-              <Badge variant="outline">
-                Período {seccion.periodoEscolarId}
-              </Badge>
+            {periodoLabel && (
+              <Badge variant="outline">Período {periodoLabel}</Badge>
             )}
           </div>
         </div>

--- a/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
@@ -45,7 +45,7 @@ function formatTurnoLabel(turno?: string | null) {
 
 export default function EvaluacionesIndexPage() {
   const router = useRouter();
-  const { periodoEscolarId } = useActivePeriod();
+  const { periodoEscolarId, getPeriodoNombre } = useActivePeriod();
 
   const { activeRole } = useViewerScope();
   const isAdmin = activeRole === UserRole.ADMIN;
@@ -174,6 +174,8 @@ export default function EvaluacionesIndexPage() {
     materiaNombreById,
   ]);
 
+  const periodoLabel = getPeriodoNombre(periodoEscolarId ?? null);
+
   if (scope === "family" || scope === "student") {
     return (
       <DashboardLayout>
@@ -222,7 +224,9 @@ export default function EvaluacionesIndexPage() {
             <h2 className="text-3xl font-bold tracking-tight">{title}</h2>
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <Badge variant="outline">Primario</Badge>
-              <Badge variant="outline">Período {periodoEscolarId ?? "—"}</Badge>
+              {periodoLabel && (
+                <Badge variant="outline">Período {periodoLabel}</Badge>
+              )}
             </div>
             <ActiveTrimestreBadge className="mt-2" />
           </div>

--- a/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
@@ -22,6 +22,7 @@ import type {
   SeccionMateriaDTO,
 } from "@/types/api-generated";
 import { NivelAcademico as NivelAcademicoEnum } from "@/types/api-generated";
+import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 
 type DocenteAsignado = {
   nombre: string;
@@ -95,6 +96,7 @@ export default function FamilyMateriasView({
   initialLoading,
   initialError,
 }: FamilyMateriasViewProps) {
+  const { getPeriodoNombre } = useActivePeriod();
   const [selectedMatriculaId, setSelectedMatriculaId] = useState<number | null>(
     null,
   );
@@ -324,6 +326,9 @@ export default function FamilyMateriasView({
         const turno = detalle?.seccion?.turno
           ? formatTurno(detalle.seccion.turno)
           : null;
+        const periodoLabel = getPeriodoNombre(
+          detalle?.seccion?.periodoEscolarId ?? null,
+        );
 
         return (
           <TabsContent
@@ -347,10 +352,8 @@ export default function FamilyMateriasView({
                     <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                       <Badge variant="outline">{nivelLabel(nivel)}</Badge>
                       {turno && <Badge variant="outline">Turno {turno}</Badge>}
-                      {detalle?.seccion?.periodoEscolarId && (
-                        <Badge variant="outline">
-                          Período {detalle.seccion.periodoEscolarId}
-                        </Badge>
+                      {periodoLabel && (
+                        <Badge variant="outline">Período {periodoLabel}</Badge>
                       )}
                     </div>
                   </CardHeader>

--- a/frontend-ecep/src/app/dashboard/materias/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/page.tsx
@@ -49,6 +49,7 @@ export default function MateriasPage() {
     hijos,
     periodoEscolarId,
     titularBySeccionId,
+    getPeriodoNombre,
   } = useScopedIndex({ includeTitularSec: true });
 
   const [q, setQ] = useState("");
@@ -113,6 +114,8 @@ export default function MateriasPage() {
     );
   }, [q, seccionesPrimario]);
 
+  const periodoLabel = getPeriodoNombre(periodoEscolarId ?? null);
+
   return (
     <DashboardLayout>
       <div className="p-4 md:p-8 space-y-6">
@@ -121,8 +124,8 @@ export default function MateriasPage() {
             <h2 className="text-3xl font-bold tracking-tight">Materias</h2>
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <Badge variant="outline">Primario</Badge>
-              {periodoEscolarId && (
-                <Badge variant="outline">Período {periodoEscolarId}</Badge>
+              {periodoLabel && (
+                <Badge variant="outline">Período {periodoLabel}</Badge>
               )}
             </div>
           </div>

--- a/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
@@ -32,6 +32,7 @@ import AsignarDocenteSeccionDialog from "@/app/dashboard/materias/_components/As
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
 import { UserRole } from "@/types/api-generated";
+import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 
 type Seccion = SeccionDTO;
 type SM = SeccionMateriaDTO;
@@ -111,6 +112,7 @@ export default function MateriasSeccionPage() {
   const { id } = useParams<{ id: string }>();
   const seccionId = Number(id);
   const router = useRouter();
+  const { getPeriodoNombre } = useActivePeriod();
   const { type, activeRole } = useViewerScope();
   const {
     loading: scopedLoading,
@@ -229,6 +231,7 @@ export default function MateriasSeccionPage() {
   const esInicial = seccion ? isInicial(seccion) : false;
   const esPrimario = seccion ? isPrimario(seccion) : false;
   const seccionLabel = seccion ? fmtSeccion(seccion) : `Sección #${seccionId}`;
+  const periodoLabel = getPeriodoNombre(seccion?.periodoEscolarId ?? null);
   const nivelBadge = seccion
     ? esInicial
       ? "Inicial"
@@ -439,10 +442,8 @@ export default function MateriasSeccionPage() {
               {turnoBadgeLabel && (
                 <Badge variant="outline">{turnoBadgeLabel}</Badge>
               )}
-              {seccion?.periodoEscolarId && (
-                <Badge variant="outline">
-                  Período {seccion.periodoEscolarId}
-                </Badge>
+              {periodoLabel && (
+                <Badge variant="outline">Período {periodoLabel}</Badge>
               )}
             </div>
             <p className="mt-2 text-sm text-muted-foreground">

--- a/frontend-ecep/src/hooks/scope/useScopedIndex.ts
+++ b/frontend-ecep/src/hooks/scope/useScopedIndex.ts
@@ -20,6 +20,8 @@ export function useScopedIndex(opts?: {
   const {
     loading: loadingPeriodo,
     periodoEscolarId,
+    periodoEscolar,
+    getPeriodoNombre,
     hoyISO,
   } = useActivePeriod();
 
@@ -58,6 +60,8 @@ export function useScopedIndex(opts?: {
         secciones: [] as any[], // vacío en family
         titularBySeccionId: new Map<number, string>(),
         periodoEscolarId,
+        periodoEscolar,
+        getPeriodoNombre,
         hoyISO,
       };
     }
@@ -70,6 +74,8 @@ export function useScopedIndex(opts?: {
       secciones, // array de SeccionDTO
       titularBySeccionId,
       periodoEscolarId,
+      periodoEscolar,
+      getPeriodoNombre,
       hoyISO,
     };
   }, [
@@ -80,6 +86,8 @@ export function useScopedIndex(opts?: {
     secciones,
     titularBySeccionId,
     periodoEscolarId,
+    periodoEscolar,
+    getPeriodoNombre,
     hoyISO,
   ]);
 }


### PR DESCRIPTION
## Resumen
- exponer en `useActivePeriod` un helper para obtener el nombre/año de un período escolar
- propagar el helper mediante `useScopedIndex` y consumirlo en páginas de materias, calificaciones, evaluaciones y alumnos
- actualizar vistas familiares y de secciones para mostrar el año del período en lugar del ID numérico

## Pruebas
- `npm run lint` *(falla: comando `next` no disponible en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d59b97a9748327bb10ab774939c416