### PR TITLE
Ajustar permisos de docentes por rol en secciones

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/AsignacionDocenteSeccionService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/AsignacionDocenteSeccionService.java
@@ -1,17 +1,21 @@
 package edu.ecep.base_app.gestionacademica.application;
 
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService.DocenteScope;
 import edu.ecep.base_app.gestionacademica.domain.AsignacionDocenteSeccion;
 import edu.ecep.base_app.gestionacademica.domain.enums.RolSeccion;
 import edu.ecep.base_app.gestionacademica.presentation.dto.AsignacionDocenteSeccionCreateDTO;
 import edu.ecep.base_app.gestionacademica.presentation.dto.AsignacionDocenteSeccionDTO;
 import edu.ecep.base_app.gestionacademica.infrastructure.mapper.AsignacionDocenteSeccionMapper;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.AsignacionDocenteSeccionRepository;
+import edu.ecep.base_app.shared.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -19,16 +23,34 @@ public class AsignacionDocenteSeccionService {
 
     private final AsignacionDocenteSeccionRepository repo;
     private final AsignacionDocenteSeccionMapper mapper;
+    private final DocenteScopeService docenteScopeService;
 
     @Transactional(readOnly = true)
     public List<AsignacionDocenteSeccionDTO> findAll() {
-        return repo.findAll().stream()
+        List<AsignacionDocenteSeccionDTO> asignaciones = repo.findAll().stream()
                 .map(mapper::toDto)
                 .toList();
+
+        Optional<DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            DocenteScope scope = scopeOpt.get();
+            Set<Long> accesibles = scope.seccionesAccesibles();
+            if (accesibles.isEmpty()) {
+                return List.of();
+            }
+            asignaciones = asignaciones.stream()
+                    .filter(dto -> accesibles.contains(dto.getSeccionId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+
+        return asignaciones;
     }
 
     @Transactional(readOnly = true)
     public List<AsignacionDocenteSeccionDTO> findBySeccion(Long seccionId) {
+        docenteScopeService.ensurePuedeAccederSeccion(seccionId);
         return repo.findBySeccion_Id(seccionId).stream()
                 .map(mapper::toDto)
                 .toList();
@@ -36,6 +58,13 @@ public class AsignacionDocenteSeccionService {
 
     @Transactional(readOnly = true)
     public List<AsignacionDocenteSeccionDTO> findVigentesByEmpleado(Long empleadoId, LocalDate fecha) {
+        Optional<DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent() && !scopeOpt.get().empleadoId().equals(empleadoId)) {
+            throw new UnauthorizedException("No tiene permisos para consultar las asignaciones del docente indicado.");
+        } else if (scopeOpt.isEmpty() && docenteScopeService.isTeacher()) {
+            throw new UnauthorizedException("No tiene permisos para consultar las asignaciones del docente indicado.");
+        }
+
         LocalDate targetDate = fecha != null ? fecha : LocalDate.now();
         return repo.findVigentesByEmpleado(empleadoId, targetDate).stream()
                 .map(mapper::toDto)
@@ -44,6 +73,8 @@ public class AsignacionDocenteSeccionService {
 
     @Transactional
     public Long create(AsignacionDocenteSeccionCreateDTO dto) {
+        ensureTeacherCannotAssign();
+
         LocalDate desde = dto.getVigenciaDesde();
         if (desde == null) {
             desde = LocalDate.now();
@@ -85,6 +116,13 @@ public class AsignacionDocenteSeccionService {
 
     @Transactional
     public void delete(Long id) {
+        ensureTeacherCannotAssign();
         repo.deleteById(id);
+    }
+
+    private void ensureTeacherCannotAssign() {
+        if (docenteScopeService.isTeacher()) {
+            throw new UnauthorizedException("No tiene permisos para asignar docentes a secciones.");
+        }
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/DocenteScopeService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/DocenteScopeService.java
@@ -73,6 +73,16 @@ public class DocenteScopeService {
         }
     }
 
+    public void ensurePuedeGestionarSeccion(Long seccionId) {
+        if (seccionId == null || !isTeacher()) {
+            return;
+        }
+        DocenteScope scope = requireScope();
+        if (!scope.esTitularDeSeccion(seccionId)) {
+            throw new UnauthorizedException("No tiene permisos para gestionar la sección solicitada.");
+        }
+    }
+
     public void ensurePuedeGestionarSeccionMateria(Long seccionMateriaId) {
         if (seccionMateriaId == null || !isTeacher()) {
             return;
@@ -169,6 +179,10 @@ public class DocenteScopeService {
 
         public boolean puedeGestionarSeccionMateria(Long seccionMateriaId) {
             return seccionMateriasGestionables.contains(seccionMateriaId);
+        }
+
+        public boolean esTitularDeSeccion(Long seccionId) {
+            return seccionesTitular.contains(seccionId);
         }
 
         public Long seccionDeSeccionMateria(Long seccionMateriaId) {

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/SeccionMateriaService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/SeccionMateriaService.java
@@ -1,18 +1,52 @@
 package edu.ecep.base_app.gestionacademica.application;
 
-import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionMateriaCreateDTO;
-import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionMateriaDTO;
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService.DocenteScope;
 import edu.ecep.base_app.gestionacademica.infrastructure.mapper.SeccionMateriaMapper;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.SeccionMateriaRepository;
+import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionMateriaCreateDTO;
+import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionMateriaDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class SeccionMateriaService {
-    private final SeccionMateriaRepository repo; private final SeccionMateriaMapper mapper;
-    public List<SeccionMateriaDTO> findAll(){ return repo.findAll().stream().map(mapper::toDto).toList(); }
-    public Long create(SeccionMateriaCreateDTO dto){ if(repo.existsBySeccionIdAndMateriaId(dto.getSeccionId(), dto.getMateriaId())) throw new IllegalArgumentException("Materia ya asignada al plan de estudio"); return repo.save(mapper.toEntity(dto)).getId(); }
+
+    private final SeccionMateriaRepository repo;
+    private final SeccionMateriaMapper mapper;
+    private final DocenteScopeService docenteScopeService;
+
+    public List<SeccionMateriaDTO> findAll() {
+        List<SeccionMateriaDTO> materias = repo.findAll().stream()
+                .map(mapper::toDto)
+                .toList();
+
+        Optional<DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            DocenteScope scope = scopeOpt.get();
+            Set<Long> accesibles = scope.seccionesAccesibles();
+            if (accesibles.isEmpty()) {
+                return List.of();
+            }
+            materias = materias.stream()
+                    .filter(dto -> accesibles.contains(dto.getSeccionId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+
+        return materias;
+    }
+
+    public Long create(SeccionMateriaCreateDTO dto) {
+        docenteScopeService.ensurePuedeGestionarSeccion(dto.getSeccionId());
+        if (repo.existsBySeccionIdAndMateriaId(dto.getSeccionId(), dto.getMateriaId())) {
+            throw new IllegalArgumentException("Materia ya asignada al plan de estudio");
+        }
+        return repo.save(mapper.toEntity(dto)).getId();
+    }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/SeccionService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/SeccionService.java
@@ -1,43 +1,83 @@
 package edu.ecep.base_app.gestionacademica.application;
 
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService.DocenteScope;
 import edu.ecep.base_app.gestionacademica.infrastructure.mapper.SeccionMapper;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.SeccionRepository;
 import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionCreateDTO;
 import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionDTO;
 import edu.ecep.base_app.shared.exception.NotFoundException;
-import java.util.List;
-
+import edu.ecep.base_app.shared.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service @RequiredArgsConstructor
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
 public class SeccionService {
-    private final SeccionRepository repo; private final SeccionMapper mapper;
-    public List<SeccionDTO> findAll(){ return repo.findAll(Sort.by("periodoEscolar.id","nivel","gradoSala","division")).stream().map(mapper::toDto).toList(); }
-    public Long create(SeccionCreateDTO dto){
-        if(repo.existsByPeriodoEscolarIdAndNivelAndGradoSalaAndDivisionAndTurno(dto.getPeriodoEscolarId(), dto.getNivel(), dto.getGradoSala(), dto.getDivision(), dto.getTurno()))
+
+    private final SeccionRepository repo;
+    private final SeccionMapper mapper;
+    private final DocenteScopeService docenteScopeService;
+
+    public List<SeccionDTO> findAll() {
+        List<edu.ecep.base_app.gestionacademica.domain.Seccion> secciones = repo.findAll(
+                Sort.by("periodoEscolar.id", "nivel", "gradoSala", "division"));
+
+        Optional<DocenteScope> scopeOpt = docenteScopeService.getScope();
+        if (scopeOpt.isPresent()) {
+            DocenteScope scope = scopeOpt.get();
+            Set<Long> accesibles = scope.seccionesAccesibles();
+            if (accesibles.isEmpty()) {
+                return List.of();
+            }
+            secciones = secciones.stream()
+                    .filter(seccion -> accesibles.contains(seccion.getId()))
+                    .toList();
+        } else if (docenteScopeService.isTeacher()) {
+            return List.of();
+        }
+
+        return secciones.stream().map(mapper::toDto).toList();
+    }
+
+    public Long create(SeccionCreateDTO dto) {
+        ensureNoTeacherModification();
+        if (repo.existsByPeriodoEscolarIdAndNivelAndGradoSalaAndDivisionAndTurno(
+                dto.getPeriodoEscolarId(), dto.getNivel(), dto.getGradoSala(), dto.getDivision(), dto.getTurno())) {
             throw new IllegalArgumentException("La sección ya existe en ese periodo");
+        }
         return repo.save(mapper.toEntity(dto)).getId();
     }
 
-    public SeccionDTO get(Long id){
+    public SeccionDTO get(Long id) {
+        docenteScopeService.ensurePuedeAccederSeccion(id);
         return repo.findById(id)
                 .map(mapper::toDto)
                 .orElseThrow(NotFoundException::new);
     }
 
-    public void update(Long id, SeccionDTO dto){
+    public void update(Long id, SeccionDTO dto) {
+        ensureNoTeacherModification();
         var entity = repo.findById(id).orElseThrow(NotFoundException::new);
         mapper.update(entity, dto);
         repo.save(entity);
     }
 
-    public void delete(Long id){
-        if(!repo.existsById(id)){
+    public void delete(Long id) {
+        ensureNoTeacherModification();
+        if (!repo.existsById(id)) {
             throw new NotFoundException();
         }
         repo.deleteById(id);
+    }
+
+    private void ensureNoTeacherModification() {
+        if (docenteScopeService.isTeacher()) {
+            throw new UnauthorizedException("No tiene permisos para modificar secciones.");
+        }
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/rest/SeccionController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/presentation/rest/SeccionController.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.gestionacademica.presentation.rest;
 
+import edu.ecep.base_app.gestionacademica.application.DocenteScopeService;
 import edu.ecep.base_app.gestionacademica.domain.Seccion;
 import edu.ecep.base_app.identidad.presentation.dto.AlumnoLiteDTO;
 import edu.ecep.base_app.gestionacademica.presentation.dto.SeccionCreateDTO;
@@ -28,6 +29,7 @@ import org.springframework.validation.annotation.Validated;
 @RequiredArgsConstructor @Validated
 public class SeccionController {
     private final SeccionService service;
+    private final DocenteScopeService docenteScopeService;
     private final MatriculaRepository matriculaRepository;
     private final AlumnoRepository alumnoRepository;
     private final MatriculaSeccionHistorialRepository mshRepo;
@@ -42,6 +44,8 @@ public class SeccionController {
     public List<AlumnoLiteDTO> alumnosActivos(
             @PathVariable Long id,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fecha) {
+
+        docenteScopeService.ensurePuedeAccederSeccion(id);
 
         LocalDate f = (fecha != null) ? fecha : LocalDate.now();
         var activos = mshRepo.findActivosBySeccionOnDate(id, f);


### PR DESCRIPTION
## Summary
- Añadir validaciones en `DocenteScopeService` para distinguir secciones tituladas y reforzar los chequeos de acceso.
- Restringir las operaciones de secciones y secciones-materias según el alcance del docente, evitando modificaciones por parte de docentes no administrativos.
- Limitar las consultas y altas de asignaciones de docentes a secciones y materias para impedir que docentes asignen personal y sólo vean datos permitidos.

## Testing
- `./mvnw -q -pl . test` *(falla: el entorno no pudo descargar dependencias de Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a09a6e8483279dffcd667878266e