### PR TITLE
feat: adopt radix date picker across dashboard

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -18,6 +18,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
@@ -678,22 +679,24 @@ function DireccionConfig({
               <div className="grid gap-3 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label>Desde</Label>
-                  <Input
-                    type="date"
-                    value={draft.inicio}
-                    onChange={(e) =>
-                      handleDraftChange(tri.id, "inicio", e.target.value)
+                  <DatePicker
+                    value={draft.inicio || undefined}
+                    max={draft.fin || undefined}
+                    onChange={(value) =>
+                      handleDraftChange(tri.id, "inicio", value ?? "")
                     }
+                    required
                   />
                 </div>
                 <div className="space-y-1">
                   <Label>Hasta</Label>
-                  <Input
-                    type="date"
-                    value={draft.fin}
-                    onChange={(e) =>
-                      handleDraftChange(tri.id, "fin", e.target.value)
+                  <DatePicker
+                    value={draft.fin || undefined}
+                    min={draft.inicio || undefined}
+                    onChange={(value) =>
+                      handleDraftChange(tri.id, "fin", value ?? "")
                     }
+                    required
                   />
                 </div>
               </div>

--- a/frontend-ecep/src/app/dashboard/actas/_components/EditActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/EditActaDialog.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@/types/api-generated";
 import { RolEmpleado } from "@/types/api-generated";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -288,10 +289,10 @@ export default function EditActaDialog({
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="text-sm mb-1 block">Fecha del suceso</label>
-                <Input
-                  type="date"
-                  value={fecha}
-                  onChange={(e) => setFecha(e.target.value)}
+                <DatePicker
+                  value={fecha || undefined}
+                  onChange={(value) => setFecha(value ?? "")}
+                  required
                 />
               </div>
               <div>

--- a/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/NewActaDialog.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/types/api-generated";
 import { RolEmpleado } from "@/types/api-generated";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -438,12 +439,12 @@ export default function NewActaDialog({
                 <label className="text-sm font-medium text-foreground">
                   Fecha del suceso *
                 </label>
-                <Input
-                  type="date"
+                <DatePicker
                   min={min2DaysISO()}
                   max={todayISO()}
-                  value={fecha}
-                  onChange={(e) => setFecha(e.target.value)}
+                  value={fecha || undefined}
+                  onChange={(value) => setFecha(value ?? "")}
+                  required
                 />
               </div>
               <div className="space-y-2">

--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -11,6 +11,7 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -797,24 +798,24 @@ export default function AccidentesIndexPage() {
           </Select>
 
           <div className="flex items-center gap-2">
-            <Input
-              type="date"
-              value={fromDate}
-              onChange={(e) => {
-                const value = e.target.value;
-                setFromDate(value);
+            <DatePicker
+              value={fromDate || undefined}
+              max={toDate || undefined}
+              onChange={(value) => {
+                const next = value ?? "";
+                setFromDate(next);
                 if (value && toDate && value > toDate) {
                   setToDate(value);
                 }
               }}
             />
             <span className="text-xs text-muted-foreground">a</span>
-            <Input
-              type="date"
-              value={toDate}
-              onChange={(e) => {
-                const value = e.target.value;
-                setToDate(value);
+            <DatePicker
+              value={toDate || undefined}
+              min={fromDate || undefined}
+              onChange={(value) => {
+                const next = value ?? "";
+                setToDate(next);
                 if (value && fromDate && value < fromDate) {
                   setFromDate(value);
                 }

--- a/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Search, Calendar, Plus, Eye, Pencil, Trash2 } from "lucide-react";
 import {
@@ -656,10 +657,9 @@ export default function AccidentesSeccionPage() {
               <label className="text-xs block mb-1">
                 Fecha (roster activo)
               </label>
-              <Input
-                type="date"
-                value={fecha}
-                onChange={(e) => setFecha(e.target.value)}
+              <DatePicker
+                value={fecha || undefined}
+                onChange={(value) => setFecha(value ?? "")}
               />
             </div>
             <div className="relative w-[220px]">

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -1016,16 +1017,16 @@ export default function AlumnoPerfilPage() {
                       </div>
                       <div className="space-y-2">
                         <Label>Fecha de nacimiento</Label>
-                        <Input
-                          type="date"
+                        <DatePicker
                           max={maxBirthDate}
-                          value={personaDraft.fechaNacimiento}
-                          onChange={(e) =>
+                          value={personaDraft.fechaNacimiento || undefined}
+                          onChange={(value) =>
                             setPersonaDraft((prev) => ({
                               ...prev,
-                              fechaNacimiento: e.target.value,
+                              fechaNacimiento: value ?? "",
                             }))
                           }
+                          required
                         />
                       </div>
                       <div className="space-y-2">
@@ -1124,15 +1125,15 @@ export default function AlumnoPerfilPage() {
                     <div className="grid gap-3 md:grid-cols-2">
                       <div className="space-y-2">
                         <Label>Fecha de inscripción</Label>
-                        <Input
-                          type="date"
-                          value={alumnoDraft.fechaInscripcion}
-                          onChange={(e) =>
+                        <DatePicker
+                          value={alumnoDraft.fechaInscripcion || undefined}
+                          onChange={(value) =>
                             setAlumnoDraft((prev) => ({
                               ...prev,
-                              fechaInscripcion: e.target.value,
+                              fechaInscripcion: value ?? "",
                             }))
                           }
+                          required
                         />
                       </div>
                       <div className="space-y-2">

--- a/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -1013,12 +1014,11 @@ function ScheduleModal({
                 <label className="text-xs font-medium text-muted-foreground">
                   Fecha {idx + 1}
                 </label>
-                <Input
-                  type="date"
-                  value={value}
-                  onChange={(e) => {
+                <DatePicker
+                  value={value || undefined}
+                  onChange={(nextValue) => {
                     const next = [...fechas];
-                    next[idx] = e.target.value;
+                    next[idx] = nextValue ?? "";
                     setFechas(next);
                   }}
                 />

--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -18,6 +18,7 @@ import {
   CardContent,
   CardDescription,
 } from "@/components/ui/card";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -354,15 +355,15 @@ export default function AltaAlumnoPage() {
                 <label className="text-sm font-medium text-muted-foreground">
                   Fecha de inscripción
                 </label>
-                <Input
-                  type="date"
-                  value={alumnoForm.fechaInscripcion}
-                  onChange={(e) =>
+                <DatePicker
+                  value={alumnoForm.fechaInscripcion || undefined}
+                  onChange={(value) =>
                     setAlumnoForm((prev) => ({
                       ...prev,
-                      fechaInscripcion: e.target.value,
+                      fechaInscripcion: value ?? "",
                     }))
                   }
+                  required
                 />
               </div>
               <div className="space-y-2">
@@ -497,11 +498,11 @@ function PersonaFormFields({ values, onChange }: PersonaFormFieldsProps) {
             <label className="text-sm font-medium text-muted-foreground">
               Fecha de nacimiento
             </label>
-            <Input
-              type="date"
+            <DatePicker
               max={maxBirthDate}
-              value={values.fechaNacimiento}
-              onChange={(e) => onChange("fechaNacimiento", e.target.value)}
+              value={values.fechaNacimiento || undefined}
+              onChange={(value) => onChange("fechaNacimiento", value ?? "")}
+              required
             />
           </div>
           <div className="space-y-1">

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/NuevaAsistenciaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/NuevaAsistenciaDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -207,20 +207,21 @@ export default function NuevaAsistenciaDialog({
         <div className="grid grid-cols-2 gap-4">
           <div>
             <Label>Fecha</Label>
-            <Input
-              type="date"
-              value={fecha}
+            <DatePicker
+              value={fecha || undefined}
               min={getTrimestreInicio(trimestre) || undefined}
               max={getTrimestreFin(trimestre) || undefined}
-              onChange={(e) => {
-                const value = e.target.value;
-                setFecha(value);
+              onChange={(value) => {
+                const next = value ?? "";
+                setFecha(next);
                 if (!value) {
                   setDateError("Seleccioná una fecha");
                   return;
                 }
                 setDateError(computeDateError(value));
               }}
+              error={Boolean(dateError)}
+              required
             />
             {!dentro && (
               <p className="text-xs text-red-600 mt-1">Fuera del trimestre</p>

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaDireccion.tsx
@@ -9,6 +9,7 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
@@ -403,21 +404,21 @@ export default function VistaDireccion() {
           <div className="grid grid-cols-2 gap-4">
             <div>
               <Label>Inicio</Label>
-              <Input
-                type="date"
-                value={nuevoTrimestre.inicio ?? ""}
-                onChange={(e) =>
-                  setNuevoTrimestre((s) => ({ ...s, inicio: e.target.value }))
+              <DatePicker
+                value={nuevoTrimestre.inicio ?? undefined}
+                max={nuevoTrimestre.fin ?? undefined}
+                onChange={(value) =>
+                  setNuevoTrimestre((s) => ({ ...s, inicio: value ?? "" }))
                 }
               />
             </div>
             <div>
               <Label>Fin</Label>
-              <Input
-                type="date"
-                value={nuevoTrimestre.fin ?? ""}
-                onChange={(e) =>
-                  setNuevoTrimestre((s) => ({ ...s, fin: e.target.value }))
+              <DatePicker
+                value={nuevoTrimestre.fin ?? undefined}
+                min={nuevoTrimestre.inicio ?? undefined}
+                onChange={(value) =>
+                  setNuevoTrimestre((s) => ({ ...s, fin: value ?? "" }))
                 }
               />
             </div>
@@ -439,10 +440,9 @@ export default function VistaDireccion() {
           </DialogHeader>
           <div>
             <Label>Fecha</Label>
-            <Input
-              type="date"
-              value={noHabilFecha}
-              onChange={(e) => setNoHabilFecha(e.target.value)}
+            <DatePicker
+              value={noHabilFecha || undefined}
+              onChange={(value) => setNoHabilFecha(value ?? "")}
             />
           </div>
           <DialogFooter>

--- a/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { School, Clock3 } from "lucide-react";
@@ -582,10 +583,10 @@ export default function ExamenDetailPage() {
               </div>
               <div>
                 <label className="text-xs text-muted-foreground">Fecha</label>
-                <Input
-                  type="date"
-                  value={editFecha}
-                  onChange={(e) => setEditFecha(e.target.value)}
+                <DatePicker
+                  value={editFecha || undefined}
+                  onChange={(value) => setEditFecha(value ?? "")}
+                  required
                 />
               </div>
             </div>

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -57,6 +57,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Calendar, Edit, Plus, School, Clock3 } from "lucide-react";
@@ -486,13 +487,11 @@ export default function SeccionEvaluacionesPage() {
 
                   <div>
                     <label className="text-sm mb-1 block">Fecha</label>
-                    <Input
-                      type="date"
-                      value={fecha}
+                    <DatePicker
+                      value={fecha || undefined}
                       min={minDate}
                       max={maxDate}
-                      onChange={(e) => {
-                        const next = e.target.value;
+                      onChange={(next) => {
                         if (!next) {
                           setFecha(minDate);
                           return;
@@ -512,6 +511,7 @@ export default function SeccionEvaluacionesPage() {
                         }
                         setFecha(next);
                       }}
+                      required
                     />
                   </div>
 

--- a/frontend-ecep/src/app/dashboard/materias/_components/AsignarDocenteMateriaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/AsignarDocenteMateriaDialog.tsx
@@ -16,7 +16,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
+import { DatePicker } from "@/components/ui/date-picker";
 import { gestionAcademica } from "@/services/api/modules";
 import type { SeccionMateriaDTO, MateriaDTO } from "@/types/api-generated";
 import { toast } from "sonner";
@@ -168,18 +168,18 @@ export default function AsignarDocenteMateriaDialog({
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="text-sm mb-1 block">Desde</label>
-                <Input
-                  type="date"
-                  value={desde}
-                  onChange={(e) => setDesde(e.target.value)}
+                <DatePicker
+                  value={desde || undefined}
+                  max={hasta || undefined}
+                  onChange={(value) => setDesde(value ?? "")}
                 />
               </div>
               <div>
                 <label className="text-sm mb-1 block">Hasta</label>
-                <Input
-                  type="date"
-                  value={hasta}
-                  onChange={(e) => setHasta(e.target.value)}
+                <DatePicker
+                  value={hasta || undefined}
+                  min={desde || undefined}
+                  onChange={(value) => setHasta(value ?? "")}
                 />
               </div>
             </div>

--- a/frontend-ecep/src/app/dashboard/materias/_components/AsignarDocenteSeccionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/AsignarDocenteSeccionDialog.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
+import { DatePicker } from "@/components/ui/date-picker";
 import { gestionAcademica } from "@/services/api/modules";
 import type { RolSeccion } from "@/types/api-generated";
 import { toast } from "sonner";
@@ -188,18 +188,18 @@ export default function AsignarDocenteSeccionDialog({
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="text-sm mb-1 block">Desde</label>
-                <Input
-                  type="date"
-                  value={desde}
-                  onChange={(event) => setDesde(event.target.value)}
+                <DatePicker
+                  value={desde || undefined}
+                  max={hasta || undefined}
+                  onChange={(value) => setDesde(value ?? "")}
                 />
               </div>
               <div>
                 <label className="text-sm mb-1 block">Hasta</label>
-                <Input
-                  type="date"
-                  value={hasta}
-                  onChange={(event) => setHasta(event.target.value)}
+                <DatePicker
+                  value={hasta || undefined}
+                  min={desde || undefined}
+                  onChange={(value) => setHasta(value ?? "")}
                 />
               </div>
             </div>

--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -36,6 +36,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -1891,14 +1892,13 @@ export default function PagosPage() {
                     <Label htmlFor="fechaVencimiento">
                       Fecha de vencimiento
                     </Label>
-                    <Input
+                    <DatePicker
                       id="fechaVencimiento"
-                      type="date"
-                      value={createForm.fechaVencimiento}
-                      onChange={(event) =>
+                      value={createForm.fechaVencimiento || undefined}
+                      onChange={(value) =>
                         setCreateForm((prev) => ({
                           ...prev,
-                          fechaVencimiento: event.target.value,
+                          fechaVencimiento: value ?? "",
                         }))
                       }
                     />
@@ -2163,14 +2163,13 @@ export default function PagosPage() {
 
                     <div className="grid gap-2">
                       <Label htmlFor="fechaPago">Fecha de pago</Label>
-                      <Input
+                      <DatePicker
                         id="fechaPago"
-                        type="date"
-                        value={pagoForm.fecha}
-                        onChange={(event) =>
+                        value={pagoForm.fecha || undefined}
+                        onChange={(value) =>
                           setPagoForm((prev) => ({
                             ...prev,
-                            fecha: event.target.value,
+                            fecha: value ?? "",
                           }))
                         }
                       />

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -46,6 +46,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -5135,15 +5136,14 @@ export default function PersonalPage() {
                     <Label htmlFor="editar-fecha-nac">
                       Fecha de nacimiento
                     </Label>
-                    <Input
+                    <DatePicker
                       id="editar-fecha-nac"
-                      type="date"
                       max={maxBirthDate}
-                      value={editPersona.fechaNacimiento}
-                      onChange={(event) =>
+                      value={editPersona.fechaNacimiento || undefined}
+                      onChange={(value) =>
                         setEditPersona((prev) => ({
                           ...prev,
-                          fechaNacimiento: event.target.value,
+                          fechaNacimiento: value ?? "",
                         }))
                       }
                       required
@@ -5448,14 +5448,13 @@ export default function PersonalPage() {
                     <Label htmlFor="editar-fecha-ingreso">
                       Fecha de ingreso
                     </Label>
-                    <Input
+                    <DatePicker
                       id="editar-fecha-ingreso"
-                      type="date"
-                      value={editEmpleado.fechaIngreso}
-                      onChange={(event) =>
+                      value={editEmpleado.fechaIngreso || undefined}
+                      onChange={(value) =>
                         setEditEmpleado((prev) => ({
                           ...prev,
-                          fechaIngreso: event.target.value,
+                          fechaIngreso: value ?? "",
                         }))
                       }
                       required
@@ -5579,18 +5578,18 @@ export default function PersonalPage() {
                           </div>
                           <div className="space-y-2">
                             <Label htmlFor={inicioId}>Fecha de inicio</Label>
-                            <Input
+                            <DatePicker
                               id={inicioId}
-                              type="date"
-                              value={formacion.fechaInicio}
-                              onChange={(event) => {
-                                const value = event.target.value;
+                              value={formacion.fechaInicio || undefined}
+                              max={formacion.fechaFin || undefined}
+                              onChange={(value) => {
+                                const nextValue = value ?? "";
                                 updateEditFormacionEntry(index, {
-                                  fechaInicio: value,
+                                  fechaInicio: nextValue,
                                   fechaFin:
                                     formacion.fechaFin &&
-                                    formacion.fechaFin < value
-                                      ? value
+                                    formacion.fechaFin < nextValue
+                                      ? nextValue
                                       : formacion.fechaFin,
                                 });
                               }}
@@ -5598,12 +5597,11 @@ export default function PersonalPage() {
                           </div>
                           <div className="space-y-2">
                             <Label htmlFor={finId}>Fecha de finalización</Label>
-                            <Input
+                            <DatePicker
                               id={finId}
-                              type="date"
-                              value={formacion.fechaFin}
-                              onChange={(event) => {
-                                const value = event.target.value;
+                              value={formacion.fechaFin || undefined}
+                              min={formacion.fechaInicio || undefined}
+                              onChange={(value) => {
                                 if (
                                   value &&
                                   formacion.fechaInicio &&
@@ -5615,7 +5613,7 @@ export default function PersonalPage() {
                                   return;
                                 }
                                 updateEditFormacionEntry(index, {
-                                  fechaFin: value,
+                                  fechaFin: value ?? "",
                                 });
                               }}
                             />
@@ -5855,15 +5853,14 @@ export default function PersonalPage() {
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="nuevo-fecha-nac">Fecha de nacimiento</Label>
-                    <Input
+                    <DatePicker
                       id="nuevo-fecha-nac"
-                      type="date"
                       max={maxBirthDate}
-                      value={newPersona.fechaNacimiento}
-                      onChange={(event) =>
+                      value={newPersona.fechaNacimiento || undefined}
+                      onChange={(value) =>
                         setNewPersona((prev) => ({
                           ...prev,
-                          fechaNacimiento: event.target.value,
+                          fechaNacimiento: value ?? "",
                         }))
                       }
                       required
@@ -6165,14 +6162,13 @@ export default function PersonalPage() {
                     <Label htmlFor="nuevo-fecha-ingreso">
                       Fecha de ingreso
                     </Label>
-                    <Input
+                    <DatePicker
                       id="nuevo-fecha-ingreso"
-                      type="date"
-                      value={newEmpleado.fechaIngreso}
-                      onChange={(event) =>
+                      value={newEmpleado.fechaIngreso || undefined}
+                      onChange={(value) =>
                         setNewEmpleado((prev) => ({
                           ...prev,
-                          fechaIngreso: event.target.value,
+                          fechaIngreso: value ?? "",
                         }))
                       }
                       required
@@ -6335,18 +6331,18 @@ export default function PersonalPage() {
                           </div>
                           <div className="space-y-2">
                             <Label htmlFor={inicioId}>Fecha de inicio</Label>
-                            <Input
+                            <DatePicker
                               id={inicioId}
-                              type="date"
-                              value={formacion.fechaInicio}
-                              onChange={(event) => {
-                                const value = event.target.value;
+                              value={formacion.fechaInicio || undefined}
+                              max={formacion.fechaFin || undefined}
+                              onChange={(value) => {
+                                const nextValue = value ?? "";
                                 updateNewFormacionEntry(index, {
-                                  fechaInicio: value,
+                                  fechaInicio: nextValue,
                                   fechaFin:
                                     formacion.fechaFin &&
-                                    formacion.fechaFin < value
-                                      ? value
+                                    formacion.fechaFin < nextValue
+                                      ? nextValue
                                       : formacion.fechaFin,
                                 });
                               }}
@@ -6354,12 +6350,11 @@ export default function PersonalPage() {
                           </div>
                           <div className="space-y-2">
                             <Label htmlFor={finId}>Fecha de finalización</Label>
-                            <Input
+                            <DatePicker
                               id={finId}
-                              type="date"
-                              value={formacion.fechaFin}
-                              onChange={(event) => {
-                                const value = event.target.value;
+                              value={formacion.fechaFin || undefined}
+                              min={formacion.fechaInicio || undefined}
+                              onChange={(value) => {
                                 if (
                                   value &&
                                   formacion.fechaInicio &&
@@ -6371,7 +6366,7 @@ export default function PersonalPage() {
                                   return;
                                 }
                                 updateNewFormacionEntry(index, {
-                                  fechaFin: value,
+                                  fechaFin: value ?? "",
                                 });
                               }}
                             />
@@ -6534,15 +6529,14 @@ export default function PersonalPage() {
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="licencia-inicio">Fecha de inicio</Label>
-                  <Input
+                  <DatePicker
                     id="licencia-inicio"
-                    type="date"
-                    value={newLicense.fechaInicio}
-                    onChange={(event) => {
-                      const value = event.target.value;
+                    value={newLicense.fechaInicio || undefined}
+                    max={newLicense.fechaFin || undefined}
+                    onChange={(value) => {
                       setNewLicense((prev) => {
                         if (!value) {
-                          return { ...prev, fechaInicio: value };
+                          return { ...prev, fechaInicio: "" };
                         }
                         const next = { ...prev, fechaInicio: value };
                         if (prev.fechaFin && prev.fechaFin < value) {
@@ -6556,15 +6550,14 @@ export default function PersonalPage() {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="licencia-fin">Fecha de finalización</Label>
-                  <Input
+                  <DatePicker
                     id="licencia-fin"
-                    type="date"
-                    value={newLicense.fechaFin}
-                    onChange={(event) => {
-                      const value = event.target.value;
+                    value={newLicense.fechaFin || undefined}
+                    min={newLicense.fechaInicio || undefined}
+                    onChange={(value) => {
                       setNewLicense((prev) => {
                         if (!value) {
-                          return { ...prev, fechaFin: value };
+                          return { ...prev, fechaFin: "" };
                         }
                         if (prev.fechaInicio && value < prev.fechaInicio) {
                           return { ...prev, fechaFin: prev.fechaInicio };

--- a/frontend-ecep/src/app/dashboard/reportes/_components/ActasReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/ActasReport.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -94,12 +95,12 @@ export function ActasReport({
                 <CardContent className="space-y-4 text-sm">
                   <div className="space-y-2">
                     <Label>Desde</Label>
-                    <Input
-                      type="date"
-                      value={actaFrom}
-                      onChange={(event) => {
-                        const value = event.target.value;
-                        setActaFrom(value);
+                    <DatePicker
+                      value={actaFrom || undefined}
+                      max={actaTo || undefined}
+                      onChange={(value) => {
+                        const next = value ?? "";
+                        setActaFrom(next);
                         if (value && actaTo && value > actaTo) {
                           setActaTo(value);
                         }
@@ -108,12 +109,12 @@ export function ActasReport({
                   </div>
                   <div className="space-y-2">
                     <Label>Hasta</Label>
-                    <Input
-                      type="date"
-                      value={actaTo}
-                      onChange={(event) => {
-                        const value = event.target.value;
-                        setActaTo(value);
+                    <DatePicker
+                      value={actaTo || undefined}
+                      min={actaFrom || undefined}
+                      onChange={(value) => {
+                        const next = value ?? "";
+                        setActaTo(next);
                         if (value && actaFrom && value < actaFrom) {
                           setActaFrom(value);
                         }

--- a/frontend-ecep/src/app/dashboard/reportes/_components/AttendanceReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/AttendanceReport.tsx
@@ -11,7 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -309,7 +309,10 @@ function DateField({
   return (
     <div>
       <Label className="mb-1 block">{label}</Label>
-      <Input type="date" value={value} onChange={(event) => onChange(event.target.value)} />
+      <DatePicker
+        value={value || undefined}
+        onChange={(next) => onChange(next ?? "")}
+      />
     </div>
   );
 }

--- a/frontend-ecep/src/app/dashboard/reportes/_components/LicensesReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/LicensesReport.tsx
@@ -10,6 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -253,12 +254,12 @@ export function LicensesReport({
             </div>
             <div className="space-y-1">
               <Label>Desde</Label>
-              <Input
-                type="date"
-                value={licenseFrom}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  setLicenseFrom(value);
+              <DatePicker
+                value={licenseFrom || undefined}
+                max={licenseTo || undefined}
+                onChange={(value) => {
+                  const next = value ?? "";
+                  setLicenseFrom(next);
                   if (licenseTo && value && value > licenseTo) {
                     setLicenseTo(value);
                   }
@@ -267,12 +268,12 @@ export function LicensesReport({
             </div>
             <div className="space-y-1">
               <Label>Hasta</Label>
-              <Input
-                type="date"
-                value={licenseTo}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  setLicenseTo(value);
+              <DatePicker
+                value={licenseTo || undefined}
+                min={licenseFrom || undefined}
+                onChange={(value) => {
+                  const next = value ?? "";
+                  setLicenseTo(next);
                   if (licenseFrom && value && value < licenseFrom) {
                     setLicenseFrom(value);
                   }

--- a/frontend-ecep/src/app/postulacion/Step1.tsx
+++ b/frontend-ecep/src/app/postulacion/Step1.tsx
@@ -2,6 +2,7 @@
 "use client";
 import React from "react";
 import { User } from "lucide-react";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -102,16 +103,15 @@ export function Step1({
         {/* Fecha de Nacimiento */}
         <div>
           <Label htmlFor="fechaNacimiento">Fecha de Nacimiento</Label>
-          <Input
+          <DatePicker
             id="fechaNacimiento"
-            type="date"
             max={maxBirthDate}
-            value={formData.fechaNacimiento || ""}
-            onChange={(e) =>
-              handleInputChange("fechaNacimiento", e.target.value)
+            value={formData.fechaNacimiento || undefined}
+            onChange={(value) =>
+              handleInputChange("fechaNacimiento", value ?? "")
             }
-            aria-invalid={errors.fechaNacimiento || undefined}
-            className={cn(errors.fechaNacimiento && "border-destructive")}
+            error={Boolean(errors.fechaNacimiento)}
+            required
           />
         </div>
 

--- a/frontend-ecep/src/app/postulacion/Step2.tsx
+++ b/frontend-ecep/src/app/postulacion/Step2.tsx
@@ -4,6 +4,7 @@
 import React from "react";
 import { Users, Plus } from "lucide-react";
 import { Label } from "@/components/ui/label";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
@@ -222,12 +223,11 @@ export function Step2({
                   <Label htmlFor={`familiar-fecha-${i}`}>
                     Fecha de Nacimiento
                   </Label>
-                  <Input
+                  <DatePicker
                     id={`familiar-fecha-${i}`}
-                    type="date"
                     max={maxBirthDate}
-                    value={f.familiar?.fechaNacimiento ?? ""}
-                    onChange={(e) =>
+                    value={f.familiar?.fechaNacimiento ?? undefined}
+                    onChange={(value) =>
                       handleInputChange(
                         "familiares",
                         familiares.map((x, j) =>
@@ -236,7 +236,7 @@ export function Step2({
                                 ...x,
                                 familiar: {
                                   ...x.familiar!,
-                                  fechaNacimiento: e.target.value,
+                                  fechaNacimiento: value ?? "",
                                 },
                               }
                             : x,
@@ -244,10 +244,8 @@ export function Step2({
                         { errorKeys: [`familiares.${i}.familiar.fechaNacimiento`] },
                       )
                     }
-                    aria-invalid={fechaNacimientoError || undefined}
-                    className={cn(
-                      fechaNacimientoError && "border-destructive",
-                    )}
+                    error={Boolean(fechaNacimientoError)}
+                    required
                   />
                 </div>
 

--- a/frontend-ecep/src/components/ui/date-picker.tsx
+++ b/frontend-ecep/src/components/ui/date-picker.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import * as React from "react";
+import { format, parseISO } from "date-fns";
+import { Calendar as CalendarIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+export interface DatePickerProps {
+  value?: string | null;
+  onChange?: (value: string | undefined) => void;
+  min?: string;
+  max?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  name?: string;
+  id?: string;
+  required?: boolean;
+  error?: boolean;
+  align?: "start" | "center" | "end";
+}
+
+const formatDisplay = (value: string) => {
+  try {
+    const date = parseISO(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return format(date, "dd/MM/yyyy");
+  } catch (error) {
+    return value;
+  }
+};
+
+const getDate = (value?: string | null) => {
+  if (!value) return undefined;
+  try {
+    const date = parseISO(value);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
+  (
+    {
+      value,
+      onChange,
+      min,
+      max,
+      placeholder = "Seleccioná una fecha",
+      disabled,
+      className,
+      name,
+      id,
+      required,
+      error,
+      align = "start",
+    },
+    ref,
+  ) => {
+    const [open, setOpen] = React.useState(false);
+
+    const selectedDate = React.useMemo(() => getDate(value), [value]);
+    const minDate = React.useMemo(() => getDate(min), [min]);
+    const maxDate = React.useMemo(() => getDate(max), [max]);
+
+    const handleSelect = React.useCallback(
+      (date?: Date) => {
+        if (disabled) {
+          return;
+        }
+
+        if (!date) {
+          onChange?.(undefined);
+          return;
+        }
+
+        if ((minDate && date < minDate) || (maxDate && date > maxDate)) {
+          return;
+        }
+
+        onChange?.(format(date, "yyyy-MM-dd"));
+        setOpen(false);
+      },
+      [disabled, maxDate, minDate, onChange],
+    );
+
+    return (
+      <div className={cn("w-full", className)}>
+        {name ? <input type="hidden" name={name} value={value ?? ""} /> : null}
+        <Popover open={open} onOpenChange={(next) => !disabled && setOpen(next)}>
+          <PopoverTrigger asChild>
+            <Button
+              ref={ref}
+              id={id}
+              type="button"
+              variant="outline"
+              disabled={disabled}
+              aria-required={required}
+              aria-invalid={error || undefined}
+              className={cn(
+                "w-full justify-start text-left font-normal",
+                !value && "text-muted-foreground",
+                error && "border-destructive focus-visible:ring-destructive",
+              )}
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {value ? formatDisplay(value) : placeholder}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align={align} sideOffset={4}>
+            <Calendar
+              mode="single"
+              selected={selectedDate}
+              defaultMonth={selectedDate ?? minDate ?? undefined}
+              onSelect={handleSelect}
+              disabled={(date) => {
+                if (disabled) return true;
+                if (minDate && date < minDate) return true;
+                if (maxDate && date > maxDate) return true;
+                return false;
+              }}
+              fromDate={minDate}
+              toDate={maxDate}
+              initialFocus
+            />
+            {!required && value ? (
+              <div className="flex justify-end p-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    onChange?.(undefined);
+                  }}
+                >
+                  Limpiar
+                </Button>
+              </div>
+            ) : null}
+          </PopoverContent>
+        </Popover>
+      </div>
+    );
+  },
+);
+
+DatePicker.displayName = "DatePicker";


### PR DESCRIPTION
## Summary
- add a reusable DatePicker component that wraps the Radix calendar styles used in the app
- replace the native date inputs across enrollment, attendance, reporting, payments and personnel flows to use the new picker

## Testing
- pnpm lint *(fails: npm registry returned 403 during pnpm install)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bfdbf0288327b0a086189cefceaa