### PR TITLE
Refactor boletin detail layout for primary students

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -1746,8 +1746,6 @@ const handleExportCurrent = async () => {
             onPrintStudent={handlePrintBoletin}
             exportingStudent={exportingBoletin}
             isActiveStudentPrimario={isActiveBoletinPrimario}
-            boletinTrimesters={boletinTrimesters}
-            boletinSubjectsForTable={boletinSubjectsForTable}
             boletinSubjectsByTrimester={boletinSubjectsByTrimester}
           />
 


### PR DESCRIPTION
## Summary
- replace the boletín detail table/mobile split with trimester cards for primary students
- simplify the BoletinesReport props now that a single layout is used

## Testing
- `bun run lint` *(fails: missing Next.js binary before installing dependencies)*
- `bun install` *(fails: registry.npmjs.org responds with HTTP 403 for multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c0fb337c832792f4e304866609b7