### PR TITLE
Improve tab responsiveness for mobile

### DIFF
--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -320,7 +320,7 @@ export default function SeccionHistorialPage() {
             onValueChange={setSelectedTrimestreId}
             className="space-y-4"
           >
-            <TabsList className="flex flex-wrap gap-2">
+            <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap">
               {trimestresDelPeriodo.map((tri, index) => {
                 const label =
                   tri.orden != null

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -617,7 +617,7 @@ export default function CierrePrimarioView({
                     onValueChange={(value) => setTriId(String(value))}
                     className="w-full"
                   >
-                    <TabsList className="flex flex-wrap gap-2">
+                    <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap">
                       {triOpts.map((o) => (
                         <TabsTrigger key={o.id} value={String(o.id)}>
                           {o.label}

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -579,7 +579,7 @@ export default function SeccionEvaluacionesPage() {
                   onValueChange={(value) => setSelectedTrimestreId(value)}
                   className="space-y-4"
                 >
-                  <TabsList className="flex flex-wrap gap-2">
+                  <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap">
                     {trimestresDelPeriodo.map((tri, index) => {
                       const label =
                         tri.orden != null

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -1714,7 +1714,7 @@ const handleExportCurrent = async () => {
         </div>
 
         <Tabs value={tab} onValueChange={setTab} className="space-y-5">
-          <TabsList className="w-full h-auto flex-wrap gap-2">
+          <TabsList className="w-full h-auto flex gap-2 overflow-x-auto md:flex-wrap">
             <TabsTrigger value="boletines" className="flex flex-1 min-w-[8rem]">
               Boletines
             </TabsTrigger>


### PR DESCRIPTION
## Summary
- ensure Radix tabs remain horizontally scrollable on mobile while allowing wrapping on larger breakpoints in attendance, grades, evaluations, and report dashboards

## Testing
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c071bb348327ae908bf2e801b5b0