### PR TITLE
Mostrar nombre de período escolar en la interfaz

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -109,7 +109,7 @@ export default function AlumnoPerfilPage() {
 
   const [familiares, setFamiliares] = useState<FamiliarConVinculo[]>([]);
 
-  const { periodoEscolarId: activePeriodId } = useActivePeriod();
+  const { periodoEscolarId: activePeriodId, getPeriodoNombre } = useActivePeriod();
   const { hasRole } = useAuth();
   const { type: viewerScope } = useViewerScope();
   const canManageProfile = viewerScope === "staff";
@@ -1312,7 +1312,12 @@ export default function AlumnoPerfilPage() {
                         <div>
                           <div className="font-medium">Matrícula #{m.id}</div>
                           <div className="text-muted-foreground">
-                            Período: {m.periodoEscolarId ?? "—"}
+                            Período: {getPeriodoNombre(
+                              m.periodoEscolarId,
+                              ((m as any)?.periodoEscolar ?? null) as
+                                | { anio?: number }
+                                | null,
+                            )}
                             {abierta ? (
                               <>
                                 {" "}

--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -26,7 +26,6 @@ import {
 } from "@/components/ui/select";
 import { Search, UserPlus } from "lucide-react";
 import { useScopedIndex } from "@/hooks/scope/useScopedIndex";
-import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import FamilyView from "./_components/FamilyView";
 import AspirantesTab from "./_components/AspirantesTabs";
 import { identidad } from "@/services/api/modules";
@@ -125,12 +124,9 @@ export default function AlumnosIndexPage() {
     error,
     secciones,
     hijos,
-    periodoEscolarId,
+    periodoNombre,
   } = useScopedIndex({ includeTitularSec: true });
   const { hasRole } = useAuth();
-
-  // Mostramos período activo con el hook (evita UTC vs local)
-  const { hoyISO } = useActivePeriod();
 
   useEffect(() => {
     const handler = setTimeout(() => setDebouncedSearch(searchTerm), 350);
@@ -295,15 +291,21 @@ export default function AlumnosIndexPage() {
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">Alumnos</h2>
-            <div className="text-muted-foreground">
-              {scope === "staff"
-                ? `Período escolar activo: #${periodoEscolarId ?? "—"} • Hoy: ${hoyISO}`
-                : scope === "teacher"
+            {scope === "staff" ? (
+              <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <Badge variant="outline">
+                  Período {periodoNombre ?? "—"}
+                </Badge>
+              </div>
+            ) : (
+              <div className="text-muted-foreground">
+                {scope === "teacher"
                   ? "Gestión de alumnos por sección"
                   : scope === "student"
                     ? "Consulta de mi información académica"
                     : "Vista de hijos y perfiles"}
-            </div>
+              </div>
+            )}
           </div>
           {scope === "staff" && (
             <div className="flex items-center space-x-2">

--- a/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
@@ -22,6 +22,10 @@ import type {
   TrimestreDTO,
 } from "@/types/api-generated";
 import { NivelAcademico as NivelAcademicoEnum } from "@/types/api-generated";
+import {
+  formatPeriodoLabel,
+  type PeriodoLabelResolver,
+} from "@/lib/periodos";
 import { getTrimestreEstado, resolveTrimestrePeriodoId } from "@/lib/trimestres";
 import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 
@@ -30,6 +34,7 @@ interface FamilyCalificacionesViewProps {
   initialLoading?: boolean;
   initialError?: string | null;
   periodoEscolarId?: number | null;
+  getPeriodoNombre?: PeriodoLabelResolver;
 }
 
 interface MateriaResumen {
@@ -81,6 +86,7 @@ export default function FamilyCalificacionesView({
   initialLoading,
   initialError,
   periodoEscolarId,
+  getPeriodoNombre,
 }: FamilyCalificacionesViewProps) {
   const [selectedMatriculaId, setSelectedMatriculaId] = useState<number | null>(
     null,
@@ -100,6 +106,13 @@ export default function FamilyCalificacionesView({
 
   const activePeriodId =
     typeof periodoEscolarId === "number" ? periodoEscolarId : null;
+
+  const resolvePeriodoNombre = (
+    periodoId?: number | null,
+    periodo?: { anio?: number } | null,
+  ) =>
+    getPeriodoNombre?.(periodoId, periodo ?? null) ??
+    formatPeriodoLabel(periodo ?? null, periodoId);
 
   useEffect(() => {
     if (!alumnos.length) {
@@ -431,7 +444,14 @@ export default function FamilyCalificacionesView({
                       {turno && <Badge variant="outline">Turno {turno}</Badge>}
                       {seccion?.periodoEscolarId && (
                         <Badge variant="outline">
-                          Período {seccion.periodoEscolarId}
+                          Período
+                          {" "}
+                          {resolvePeriodoNombre(
+                            seccion.periodoEscolarId,
+                            ((seccion as any)?.periodoEscolar ?? null) as
+                              | { anio?: number }
+                              | null,
+                          )}
                         </Badge>
                       )}
                     </div>
@@ -559,3 +579,4 @@ export default function FamilyCalificacionesView({
     </Tabs>
   );
 }
+

--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -48,6 +48,8 @@ export default function CalificacionesIndexPage() {
     secciones,
     hijos,
     periodoEscolarId,
+    periodoNombre,
+    getPeriodoNombre,
   } = useScopedIndex({ includeTitularSec: true });
 
   const isAdmin = activeRole === UserRole.ADMIN;
@@ -71,6 +73,7 @@ export default function CalificacionesIndexPage() {
             initialLoading={loading}
             initialError={error ? String(error) : null}
             periodoEscolarId={periodoEscolarId}
+            getPeriodoNombre={getPeriodoNombre}
           />
         </div>
       </DashboardLayout>
@@ -130,8 +133,8 @@ export default function CalificacionesIndexPage() {
             <Badge variant="outline">
               Inicial: {loading ? "—" : inicial.length}
             </Badge>
-            {periodoEscolarId && (
-              <Badge variant="outline">Período {periodoEscolarId}</Badge>
+            {periodoNombre && (
+              <Badge variant="outline">Período {periodoNombre}</Badge>
             )}
           </div>
         </div>

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
@@ -10,6 +10,7 @@ import CierrePrimarioView from "./_views/CierrePrimarioView";
 import InformeInicialView from "./_views/InformeInicialView";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
+import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { UserRole } from "@/types/api-generated";
 
 export default function CalificacionesSeccionPage() {
@@ -17,6 +18,7 @@ export default function CalificacionesSeccionPage() {
   const seccionId = Number(id);
   const { type, activeRole } = useViewerScope();
   const { loading: scopedLoading, secciones: accesibles } = useScopedSecciones();
+  const { getPeriodoNombre } = useActivePeriod();
   const isAdmin = activeRole === UserRole.ADMIN;
   const isTeacher = type === "teacher";
   const isStaff = type === "staff";
@@ -115,6 +117,10 @@ export default function CalificacionesSeccionPage() {
   const sectionLabel = seccion
     ? `${seccion.gradoSala ?? ""} ${seccion.division ?? ""}`.trim()
     : `Sección #${seccionId}`;
+  const periodoNombre = getPeriodoNombre(
+    seccion?.periodoEscolarId,
+    ((seccion as any)?.periodoEscolar ?? null) as { anio?: number } | null,
+  );
 
   const formatTurnoLabel = (turno?: string | null) => {
     if (!turno) return null;
@@ -134,7 +140,7 @@ export default function CalificacionesSeccionPage() {
             {turnoLabel && <Badge variant="outline">{turnoLabel}</Badge>}
             {seccion?.periodoEscolarId && (
               <Badge variant="outline">
-                Período {seccion.periodoEscolarId}
+                Período {periodoNombre ?? "—"}
               </Badge>
             )}
           </div>

--- a/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
@@ -12,7 +12,6 @@ import type {
   EvaluacionDTO,
   NivelAcademico,
 } from "@/types/api-generated";
-import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { useScopedIndex } from "@/hooks/scope/useScopedIndex";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
 import { UserRole } from "@/types/api-generated";
@@ -45,7 +44,6 @@ function formatTurnoLabel(turno?: string | null) {
 
 export default function EvaluacionesIndexPage() {
   const router = useRouter();
-  const { periodoEscolarId } = useActivePeriod();
 
   const { activeRole } = useViewerScope();
   const isAdmin = activeRole === UserRole.ADMIN;
@@ -59,6 +57,8 @@ export default function EvaluacionesIndexPage() {
     secciones,
     titularBySeccionId,
     hijos,
+    periodoEscolarId,
+    periodoNombre,
   } = useScopedIndex({ includeTitularSec: true });
 
   const [loading, setLoading] = useState(true);
@@ -222,7 +222,7 @@ export default function EvaluacionesIndexPage() {
             <h2 className="text-3xl font-bold tracking-tight">{title}</h2>
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <Badge variant="outline">Primario</Badge>
-              <Badge variant="outline">Período {periodoEscolarId ?? "—"}</Badge>
+              <Badge variant="outline">Período {periodoNombre ?? "—"}</Badge>
             </div>
             <ActiveTrimestreBadge className="mt-2" />
           </div>

--- a/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
@@ -13,6 +13,10 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { gestionAcademica, identidad } from "@/services/api/modules";
 import { pageContent } from "@/lib/page-response";
+import {
+  formatPeriodoLabel,
+  type PeriodoLabelResolver,
+} from "@/lib/periodos";
 import type {
   AlumnoLiteDTO,
   EmpleadoDTO,
@@ -44,6 +48,7 @@ interface FamilyMateriasViewProps {
   alumnos: AlumnoLiteDTO[];
   initialLoading?: boolean;
   initialError?: string | null;
+  getPeriodoNombre?: PeriodoLabelResolver;
 }
 
 function resolveNivel(alumno: AlumnoLiteDTO | null, detalle: SeccionDetalle | null) {
@@ -94,6 +99,7 @@ export default function FamilyMateriasView({
   alumnos,
   initialLoading,
   initialError,
+  getPeriodoNombre,
 }: FamilyMateriasViewProps) {
   const [selectedMatriculaId, setSelectedMatriculaId] = useState<number | null>(
     null,
@@ -101,6 +107,13 @@ export default function FamilyMateriasView({
   const [loadingDetalle, setLoadingDetalle] = useState(false);
   const [errorDetalle, setErrorDetalle] = useState<string | null>(null);
   const [detalles, setDetalles] = useState<Map<number, SeccionDetalle>>(new Map());
+
+  const resolvePeriodoNombre = (
+    periodoId?: number | null,
+    periodo?: { anio?: number } | null,
+  ) =>
+    getPeriodoNombre?.(periodoId, periodo ?? null) ??
+    formatPeriodoLabel(periodo ?? null, periodoId);
 
   useEffect(() => {
     if (!alumnos.length) {
@@ -349,7 +362,14 @@ export default function FamilyMateriasView({
                       {turno && <Badge variant="outline">Turno {turno}</Badge>}
                       {detalle?.seccion?.periodoEscolarId && (
                         <Badge variant="outline">
-                          Período {detalle.seccion.periodoEscolarId}
+                          Período
+                          {" "}
+                          {resolvePeriodoNombre(
+                            detalle.seccion.periodoEscolarId,
+                            ((detalle.seccion as any)?.periodoEscolar ?? null) as
+                              | { anio?: number }
+                              | null,
+                          )}
                         </Badge>
                       )}
                     </div>
@@ -431,3 +451,4 @@ export default function FamilyMateriasView({
     </Tabs>
   );
 }
+

--- a/frontend-ecep/src/app/dashboard/materias/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/page.tsx
@@ -47,7 +47,8 @@ export default function MateriasPage() {
     error,
     secciones,
     hijos,
-    periodoEscolarId,
+    periodoNombre,
+    getPeriodoNombre,
     titularBySeccionId,
   } = useScopedIndex({ includeTitularSec: true });
 
@@ -75,6 +76,7 @@ export default function MateriasPage() {
             alumnos={hijos}
             initialLoading={loading}
             initialError={error ? String(error) : null}
+            getPeriodoNombre={getPeriodoNombre}
           />
         </div>
       </DashboardLayout>
@@ -121,8 +123,8 @@ export default function MateriasPage() {
             <h2 className="text-3xl font-bold tracking-tight">Materias</h2>
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <Badge variant="outline">Primario</Badge>
-              {periodoEscolarId && (
-                <Badge variant="outline">Período {periodoEscolarId}</Badge>
+              {periodoNombre && (
+                <Badge variant="outline">Período {periodoNombre}</Badge>
               )}
             </div>
           </div>

--- a/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
@@ -30,6 +30,7 @@ import AddMateriaToSeccionDialog from "@/app/dashboard/materias/_components/AddM
 import AsignarDocenteMateriaDialog from "@/app/dashboard/materias/_components/AsignarDocenteMateriaDialog";
 import AsignarDocenteSeccionDialog from "@/app/dashboard/materias/_components/AsignarDocenteSeccionDialog";
 import { useViewerScope } from "@/hooks/scope/useViewerScope";
+import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
 import { UserRole } from "@/types/api-generated";
 
@@ -112,6 +113,7 @@ export default function MateriasSeccionPage() {
   const seccionId = Number(id);
   const router = useRouter();
   const { type, activeRole } = useViewerScope();
+  const { getPeriodoNombre } = useActivePeriod();
   const {
     loading: scopedLoading,
     secciones: accesibles,
@@ -236,6 +238,10 @@ export default function MateriasSeccionPage() {
         ? "Primario"
         : (seccion.nivel as string | undefined) ?? null
     : null;
+  const periodoNombre = getPeriodoNombre(
+    seccion?.periodoEscolarId,
+    ((seccion as any)?.periodoEscolar ?? null) as { anio?: number } | null,
+  );
   const ocupadosSeccion = useMemo(
     () => ({
       titularId: titularSeccion?.empleadoId ?? null,
@@ -441,7 +447,7 @@ export default function MateriasSeccionPage() {
               )}
               {seccion?.periodoEscolarId && (
                 <Badge variant="outline">
-                  Período {seccion.periodoEscolarId}
+                  Período {periodoNombre ?? "—"}
                 </Badge>
               )}
             </div>

--- a/frontend-ecep/src/hooks/scope/useScopedIndex.ts
+++ b/frontend-ecep/src/hooks/scope/useScopedIndex.ts
@@ -20,7 +20,9 @@ export function useScopedIndex(opts?: {
   const {
     loading: loadingPeriodo,
     periodoEscolarId,
+    periodoEscolar,
     hoyISO,
+    getPeriodoNombre,
   } = useActivePeriod();
 
   // Secciones para staff/teacher
@@ -58,6 +60,9 @@ export function useScopedIndex(opts?: {
         secciones: [] as any[], // vacío en family
         titularBySeccionId: new Map<number, string>(),
         periodoEscolarId,
+        periodoEscolar,
+        periodoNombre: getPeriodoNombre(periodoEscolarId, periodoEscolar),
+        getPeriodoNombre,
         hoyISO,
       };
     }
@@ -70,6 +75,9 @@ export function useScopedIndex(opts?: {
       secciones, // array de SeccionDTO
       titularBySeccionId,
       periodoEscolarId,
+      periodoEscolar,
+      periodoNombre: getPeriodoNombre(periodoEscolarId, periodoEscolar),
+      getPeriodoNombre,
       hoyISO,
     };
   }, [
@@ -80,6 +88,8 @@ export function useScopedIndex(opts?: {
     secciones,
     titularBySeccionId,
     periodoEscolarId,
+    periodoEscolar,
+    getPeriodoNombre,
     hoyISO,
   ]);
 }

--- a/frontend-ecep/src/lib/periodos.ts
+++ b/frontend-ecep/src/lib/periodos.ts
@@ -1,0 +1,19 @@
+import type { PeriodoEscolarDTO } from "@/types/api-generated";
+
+export type PeriodoLabelResolver = (
+  periodoId?: number | null,
+  periodo?: Pick<PeriodoEscolarDTO, "anio"> | null,
+) => string;
+
+export function formatPeriodoLabel(
+  periodo?: Pick<PeriodoEscolarDTO, "anio"> | null | undefined,
+  fallbackId?: number | null,
+): string {
+  if (periodo?.anio != null) {
+    return String(periodo.anio);
+  }
+  if (fallbackId != null) {
+    return String(fallbackId);
+  }
+  return "—";
+}


### PR DESCRIPTION
## Summary
- agregar utilidades para formatear nombres de períodos y exponerlas desde `useActivePeriod`
- actualizar los hooks y vistas principales para mostrar badges con el nombre del período escolar activo
- propagar el formateo a vistas familiares y de detalle para evitar mostrar IDs en la interfaz

## Testing
- `npm run lint` *(falla: el registro npm devuelve 403 y no permite instalar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c8818cd08327af9e503264f4a295