### PR TITLE
Refactor reportes dashboard into modular components

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/_components/ActasReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/ActasReport.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import LoadingState from "@/components/common/LoadingState";
+import { TabsContent } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FileText, Calendar, Clock, Printer } from "lucide-react";
+import type { ActaRegistro } from "../types";
+
+export type ActasReportProps = {
+  reportRef: RefObject<HTMLDivElement>;
+  actaFrom: string;
+  setActaFrom: Dispatch<SetStateAction<string>>;
+  actaTo: string;
+  setActaTo: Dispatch<SetStateAction<string>>;
+  actaLevel: "Todos" | "Inicial" | "Primario";
+  setActaLevel: Dispatch<SetStateAction<"Todos" | "Inicial" | "Primario">>;
+  actaSection: "all" | string;
+  setActaSection: Dispatch<SetStateAction<"all" | string>>;
+  actaStudentQuery: string;
+  setActaStudentQuery: Dispatch<SetStateAction<string>>;
+  actaRegistros: ActaRegistro[];
+  filteredActas: ActaRegistro[];
+  loadingActasRegistro: boolean;
+  actaErrorMsg: string | null;
+  activeActa: ActaRegistro | null;
+  setActiveActa: Dispatch<SetStateAction<ActaRegistro | null>>;
+  exportingActaId: string | null;
+  onExportActa: (acta: ActaRegistro) => Promise<void>;
+};
+
+export function ActasReport({
+  reportRef,
+  actaFrom,
+  setActaFrom,
+  actaTo,
+  setActaTo,
+  actaLevel,
+  setActaLevel,
+  actaSection,
+  setActaSection,
+  actaStudentQuery,
+  setActaStudentQuery,
+  actaRegistros,
+  filteredActas,
+  loadingActasRegistro,
+  actaErrorMsg,
+  activeActa,
+  setActiveActa,
+  exportingActaId,
+  onExportActa,
+}: ActasReportProps) {
+  return (
+    <>
+      <TabsContent value="actas" ref={reportRef} className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <FileText className="h-5 w-5" /> Reporte de Actas de Accidentes
+            </CardTitle>
+            <CardDescription>Filtrá y consultá rápidamente los registros de actas.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-6 lg:grid-cols-[280px_1fr]">
+              <Card className="border bg-muted/40">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm font-medium">Filtros</CardTitle>
+                  <CardDescription>Acotá la búsqueda según necesidad.</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm">
+                  <div className="space-y-2">
+                    <Label>Desde</Label>
+                    <Input
+                      type="date"
+                      value={actaFrom}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setActaFrom(value);
+                        if (value && actaTo && value > actaTo) {
+                          setActaTo(value);
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Hasta</Label>
+                    <Input
+                      type="date"
+                      value={actaTo}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setActaTo(value);
+                        if (value && actaFrom && value < actaFrom) {
+                          setActaFrom(value);
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Nivel</Label>
+                    <Select value={actaLevel} onValueChange={(value) => setActaLevel(value as typeof actaLevel)}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Todos los niveles" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Todos">Todos los niveles</SelectItem>
+                        <SelectItem value="Inicial">Inicial</SelectItem>
+                        <SelectItem value="Primario">Primario</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Sección</Label>
+                    <Select
+                      value={actaSection}
+                      onValueChange={setActaSection}
+                      disabled={actaRegistros.length === 0}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Todas las secciones" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">Todas</SelectItem>
+                        {Array.from(new Set(actaRegistros.map((acta) => acta.section)))
+                          .filter(Boolean)
+                          .map((section) => (
+                            <SelectItem key={section} value={section}>
+                              {section}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Alumno</Label>
+                    <Input
+                      placeholder="Nombre o apellido"
+                      value={actaStudentQuery}
+                      onChange={(event) => setActaStudentQuery(event.target.value)}
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <div className="space-y-4">
+                {actaErrorMsg && (
+                  <div className="rounded-lg border border-dashed bg-red-50 p-4 text-sm text-red-600">
+                    {actaErrorMsg}
+                  </div>
+                )}
+
+                {loadingActasRegistro && !actaErrorMsg && (
+                  <div className="rounded-lg border border-dashed bg-muted/60 p-4">
+                    <LoadingState label="Cargando actas…" />
+                  </div>
+                )}
+
+                <div className="rounded-lg border bg-muted/30 p-4">
+                  <p className="text-sm text-muted-foreground">Actas encontradas</p>
+                  <p className="text-2xl font-semibold">
+                    {loadingActasRegistro ? "—" : filteredActas.length}
+                  </p>
+                </div>
+
+                <div className="space-y-3">
+                  {filteredActas.map((acta) => (
+                    <Card
+                      key={acta.id}
+                      className="cursor-pointer border transition hover:border-primary/40"
+                      onClick={() => setActiveActa(acta)}
+                    >
+                      <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4 text-sm">
+                        <div>
+                          <div className="font-medium">{acta.student}</div>
+                          <div className="text-muted-foreground">
+                            {acta.section} • {acta.teacher}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                          <span className="inline-flex items-center gap-1">
+                            <Calendar className="h-3 w-3" /> {acta.date}
+                          </span>
+                          <span className="inline-flex items-center gap-1">
+                            <Clock className="h-3 w-3" /> {acta.time}
+                          </span>
+                          <Badge variant={acta.signed ? "default" : "destructive"}>
+                            {acta.signed ? "Firmada" : "No firmada"}
+                          </Badge>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                  {filteredActas.length === 0 && !loadingActasRegistro && !actaErrorMsg && (
+                    <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+                      No encontramos actas con los criterios seleccionados.
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <Dialog open={!!activeActa} onOpenChange={(open) => !open && setActiveActa(null)}>
+        <DialogContent className="max-w-2xl">
+          {activeActa && (
+            <>
+              <DialogHeader>
+                <DialogTitle>Acta #{activeActa.id}</DialogTitle>
+                <DialogDescription>
+                  {activeActa.student} • {activeActa.section} • {activeActa.teacher}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4 text-sm">
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <span className="text-muted-foreground">Alumno</span>
+                    <p className="font-medium">{activeActa.student}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">DNI del alumno</span>
+                    <p className="font-medium">{activeActa.studentDni ?? "—"}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Familiar responsable</span>
+                    <p className="font-medium">{activeActa.familyName ?? "—"}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">DNI del familiar</span>
+                    <p className="font-medium">{activeActa.familyDni ?? "—"}</p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="col-span-2">
+                    <span className="text-muted-foreground">Fecha y horario</span>
+                    <p className="font-medium">
+                      {activeActa.date} • {activeActa.time}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Lugar</span>
+                    <p className="font-medium">{activeActa.location}</p>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">Estado</span>
+                    <Badge variant={activeActa.signed ? "default" : "destructive"}>
+                      {activeActa.signed ? "Firmada" : "No firmada"}
+                    </Badge>
+                  </div>
+                  <div className="col-span-2">
+                    <span className="text-muted-foreground">Dirección firmante</span>
+                    <p className="font-medium">
+                      {activeActa.signer ?? "Pendiente de asignación"}
+                      {activeActa.signerDni ? ` (DNI ${activeActa.signerDni})` : ""}
+                    </p>
+                  </div>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Descripción</span>
+                  <p className="whitespace-pre-wrap text-sm">{activeActa.description}</p>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Acciones realizadas</span>
+                  <p className="whitespace-pre-wrap text-sm">{activeActa.actions}</p>
+                </div>
+                <Button
+                  variant="outline"
+                  disabled={exportingActaId === activeActa.id}
+                  onClick={() => onExportActa(activeActa)}
+                >
+                  <Printer className="mr-2 h-4 w-4" />
+                  {exportingActaId === activeActa.id ? "Generando…" : "Imprimir Acta"}
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend-ecep/src/app/dashboard/reportes/_components/ApprovalReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/ApprovalReport.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import type { RefObject } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { TabsContent } from "@/components/ui/tabs";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+} from "recharts";
+import { TrendingUp, Users, AlertCircle } from "lucide-react";
+import type { ApprovalRecord, ApprovalSection, ApprovalSummary } from "../types";
+import { PIE_COLORS } from "../constants";
+
+export type ApprovalOverview = {
+  section: ApprovalSection;
+  sorted: ApprovalRecord[];
+  chartData: { name: string; value: number }[];
+};
+
+export type ApprovalReportProps = {
+  reportRef: RefObject<HTMLDivElement>;
+  totalApprovalSubjects: number;
+  overallPieData: { name: string; value: number }[];
+  approvalSummary: ApprovalSummary;
+  approvalSections: ApprovalSection[];
+  selectedApprovalSection: string | null;
+  onSelectApprovalSection: (id: string) => void;
+  approvalSort: "nombre" | "promedio" | "desaprobadas";
+  onChangeApprovalSort: (value: "nombre" | "promedio" | "desaprobadas") => void;
+  approvalOverview?: ApprovalOverview;
+};
+
+export function ApprovalReport({
+  reportRef,
+  totalApprovalSubjects,
+  overallPieData,
+  approvalSummary,
+  approvalSections,
+  selectedApprovalSection,
+  onSelectApprovalSection,
+  approvalSort,
+  onChangeApprovalSort,
+  approvalOverview,
+}: ApprovalReportProps) {
+  return (
+    <TabsContent value="aprobacion" ref={reportRef} className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <TrendingUp className="h-5 w-5" /> Reporte de Aprobación
+          </CardTitle>
+          <CardDescription>
+            Indicadores generales del nivel primario. Nivel inicial se encuentra deshabilitado por no contar con evaluación por materia.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex items-center gap-2">
+              <Label>Nivel</Label>
+              <Select defaultValue="Primario">
+                <SelectTrigger className="w-[160px]">
+                  <SelectValue placeholder="Seleccionar nivel" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Inicial" disabled>
+                    Inicial (no disponible)
+                  </SelectItem>
+                  <SelectItem value="Primario">Primario</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">Materias aprobadas vs desaprobadas</CardTitle>
+              </CardHeader>
+              <CardContent className="flex h-48 items-center justify-center">
+                {totalApprovalSubjects === 0 ? (
+                  <div className="text-sm text-muted-foreground">
+                    No hay calificaciones registradas aún en el nivel primario.
+                  </div>
+                ) : (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={overallPieData}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius={45}
+                        outerRadius={70}
+                      >
+                        {overallPieData.map((entry, index) => (
+                          <Cell key={entry.name} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <RechartsTooltip
+                        formatter={(value: number, name: string) => {
+                          const percent = totalApprovalSubjects
+                            ? ((value as number) / totalApprovalSubjects) * 100
+                            : 0;
+                          return [`${value} materia(s)` as string, `${name} (${percent.toFixed(1)}%)`];
+                        }}
+                      />
+                    </PieChart>
+                  </ResponsiveContainer>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">Materia con más desaprobaciones</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  <div className="flex items-center gap-2 text-lg font-semibold">
+                    <AlertCircle className="h-5 w-5 text-red-500" />
+                    {totalApprovalSubjects === 0 ? "Sin datos disponibles" : approvalSummary.subjectWithMoreFails}
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    Identificar estos espacios ayuda a realizar intervenciones pedagógicas focalizadas.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border shadow-sm">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">Alumnos con materias pendientes</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-3 text-lg font-semibold">
+                  <Users className="h-5 w-5 text-amber-500" />
+                  {totalApprovalSubjects === 0 ? "—" : approvalSummary.studentsWithPending}
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Deben rendir instancias complementarias para promocionar el año.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-4">
+            {approvalSections.map((section) => {
+              const isActive = selectedApprovalSection === section.id;
+              return (
+                <Card
+                  key={section.id}
+                  className={`cursor-pointer border transition ${isActive ? "border-primary shadow" : "hover:border-primary/40"}`}
+                  onClick={() => onSelectApprovalSection(section.id)}
+                >
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm font-medium">{section.label}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Aprobadas</span>
+                      <span className="font-semibold">{section.stats.approved}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Desaprobadas</span>
+                      <span className="font-semibold text-destructive">{section.stats.failed}</span>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Promedio aprobado / alumno: {section.stats.averageApprovedPerStudent.toFixed(1)}
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          {approvalSections.length === 0 && (
+            <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+              No encontramos secciones con calificaciones cargadas en el nivel primario.
+            </div>
+          )}
+
+          {approvalOverview ? (
+            <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+              <Card className="border">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    {approvalOverview.section.label}: estado general
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex h-56 flex-col items-center justify-center">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        data={approvalOverview.chartData}
+                        dataKey="value"
+                        nameKey="name"
+                        innerRadius={50}
+                        outerRadius={80}
+                        label
+                      >
+                        {approvalOverview.chartData.map((entry, index) => (
+                          <Cell key={entry.name} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <RechartsTooltip />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+
+              <Card className="border">
+                <CardHeader className="flex flex-wrap items-center justify-between gap-3 pb-2">
+                  <div>
+                    <CardTitle className="text-sm font-medium">Detalle por alumno</CardTitle>
+                    <CardDescription>Ordená la vista según tu necesidad de análisis</CardDescription>
+                    <p className="text-xs text-muted-foreground">
+                      Promedio de materias aprobadas por alumno: {approvalOverview.section.stats.averageApprovedPerStudent.toFixed(1)}
+                    </p>
+                  </div>
+                  <div className="w-[200px]">
+                    <Select value={approvalSort} onValueChange={onChangeApprovalSort}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Ordenar por" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="nombre">Nombre</SelectItem>
+                        <SelectItem value="promedio">Promedio general</SelectItem>
+                        <SelectItem value="desaprobadas">Materias desaprobadas</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </CardHeader>
+                <CardContent className="overflow-x-auto">
+                  <table className="w-full min-w-[560px] text-sm">
+                    <thead className="bg-muted text-xs uppercase">
+                      <tr>
+                        <th className="px-3 py-2 text-left">Alumno</th>
+                        <th className="px-3 py-2 text-left">Materia</th>
+                        <th className="px-3 py-2 text-left">Nota</th>
+                        <th className="px-3 py-2 text-left">Estado</th>
+                        <th className="px-3 py-2 text-left">Promedio</th>
+                        <th className="px-3 py-2 text-left">Materias desaprobadas</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {approvalOverview.sorted.map((record) => (
+                        <tr key={`${record.studentId}-${record.subject}`} className="border-b last:border-0">
+                          <td className="px-3 py-2">{record.studentName}</td>
+                          <td className="px-3 py-2">{record.subject}</td>
+                          <td className="px-3 py-2">{record.grade.toFixed(1)}</td>
+                          <td className="px-3 py-2">
+                            <Badge variant={record.status === "APROBADO" ? "default" : "destructive"}>
+                              {record.status === "APROBADO" ? "Aprobado" : "Desaprobado"}
+                            </Badge>
+                          </td>
+                          <td className="px-3 py-2">{record.average.toFixed(1)}</td>
+                          <td className="px-3 py-2">{record.failedCount}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </CardContent>
+              </Card>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+              Seleccioná una sección para ver el detalle específico.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </TabsContent>
+  );
+}

--- a/frontend-ecep/src/app/dashboard/reportes/_components/AttendanceReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/AttendanceReport.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import LoadingState from "@/components/common/LoadingState";
+import { TabsContent } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Users, Search } from "lucide-react";
+import type { AttendanceSummarySection } from "../types";
+import { formatPercent } from "../utils";
+import { PIE_COLORS } from "../constants";
+
+export type AttendanceSectionOption = {
+  id: string;
+  label: string;
+  level: string;
+};
+
+export type AttendanceReportProps = {
+  reportRef: RefObject<HTMLDivElement>;
+  attendanceFrom: string;
+  attendanceTo: string;
+  setAttendanceFrom: Dispatch<SetStateAction<string>>;
+  setAttendanceTo: Dispatch<SetStateAction<string>>;
+  attendanceSectionOptions: AttendanceSectionOption[];
+  selectedAttendanceSections: string[];
+  setSelectedAttendanceSections: Dispatch<SetStateAction<string[]>>;
+  attendancePopoverOpen: boolean;
+  setAttendancePopoverOpen: Dispatch<SetStateAction<boolean>>;
+  attendanceError: string | null;
+  loadingAttendance: boolean;
+  attendanceLevelSummary: Record<string, { totalDays: number; attended: number }>;
+  attendanceSelectedSummaries: AttendanceSummarySection[];
+};
+
+export function AttendanceReport({
+  reportRef,
+  attendanceFrom,
+  attendanceTo,
+  setAttendanceFrom,
+  setAttendanceTo,
+  attendanceSectionOptions,
+  selectedAttendanceSections,
+  setSelectedAttendanceSections,
+  attendancePopoverOpen,
+  setAttendancePopoverOpen,
+  attendanceError,
+  loadingAttendance,
+  attendanceLevelSummary,
+  attendanceSelectedSummaries,
+}: AttendanceReportProps) {
+  return (
+    <TabsContent value="asistencias" ref={reportRef} className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Users className="h-5 w-5" /> Reporte de Asistencias de Alumnos
+          </CardTitle>
+          <CardDescription>
+            Analizá el comportamiento de asistencia por nivel, sección y alumno.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div className="grid gap-4 md:grid-cols-4">
+            <DateField
+              label="Desde"
+              value={attendanceFrom}
+              onChange={(value) => {
+                setAttendanceFrom(value);
+                if (value && attendanceTo && value > attendanceTo) {
+                  setAttendanceTo(value);
+                }
+              }}
+            />
+            <DateField
+              label="Hasta"
+              value={attendanceTo}
+              onChange={(value) => {
+                setAttendanceTo(value);
+                if (value && attendanceFrom && value < attendanceFrom) {
+                  setAttendanceFrom(value);
+                }
+              }}
+            />
+            <div className="md:col-span-2">
+              <Label className="mb-1 block">Secciones</Label>
+              <Popover open={attendancePopoverOpen} onOpenChange={setAttendancePopoverOpen}>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" className="w-full justify-between">
+                    {selectedAttendanceSections.length
+                      ? `${selectedAttendanceSections.length} sección(es) seleccionadas`
+                      : "Seleccionar secciones"}
+                    <Search className="h-4 w-4" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-[260px] p-0" align="start">
+                  <Command>
+                    <CommandInput placeholder="Buscar sección..." />
+                    <CommandList>
+                      <CommandEmpty>Sin resultados</CommandEmpty>
+                      <CommandGroup>
+                        {attendanceSectionOptions.map((section) => {
+                          const checked = selectedAttendanceSections.includes(section.id);
+                          return (
+                            <CommandItem
+                              key={section.id}
+                              onSelect={() => {
+                                setSelectedAttendanceSections((prev) => {
+                                  if (checked) {
+                                    const updated = prev.filter((id) => id !== section.id);
+                                    return updated.length ? updated : [section.id];
+                                  }
+                                  return [...prev, section.id];
+                                });
+                              }}
+                            >
+                              <div className="flex w-full items-center justify-between gap-2">
+                                <div>
+                                  <p className="text-sm font-medium">{section.label}</p>
+                                  <p className="text-xs text-muted-foreground">{section.level}</p>
+                                </div>
+                                <Checkbox
+                                  checked={checked}
+                                  onCheckedChange={(value) => {
+                                    setSelectedAttendanceSections((prev) => {
+                                      if (value) return [...prev, section.id];
+                                      const updated = prev.filter((id) => id !== section.id);
+                                      return updated.length ? updated : [];
+                                    });
+                                  }}
+                                />
+                              </div>
+                            </CommandItem>
+                          );
+                        })}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+
+          {attendanceError && (
+            <div className="rounded-lg border border-dashed bg-red-50 p-4 text-sm text-red-600">
+              {attendanceError}
+            </div>
+          )}
+
+          {loadingAttendance && !attendanceError && (
+            <div className="rounded-lg border border-dashed bg-muted/60 p-6">
+              <LoadingState label="Cargando asistencia…" />
+            </div>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-3">
+            {Object.entries(attendanceLevelSummary).map(([level, summary], index) => {
+              const attendance = summary.totalDays ? summary.attended / summary.totalDays : 0;
+              return (
+                <Card key={level} className="border shadow-sm">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm font-medium">Promedio de asistencia – {level}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex h-48 items-center justify-center">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie data={[{ name: "Asistió", value: attendance }, { name: "Ausentismo", value: 1 - attendance }]}
+                          dataKey="value"
+                          nameKey="name"
+                          innerRadius={45}
+                          outerRadius={70}
+                        >
+                          {[attendance, 1 - attendance].map((_, colorIndex) => (
+                            <Cell
+                              key={colorIndex}
+                              fill={PIE_COLORS[(index + colorIndex) % PIE_COLORS.length]}
+                            />
+                          ))}
+                        </Pie>
+                        <RechartsTooltip formatter={(value: number, name) => `${name}: ${(value * 100).toFixed(1)}%`} />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          {attendanceSelectedSummaries.map((summary) => {
+            const averageAttendance = summary.totalDays ? summary.attended / summary.totalDays : 0;
+            return (
+              <Card key={summary.sectionId} className="border">
+                <CardHeader className="flex flex-wrap items-center justify-between gap-3 pb-2">
+                  <div>
+                    <CardTitle className="text-sm font-medium">
+                      {summary.label} • {summary.level}
+                    </CardTitle>
+                    <CardDescription>
+                      {summary.students.length} alumno(s) • {summary.totalDays} registros en el período seleccionado.
+                    </CardDescription>
+                  </div>
+                  <Badge variant="outline">Promedio de asistencia {formatPercent(averageAttendance, 1)}</Badge>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="overflow-x-auto">
+                    <table className="w-full min-w-[600px] text-sm">
+                      <thead className="bg-muted text-xs uppercase">
+                        <tr>
+                          <th className="px-3 py-2 text-left">Alumno</th>
+                          <th className="px-3 py-2 text-left">Días registrables</th>
+                          <th className="px-3 py-2 text-left">Asistidos</th>
+                          <th className="px-3 py-2 text-left">Ausentes</th>
+                          <th className="px-3 py-2 text-left">Llegadas tarde</th>
+                          <th className="px-3 py-2 text-left">Retiros ant.</th>
+                          <th className="px-3 py-2 text-left">% Asistencia</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {summary.students.map((student) => (
+                          <tr key={student.id} className="border-b last:border-0">
+                            <td className="px-3 py-2">{student.name}</td>
+                            <td className="px-3 py-2">{student.total}</td>
+                            <td className="px-3 py-2">{student.presentes}</td>
+                            <td className="px-3 py-2">{student.ausentes}</td>
+                            <td className="px-3 py-2">{student.tarde}</td>
+                            <td className="px-3 py-2">{student.retiroAnticipado}</td>
+                            <td className="px-3 py-2 font-semibold">{formatPercent(student.attendance, 1)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <div className="h-64 w-full">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <BarChart
+                        data={summary.students.map((student) => ({
+                          name: student.name,
+                          attendance: (student.attendance * 100).toFixed(1),
+                        }))}
+                      >
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="name" hide={summary.students.length > 6} />
+                        <YAxis domain={[0, 100]} tickFormatter={(value) => `${value}%`} />
+                        <RechartsTooltip formatter={(value: string) => `${value}%`} />
+                        <Bar dataKey="attendance" fill="#0ea5e9" radius={[6, 6, 0, 0]} />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+
+          {!loadingAttendance && !attendanceError && attendanceSelectedSummaries.length === 0 && (
+            <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+              No encontramos registros de asistencia para las secciones seleccionadas.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </TabsContent>
+  );
+}
+
+function DateField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div>
+      <Label className="mb-1 block">{label}</Label>
+      <Input type="date" value={value} onChange={(event) => onChange(event.target.value)} />
+    </div>
+  );
+}

--- a/frontend-ecep/src/app/dashboard/reportes/_components/BoletinesReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/BoletinesReport.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { useMemo, type RefObject } from "react";
+import LoadingState from "@/components/common/LoadingState";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { TabsContent } from "@/components/ui/tabs";
+import { GraduationCap, Printer } from "lucide-react";
+import { type BoletinStudent, type BoletinSubject } from "../types";
+import {
+  formatPercent,
+  getBoletinGradeDisplay,
+  sanitizeTeacherName,
+} from "../utils";
+
+export type BoletinesReportProps = {
+  reportRef: RefObject<HTMLDivElement>;
+  loading: boolean;
+  error: string | null;
+  sections: { id: string; label: string; level: string }[];
+  selectedSectionId: string;
+  onSelectSection: (sectionId: string) => void;
+  students: BoletinStudent[];
+  onSelectStudent: (student: BoletinStudent) => void;
+  activeStudent: BoletinStudent | null;
+  onCloseStudent: () => void;
+  onPrintStudent: () => void;
+  exportingStudent: boolean;
+  isActiveStudentPrimario: boolean;
+  boletinTrimesters: { id: number; label: string }[];
+  boletinSubjectsForTable: BoletinSubject[];
+  boletinSubjectsByTrimester: {
+    id: number;
+    label: string;
+    subjects: { id: string; name: string; teacher: string | null; grade: string }[];
+  }[];
+};
+
+export function BoletinesReport({
+  reportRef,
+  loading,
+  error,
+  sections,
+  selectedSectionId,
+  onSelectSection,
+  students,
+  onSelectStudent,
+  activeStudent,
+  onCloseStudent,
+  onPrintStudent,
+  exportingStudent,
+  isActiveStudentPrimario,
+  boletinTrimesters,
+  boletinSubjectsForTable,
+  boletinSubjectsByTrimester,
+}: BoletinesReportProps) {
+  const sectionPlaceholder = useMemo(() => {
+    if (loading) return "Cargando secciones…";
+    if (sections.length === 0) return "No hay secciones disponibles";
+    return "Seleccione una sección";
+  }, [loading, sections.length]);
+
+  return (
+    <>
+      <TabsContent value="boletines" ref={reportRef} className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <GraduationCap className="h-5 w-5" /> Reporte de Boletines
+            </CardTitle>
+            <CardDescription>
+              Seleccione una sección para visualizar el resumen académico de cada alumno.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="max-w-sm">
+              <LabelledSectionSelect
+                loading={loading}
+                placeholder={sectionPlaceholder}
+                sections={sections}
+                selectedSectionId={selectedSectionId}
+                onSelectSection={onSelectSection}
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-lg border border-dashed bg-red-50 p-6 text-sm text-red-600">
+                {error}
+              </div>
+            )}
+
+            {loading && !error ? (
+              <div className="rounded-lg border border-dashed bg-muted/50 p-6">
+                <LoadingState label="Cargando información académica…" />
+              </div>
+            ) : !selectedSectionId ? (
+              <div className="rounded-lg border border-dashed bg-muted/50 p-6 text-sm text-muted-foreground">
+                Elegí una sección del listado para ver sus alumnos.
+              </div>
+            ) : (
+              <StudentsGrid students={students} onSelectStudent={onSelectStudent} />
+            )}
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <Sheet open={!!activeStudent} onOpenChange={(open) => !open && onCloseStudent()}>
+        <SheetContent className="flex h-full w-full max-w-full flex-col overflow-y-auto sm:max-w-3xl md:overflow-y-visible lg:w-[80vw] lg:max-w-5xl">
+          {activeStudent && (
+            <>
+              <SheetHeader className="space-y-4 text-left">
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="space-y-2">
+                    <SheetTitle className="text-xl lg:text-2xl">{activeStudent.name}</SheetTitle>
+                    <SheetDescription className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                      <span className="font-medium text-foreground">{activeStudent.section}</span>
+                      <span className="text-muted-foreground">
+                        Legajo: {activeStudent.matriculaId ?? activeStudent.alumnoId ?? "—"}
+                      </span>
+                    </SheetDescription>
+                  </div>
+                  <Button
+                    variant="outline"
+                    className="justify-center lg:justify-start"
+                    onClick={onPrintStudent}
+                    disabled={exportingStudent}
+                  >
+                    <Printer className="mr-2 h-4 w-4" />
+                    {exportingStudent ? "Generando…" : "Imprimir resumen"}
+                  </Button>
+                </div>
+              </SheetHeader>
+
+              <div className="mt-6 grid gap-3 text-sm sm:grid-cols-2">
+                <SummaryCard label="Promedio general">
+                  {typeof activeStudent.average === "number" ? activeStudent.average.toFixed(1) : "—"}
+                </SummaryCard>
+                <SummaryCard label="Asistencia">
+                  {typeof activeStudent.attendancePercentage === "number"
+                    ? formatPercent(activeStudent.attendancePercentage, 1)
+                    : "—"}
+                </SummaryCard>
+              </div>
+
+              <div
+                className={`mt-6 flex-1 space-y-4 pb-8 text-sm ${
+                  isActiveStudentPrimario
+                    ? "lg:grid lg:grid-cols-[minmax(0,320px)_1fr] lg:items-start lg:gap-6 lg:space-y-0"
+                    : ""
+                }`}
+              >
+                {activeStudent.attendanceDetail && (
+                  <div className="rounded-lg border p-4 lg:sticky lg:top-6">
+                    <h3 className="text-sm font-semibold">Detalle de asistencia</h3>
+                    <ul className="mt-2 space-y-1 text-muted-foreground">
+                      <li>Días hábiles: {activeStudent.attendanceDetail.workingDays}</li>
+                      <li>Asistidos: {activeStudent.attendanceDetail.attended}</li>
+                      <li>Inasistencias justificadas: {activeStudent.attendanceDetail.justified}</li>
+                      <li>Inasistencias injustificadas: {activeStudent.attendanceDetail.unjustified}</li>
+                    </ul>
+                  </div>
+                )}
+
+                {activeStudent.level === "Primario" ? (
+                  <BoletinSubjectsDetail
+                    boletinTrimesters={boletinTrimesters}
+                    boletinSubjectsByTrimester={boletinSubjectsByTrimester}
+                    boletinSubjectsForTable={boletinSubjectsForTable}
+                  />
+                ) : (
+                  <InformeDetail informes={activeStudent.informes} activeStudentId={activeStudent.id} />
+                )}
+              </div>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+function LabelledSectionSelect({
+  loading,
+  placeholder,
+  sections,
+  selectedSectionId,
+  onSelectSection,
+}: {
+  loading: boolean;
+  placeholder: string;
+  sections: { id: string; label: string; level: string }[];
+  selectedSectionId: string;
+  onSelectSection: (sectionId: string) => void;
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium text-foreground">Sección</label>
+      <Select
+        value={selectedSectionId}
+        onValueChange={onSelectSection}
+        disabled={loading || sections.length === 0}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {sections.map((section) => (
+            <SelectItem key={section.id} value={section.id}>
+              {section.label}
+              {section.level ? ` — ${section.level}` : ""}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function StudentsGrid({
+  students,
+  onSelectStudent,
+}: {
+  students: BoletinStudent[];
+  onSelectStudent: (student: BoletinStudent) => void;
+}) {
+  if (students.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed bg-muted/50 p-6 text-sm text-muted-foreground">
+        No hay alumnos registrados en esta sección.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {students.map((student) => (
+        <Card
+          key={student.id}
+          className="cursor-pointer transition-colors hover:border-primary"
+          onClick={() => onSelectStudent(student)}
+        >
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">{student.name}</CardTitle>
+            <CardDescription>{student.section}</CardDescription>
+            <Badge variant="outline" className="mt-1 w-fit">
+              {student.level}
+            </Badge>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex items-center gap-2">
+              <Badge
+                variant={
+                  student.status
+                    ? student.status === "Promociona"
+                      ? "default"
+                      : student.status === "No Promociona"
+                        ? "destructive"
+                        : "outline"
+                    : "outline"
+                }
+              >
+                {student.status ?? "Sin estado"}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                Click para ver {student.level === "Primario" ? "boletín" : "informes"} completo
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function SummaryCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border bg-muted/30 p-4">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold text-foreground">{children}</p>
+    </div>
+  );
+}
+
+function BoletinSubjectsDetail({
+  boletinTrimesters,
+  boletinSubjectsByTrimester,
+  boletinSubjectsForTable,
+}: {
+  boletinTrimesters: { id: number; label: string }[];
+  boletinSubjectsByTrimester: {
+    id: number;
+    label: string;
+    subjects: { id: string; name: string; teacher: string | null; grade: string }[];
+  }[];
+  boletinSubjectsForTable: BoletinSubject[];
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border">
+        <div className="border-b px-4 py-3 text-sm font-semibold">Materias y calificaciones</div>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[620px] text-sm">
+            <thead className="bg-muted text-xs uppercase">
+              <tr>
+                <th className="px-3 py-2 text-left">Materia</th>
+                {boletinTrimesters.map((trimester) => (
+                  <th key={trimester.id} className="px-3 py-2 text-left">
+                    {trimester.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {boletinSubjectsByTrimester.length === 0 ? (
+                <tr>
+                  <td colSpan={boletinTrimesters.length + 1} className="px-3 py-6 text-center text-sm text-muted-foreground">
+                    No hay calificaciones registradas para este alumno.
+                  </td>
+                </tr>
+              ) : (
+                boletinSubjectsByTrimester[0].subjects.map((subject, subjectIndex) => (
+                  <tr key={subject.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">
+                      <div className="font-medium">{subject.name}</div>
+                      {subject.teacher && (
+                        <div className="text-xs text-muted-foreground">Docente: {subject.teacher}</div>
+                      )}
+                    </td>
+                    {boletinSubjectsByTrimester.map((trimester) => (
+                      <td key={`${trimester.id}-${subject.id}`} className="px-3 py-2 font-semibold">
+                        {trimester.subjects[subjectIndex]?.grade ?? "—"}
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="grid gap-3 p-4 md:hidden">
+        {boletinSubjectsForTable.map((subject) => {
+          const displayTeacher = sanitizeTeacherName(subject.teacher);
+
+          return (
+            <div key={subject.id} className="space-y-3 rounded-md border border-border bg-background p-3 shadow-sm">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold">{subject.name}</p>
+                {displayTeacher && (
+                  <p className="text-xs text-muted-foreground">Docente: {displayTeacher}</p>
+                )}
+              </div>
+              <div className="grid gap-2">
+                {boletinTrimesters.map((trimester) => {
+                  const grade = subject.grades.find((g) => g.trimestreId === trimester.id);
+                  const gradeValue = getBoletinGradeDisplay(grade);
+
+                  return (
+                    <div key={`${subject.id}-${trimester.id}`} className="rounded border border-dashed border-border/60 p-2">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                          {trimester.label}
+                        </span>
+                        <span className="text-sm font-semibold text-foreground">{gradeValue}</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function InformeDetail({
+  informes,
+  activeStudentId,
+}: {
+  informes?: BoletinStudent["informes"];
+  activeStudentId: string;
+}) {
+  return (
+    <div className="rounded-lg border">
+      <div className="border-b px-4 py-3 text-sm font-semibold">Informes por trimestre</div>
+      <div className="divide-y">
+        {informes && informes.length > 0 ? (
+          informes.map((informe) => (
+            <div key={`${activeStudentId}-${informe.trimestreId}`} className="grid gap-2 p-4">
+              <div className="font-medium">{informe.trimestreLabel}</div>
+              <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                {informe.descripcion || "Sin descripción"}
+              </p>
+            </div>
+          ))
+        ) : (
+          <div className="p-4 text-xs text-muted-foreground">
+            No hay informes cargados para este alumno.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend-ecep/src/app/dashboard/reportes/_components/LicensesReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/LicensesReport.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import LoadingState from "@/components/common/LoadingState";
+import { TabsContent } from "@/components/ui/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+} from "recharts";
+import { FileText, Users } from "lucide-react";
+import { LicenseSummaryCards } from "../_components/LicenseSummaryCards";
+import type { LicenseReportRow } from "../types";
+import { PIE_COLORS } from "../constants";
+import { tipoLicenciaOptions } from "../utils";
+
+export type LicenseSelectOption = [string, string];
+
+export type LicensesReportProps = {
+  reportRef: RefObject<HTMLDivElement>;
+  personalSummary: { total: number; activos: number; enLicencia: number };
+  licenseRows: LicenseReportRow[];
+  licenseLoading: boolean;
+  licenseError: string | null;
+  licenseQuery: string;
+  setLicenseQuery: Dispatch<SetStateAction<string>>;
+  licenseTeacherFilter: string;
+  setLicenseTeacherFilter: Dispatch<SetStateAction<string>>;
+  licenseTypeFilter: string;
+  setLicenseTypeFilter: Dispatch<SetStateAction<string>>;
+  licenseJustificationFilter: "all" | "justified" | "unjustified";
+  setLicenseJustificationFilter: Dispatch<SetStateAction<"all" | "justified" | "unjustified">>;
+  licenseFrom: string;
+  setLicenseFrom: Dispatch<SetStateAction<string>>;
+  licenseTo: string;
+  setLicenseTo: Dispatch<SetStateAction<string>>;
+  licenseTeacherOptions: LicenseSelectOption[];
+  licenseTypeData: { name: string; value: number }[];
+  topLicenseTypes: { name: string; value: number }[];
+  activeLicenses: number;
+  expiringLicenses: number;
+  filteredLicenses: LicenseReportRow[];
+  licenseFiltersActive: boolean;
+};
+
+export function LicensesReport({
+  reportRef,
+  personalSummary,
+  licenseRows,
+  licenseLoading,
+  licenseError,
+  licenseQuery,
+  setLicenseQuery,
+  licenseTeacherFilter,
+  setLicenseTeacherFilter,
+  licenseTypeFilter,
+  setLicenseTypeFilter,
+  licenseJustificationFilter,
+  setLicenseJustificationFilter,
+  licenseFrom,
+  setLicenseFrom,
+  licenseTo,
+  setLicenseTo,
+  licenseTeacherOptions,
+  licenseTypeData,
+  topLicenseTypes,
+  activeLicenses,
+  expiringLicenses,
+  filteredLicenses,
+  licenseFiltersActive,
+}: LicensesReportProps) {
+  return (
+    <TabsContent value="licencias" ref={reportRef} className="space-y-4">
+      <LicenseSummaryCards
+        totalPersonal={personalSummary.total}
+        activos={personalSummary.activos}
+        enLicencia={personalSummary.enLicencia}
+        totalLicencias={licenseRows.length}
+        loadingLicencias={licenseLoading}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <FileText className="h-5 w-5" /> Resumen de licencias
+          </CardTitle>
+          <CardDescription>
+            Visualizá la distribución y el estado actual de las licencias del personal.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {licenseLoading ? (
+            <div className="rounded-lg border border-dashed bg-muted/60 p-6">
+              <LoadingState label="Cargando licencias…" />
+            </div>
+          ) : licenseError ? (
+            <div className="rounded-lg border border-dashed bg-red-50 p-4 text-sm text-red-600">
+              {licenseError}
+            </div>
+          ) : licenseRows.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+              No encontramos licencias registradas en el sistema.
+            </div>
+          ) : (
+            <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+              <div className="h-64 rounded-lg border bg-muted/30 p-4">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={licenseTypeData}
+                      dataKey="value"
+                      nameKey="name"
+                      innerRadius={60}
+                      outerRadius={90}
+                      paddingAngle={2}
+                    >
+                      {licenseTypeData.map((entry, index) => (
+                        <Cell key={`${entry.name}-${index}`} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <RechartsTooltip />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="space-y-4">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-lg border bg-muted/30 p-4">
+                    <p className="text-sm text-muted-foreground">Licencias activas</p>
+                    <p className="text-2xl font-semibold">{activeLicenses}</p>
+                  </div>
+                  <div className="rounded-lg border bg-muted/30 p-4">
+                    <p className="text-sm text-muted-foreground">Próximas a vencer (7 días)</p>
+                    <p className="text-2xl font-semibold">{expiringLicenses}</p>
+                  </div>
+                </div>
+                <div className="space-y-2 text-sm text-muted-foreground">
+                  <p>Tipos más frecuentes</p>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {topLicenseTypes.length ? (
+                      topLicenseTypes.map((item) => (
+                        <div
+                          key={item.name}
+                          className="flex items-center justify-between rounded-lg border bg-background px-3 py-2"
+                        >
+                          <span>{item.name}</span>
+                          <span className="font-semibold">{item.value}</span>
+                        </div>
+                      ))
+                    ) : (
+                      <div className="rounded-lg border bg-background px-3 py-2">
+                        <p>No hay datos suficientes.</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Users className="h-5 w-5" /> Detalle de licencias por docente
+          </CardTitle>
+          <CardDescription>
+            Filtrá por docente, tipo o justificación para analizar los movimientos del personal.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-5">
+            <div className="md:col-span-2 space-y-1">
+              <Label>Búsqueda</Label>
+              <Input
+                placeholder="Buscar por docente o motivo"
+                value={licenseQuery}
+                onChange={(event) => setLicenseQuery(event.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Docente</Label>
+              <Select
+                value={licenseTeacherFilter}
+                onValueChange={setLicenseTeacherFilter}
+                disabled={licenseTeacherOptions.length === 0}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Todos los docentes" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos</SelectItem>
+                  {licenseTeacherOptions.map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Tipo</Label>
+              <Select value={licenseTypeFilter} onValueChange={setLicenseTypeFilter}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Todos los tipos" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos</SelectItem>
+                  {tipoLicenciaOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Justificación</Label>
+              <Select
+                value={licenseJustificationFilter}
+                onValueChange={(value) =>
+                  setLicenseJustificationFilter(value as typeof licenseJustificationFilter)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Todas" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todas</SelectItem>
+                  <SelectItem value="justified">Justificadas</SelectItem>
+                  <SelectItem value="unjustified">Sin justificar</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Desde</Label>
+              <Input
+                type="date"
+                value={licenseFrom}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setLicenseFrom(value);
+                  if (licenseTo && value && value > licenseTo) {
+                    setLicenseTo(value);
+                  }
+                }}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Hasta</Label>
+              <Input
+                type="date"
+                value={licenseTo}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setLicenseTo(value);
+                  if (licenseFrom && value && value < licenseFrom) {
+                    setLicenseFrom(value);
+                  }
+                }}
+              />
+            </div>
+          </div>
+
+          {licenseError && !licenseLoading ? (
+            <div className="rounded-lg border border-dashed bg-red-50 p-4 text-sm text-red-600">
+              {licenseError}
+            </div>
+          ) : null}
+
+          {licenseLoading ? (
+            <div className="rounded-lg border border-dashed bg-muted/60 p-6">
+              <LoadingState label="Cargando licencias…" />
+            </div>
+          ) : filteredLicenses.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] text-sm">
+                <thead className="bg-muted text-xs uppercase">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Docente</th>
+                    <th className="px-3 py-2 text-left">Tipo</th>
+                    <th className="px-3 py-2 text-left">Período</th>
+                    <th className="px-3 py-2 text-left">Estado</th>
+                    <th className="px-3 py-2 text-left">Motivo</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredLicenses.map((licencia) => (
+                    <tr key={licencia.id} className="border-b last:border-0">
+                      <td className="px-3 py-3 align-top">
+                        <div className="font-medium text-foreground">{licencia.teacherName}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {licencia.cargo ? licencia.cargo : "Sin cargo asignado"}
+                          {licencia.situacion ? ` • ${licencia.situacion}` : ""}
+                        </div>
+                      </td>
+                      <td className="px-3 py-3 align-top">
+                        <Badge variant="outline">{licencia.tipoLabel}</Badge>
+                        {typeof licencia.horas === "number" ? (
+                          <div className="mt-1 text-xs text-muted-foreground">{licencia.horas} hs de ausencia</div>
+                        ) : null}
+                      </td>
+                      <td className="px-3 py-3 align-top">
+                        <div>{licencia.rangeLabel}</div>
+                        {licencia.durationDays ? (
+                          <div className="text-xs text-muted-foreground">{licencia.durationDays} días</div>
+                        ) : null}
+                      </td>
+                      <td className="px-3 py-3 align-top">
+                        <div className="flex flex-wrap gap-2">
+                          <Badge
+                            variant={
+                              licencia.expiresSoon
+                                ? "destructive"
+                                : licencia.isActive
+                                  ? "default"
+                                  : "outline"
+                            }
+                          >
+                            {licencia.expiresSoon
+                              ? "Próxima a vencer"
+                              : licencia.isActive
+                                ? "Activa"
+                                : "Finalizada"}
+                          </Badge>
+                          <Badge variant={licencia.justificada ? "secondary" : "destructive"}>
+                            {licencia.justificada ? "Justificada" : "Sin justificar"}
+                          </Badge>
+                        </div>
+                      </td>
+                      <td className="px-3 py-3 align-top">
+                        {licencia.motivo ? (
+                          <div className="whitespace-pre-wrap">{licencia.motivo}</div>
+                        ) : (
+                          <span className="text-muted-foreground">Sin detalle</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+
+          {!licenseLoading && filteredLicenses.length === 0 && !licenseError ? (
+            <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+              {licenseFiltersActive
+                ? "No se encontraron licencias con los criterios seleccionados."
+                : "Aún no se registraron licencias en el sistema."}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </TabsContent>
+  );
+}

--- a/frontend-ecep/src/app/dashboard/reportes/constants.ts
+++ b/frontend-ecep/src/app/dashboard/reportes/constants.ts
@@ -1,0 +1,16 @@
+import type { ApprovalSection } from "./types";
+
+export const PIE_COLORS = ["#0ea5e9", "#fb7185", "#6366f1", "#22c55e"] as const;
+
+export const DAY_IN_MS = 1000 * 60 * 60 * 24;
+
+export const APPROVAL_DATA = {
+  summary: {
+    totalSubjects: 0,
+    approved: 0,
+    failed: 0,
+    subjectWithMoreFails: "Sin datos",
+    studentsWithPending: 0,
+  },
+  sections: [] as ApprovalSection[],
+} as const;

--- a/frontend-ecep/src/app/dashboard/reportes/types.ts
+++ b/frontend-ecep/src/app/dashboard/reportes/types.ts
@@ -1,0 +1,149 @@
+export type BoletinSubjectGrade = {
+  trimestreId: number;
+  trimestreLabel: string;
+  notaNumerica?: number | null;
+  notaConceptual?: string | null;
+  observaciones?: string | null;
+};
+
+export type BoletinSubject = {
+  id: string;
+  name: string;
+  teacher?: string | null;
+  grades: BoletinSubjectGrade[];
+};
+
+export type BoletinInforme = {
+  trimestreId: number;
+  trimestreLabel: string;
+  descripcion: string;
+};
+
+export type BoletinAttendance = {
+  workingDays: number;
+  attended: number;
+  justified: number;
+  unjustified: number;
+};
+
+export type BoletinStudent = {
+  id: string;
+  matriculaId: number | null;
+  alumnoId: number | null;
+  name: string;
+  section: string;
+  sectionId: number;
+  level: "Inicial" | "Primario";
+  average?: number | null;
+  attendancePercentage?: number | null;
+  absencePercentage?: number | null;
+  attendanceDetail?: BoletinAttendance | null;
+  status?: string;
+  subjects: BoletinSubject[];
+  informes?: BoletinInforme[];
+};
+
+export type BoletinSection = {
+  id: number;
+  label: string;
+  level: "Inicial" | "Primario";
+  students: BoletinStudent[];
+};
+
+export type ApprovalSummary = {
+  totalSubjects: number;
+  approved: number;
+  failed: number;
+  subjectWithMoreFails: string;
+  studentsWithPending: number;
+};
+
+export type ApprovalRecord = {
+  studentId: string;
+  studentName: string;
+  subject: string;
+  grade: number;
+  status: "APROBADO" | "DESAPROBADO";
+  average: number;
+  failedCount: number;
+};
+
+export type ApprovalSection = {
+  id: string;
+  label: string;
+  stats: {
+    approved: number;
+    failed: number;
+    averageApprovedPerStudent: number;
+  };
+  records: ApprovalRecord[];
+};
+
+export type AttendanceSummaryStudent = {
+  id: string;
+  name: string;
+  total: number;
+  presentes: number;
+  ausentes: number;
+  tarde: number;
+  retiroAnticipado: number;
+  attendance: number;
+};
+
+export type AttendanceSummarySection = {
+  sectionId: string;
+  label: string;
+  level: "Inicial" | "Primario";
+  students: AttendanceSummaryStudent[];
+  totalDays: number;
+  attended: number;
+};
+
+export type LicenseReportRow = {
+  id: string;
+  teacherId: number | null;
+  teacherName: string;
+  cargo?: string;
+  situacion?: string;
+  tipo: string;
+  tipoLabel: string;
+  start: string;
+  end: string | null;
+  startLabel: string;
+  endLabel: string | null;
+  rangeLabel: string;
+  durationDays: number | null;
+  horas: number | null;
+  justificada: boolean;
+  motivo: string;
+  isActive: boolean;
+  expiresSoon: boolean;
+};
+
+export type ActaRegistro = {
+  id: string;
+  student: string;
+  studentDni?: string | null;
+  section: string;
+  level: "Inicial" | "Primario";
+  teacher: string;
+  date: string;
+  time: string;
+  location: string;
+  description: string;
+  actions: string;
+  signer?: string;
+  signerDni?: string | null;
+  signed: boolean;
+  familyName?: string | null;
+  familyDni?: string | null;
+};
+
+export type CachedAlumnoInfo = {
+  name: string;
+  section: string;
+  level: "Inicial" | "Primario";
+  dni?: string | null;
+  familyName?: string | null;
+  familyDni?: string | null;
+};

--- a/frontend-ecep/src/app/dashboard/reportes/utils.ts
+++ b/frontend-ecep/src/app/dashboard/reportes/utils.ts
@@ -1,0 +1,80 @@
+import type { BoletinSubjectGrade } from "./types";
+
+const dateFormatter = new Intl.DateTimeFormat("es-AR", { dateStyle: "medium" });
+
+export const tipoLicenciaOptions = [
+  { value: "ENFERMEDAD", label: "Enfermedad" },
+  { value: "CUIDADO_FAMILIAR", label: "Cuidado familiar" },
+  { value: "FORMACION", label: "Formación" },
+  { value: "PERSONAL", label: "Motivo personal" },
+  { value: "MATERNIDAD", label: "Maternidad / Paternidad" },
+  { value: "OTRA", label: "Otra" },
+] as const;
+
+export const sanitizeTeacherName = (teacher?: string | null) => {
+  if (!teacher) return null;
+  const trimmed = String(teacher).trim();
+  return trimmed && trimmed !== "—" ? trimmed : null;
+};
+
+export const getBoletinGradeDisplay = (grade?: BoletinSubjectGrade | null) => {
+  if (!grade) return "—";
+
+  const conceptual = grade.notaConceptual?.trim();
+  if (conceptual && conceptual !== "—") {
+    return conceptual;
+  }
+
+  const numeric = typeof grade.notaNumerica === "number" ? grade.notaNumerica : null;
+  if (numeric != null && Number.isFinite(numeric)) {
+    return numeric.toFixed(1);
+  }
+
+  return "—";
+};
+
+export const formatPercent = (value: number, digits = 0) =>
+  `${(value * 100).toFixed(digits)}%`;
+
+export const parseISO = (value: string) => new Date(`${value}T00:00:00`);
+
+export const withinRange = (value: string, from?: string, to?: string) => {
+  const date = parseISO(value).getTime();
+  if (from) {
+    const fromDate = parseISO(from).getTime();
+    if (date < fromDate) return false;
+  }
+  if (to) {
+    const toDate = parseISO(to).getTime();
+    if (date > toDate) return false;
+  }
+  return true;
+};
+
+export const formatDate = (value?: string | null) => {
+  if (!value) return "";
+  const parsed = parseISO(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return dateFormatter.format(parsed);
+};
+
+export const formatTipoLicencia = (value?: string | null) => {
+  if (!value) return "Sin tipo";
+  const option = tipoLicenciaOptions.find((opt) => opt.value === value);
+  if (option) return option.label;
+  const normalized = value.replace(/_/g, " ").toLowerCase();
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+};
+
+export const toDateOrNull = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = parseISO(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+};
+
+export const startOfDay = (date: Date) => {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+};


### PR DESCRIPTION
## Summary
- extract dedicated Boletines, Aprobación, Asistencias, Licencias y Actas report sections into client components under `_components`
- add shared report types, constants and utilities for grade formatting, attendance calculations and license metadata
- update `reportes/page.tsx` to compose the new components and centralize PDF export helpers for the actas report

## Testing
- `npm run lint` *(fails: next binary missing because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5baaf5a208327961a14f90ea8d738