### PR TITLE
Expand boletín sheet width on xl screens

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/_components/BoletinesReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/BoletinesReport.tsx
@@ -130,7 +130,10 @@ export function BoletinesReport({
         open={!!activeStudent}
         onOpenChange={(open) => !open && onCloseStudent()}
       >
-        <SheetContent className="flex h-full w-full max-w-full flex-col overflow-y-auto sm:max-w-3xl md:overflow-y-visible lg:w-[80vw] lg:max-w-5xl">
+        <SheetContent
+          size="xl"
+          className="flex h-full w-full flex-col overflow-y-auto md:overflow-y-visible lg:w-[85vw] xl:w-[90vw] 2xl:w-[92vw]"
+        >
           {activeStudent && (
             <>
               <SheetHeader className="space-y-4 text-left">
@@ -373,7 +376,7 @@ function BoletinSubjectsDetail({
         Materias y calificaciones
       </div>
       <div className="space-y-4 p-4">
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2">
           {boletinSubjectsByTrimester.map((trimester) => (
             <div
               key={trimester.id}

--- a/frontend-ecep/src/components/ui/sheet.tsx
+++ b/frontend-ecep/src/components/ui/sheet.tsx
@@ -38,13 +38,49 @@ const sheetVariants = cva(
         top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
         bottom:
           'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        left: 'inset-y-0 left-0 h-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
         right:
-          'inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+          'inset-y-0 right-0 h-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+      },
+      size: {
+        default: '',
+        sm: '',
+        lg: '',
+        xl: '',
+        full: '',
       },
     },
+    compoundVariants: [
+      {
+        side: ['left', 'right'],
+        size: 'default',
+        className: 'w-3/4 sm:max-w-sm',
+      },
+      {
+        side: ['left', 'right'],
+        size: 'sm',
+        className: 'w-full sm:max-w-sm',
+      },
+      {
+        side: ['left', 'right'],
+        size: 'lg',
+        className: 'w-full sm:max-w-xl md:max-w-3xl',
+      },
+      {
+        side: ['left', 'right'],
+        size: 'xl',
+        className:
+          'w-full sm:max-w-3xl md:max-w-5xl lg:max-w-6xl xl:max-w-7xl 2xl:max-w-[90rem]',
+      },
+      {
+        side: ['left', 'right'],
+        size: 'full',
+        className: 'w-full max-w-full',
+      },
+    ],
     defaultVariants: {
       side: 'right',
+      size: 'default',
     },
   }
 );
@@ -56,12 +92,12 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = 'right', className, children, ...props }, ref) => (
+>(({ side = 'right', size, className, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
-      className={cn(sheetVariants({ side }), className)}
+      className={cn(sheetVariants({ side, size }), className)}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- allow the boletín sheet content to keep the wider layout at xl and larger breakpoints by removing the restrictive max-width caps
- add width variants to the shared sheet component so slide-overs can opt into wide layouts when necessary

## Testing
- npm run lint *(fails: `next` command unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c62c526483278f91fb4e5fcd3364