### PR TITLE
Refactor dashboard layout to nested layout file

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -155,7 +154,7 @@ export default function AccidentesIndexPage() {
 
   if (isFamilyScope) {
     return (
-      <DashboardLayout>
+      
         <div className="p-4 md:p-8 space-y-6">
           <div className="space-y-2">
             <h2 className="text-3xl font-bold tracking-tight">
@@ -171,7 +170,7 @@ export default function AccidentesIndexPage() {
             initialError={scopeError ? String(scopeError) : null}
           />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -722,17 +721,16 @@ export default function AccidentesIndexPage() {
 
   if (noAccess) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — No tenés acceso a Actas de Accidentes.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-6 p-4 md:p-8 pt-6">
+    <div className="flex-1 space-y-6 p-4 md:p-8 pt-6">
         {/* Header */}
         <div className="flex items-center justify-between gap-3">
           <div>
@@ -1035,6 +1033,6 @@ export default function AccidentesIndexPage() {
           />
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/seccion/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardHeader,
@@ -619,15 +618,14 @@ export default function AccidentesSeccionPage() {
 
   if (loading) {
     return (
-      <DashboardLayout>
+      
         <LoadingState label="Cargando actas…" />
-      </DashboardLayout>
+      
     );
   }
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button
           variant="outline"
           onClick={() => router.push("/dashboard/accidentes")}
@@ -822,6 +820,6 @@ export default function AccidentesSeccionPage() {
           />
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -932,8 +931,7 @@ export default function AlumnoPerfilPage() {
 
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button variant="outline" onClick={() => router.back()}>
           Volver
         </Button>
@@ -1795,6 +1793,6 @@ export default function AlumnoPerfilPage() {
           </div>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/services/api/modules";
 import { isBirthDateValid, maxBirthDate, formatDni } from "@/lib/form-utils";
 import type * as DTO from "@/types/api-generated";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardHeader,
@@ -295,8 +294,7 @@ export default function AltaAlumnoPage() {
   };
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-6 p-4 md:p-8">
+    <div className="flex-1 space-y-6 p-4 md:p-8">
         <Button variant="outline" onClick={() => router.push("/dashboard/alumnos")}>
           Volver
         </Button>
@@ -443,7 +441,7 @@ export default function AltaAlumnoPage() {
           </Button>
         </div>
       </div>
-    </DashboardLayout>
+    
   );
 }
 

--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import type * as DTO from "@/types/api-generated";
 import { UserRole } from "@/types/api-generated";
 import {
@@ -285,8 +284,7 @@ export default function AlumnosIndexPage() {
   }, [secciones, alumnos]);
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
@@ -564,6 +562,6 @@ export default function AlumnosIndexPage() {
           </Tabs>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/seccion/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -26,8 +25,7 @@ export default function SeccionAlumnosPage() {
   };
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button
           variant="outline"
           onClick={() => router.push("/dashboard/alumnos")}
@@ -98,6 +96,6 @@ export default function SeccionAlumnosPage() {
           </div>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/asistencia/jornada/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/jornada/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { asistencias, gestionAcademica } from "@/services/api/modules";
 import {
@@ -313,15 +312,15 @@ export default function JornadaPage() {
 
   if (loading) {
     return (
-      <DashboardLayout>
+      
         <LoadingState label="Cargando jornada…" />
-      </DashboardLayout>
+      
     );
   }
 
   if (err || !jornada) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6">
           <Card>
             <CardHeader>
@@ -336,13 +335,12 @@ export default function JornadaPage() {
             </CardContent>
           </Card>
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button variant="outline" onClick={() => router.back()}>
           Volver
         </Button>
@@ -418,6 +416,6 @@ export default function JornadaPage() {
           </CardContent>
         </Card>
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/asistencia/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { UserRole, SeccionDTO, Turno, NivelAcademico } from "@/types/api-generated";
 import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
@@ -35,8 +34,7 @@ export default function AsistenciaPage() {
   const isStudent = type === "student";
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <header className="flex items-center justify-between">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">Asistencia</h2>
@@ -65,7 +63,7 @@ export default function AsistenciaPage() {
           <FamilyAttendanceView />
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }
 

--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { NewJornadaDialog } from "@/app/dashboard/asistencia/_components/NewJornadaDialog";
 import {
@@ -239,45 +238,44 @@ export default function SeccionHistorialPage() {
 
   if (accessStatus === "admin") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Asistencia.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "forbidden") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">403 — No tenés acceso a esta sección.</div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "checking") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6">
           <LoadingState label="Verificando acceso a la sección…" />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "notAssigned") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — Esta sección no pertenece a tus asignaciones.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button
           variant="outline"
           onClick={() => router.push("/dashboard/asistencia")}
@@ -530,6 +528,6 @@ export default function SeccionHistorialPage() {
           </Tabs>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import LoadingState from "@/components/common/LoadingState";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardHeader,
@@ -56,7 +55,7 @@ export default function CalificacionesIndexPage() {
 
   if (scope === "family" || scope === "student") {
     return (
-      <DashboardLayout>
+      
         <div className="p-4 md:p-8 space-y-6">
           <div className="space-y-2">
             <h2 className="text-3xl font-bold tracking-tight">
@@ -76,17 +75,17 @@ export default function CalificacionesIndexPage() {
             getPeriodoNombre={getPeriodoNombre}
           />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (isAdmin) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Calificaciones.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -95,9 +94,9 @@ export default function CalificacionesIndexPage() {
 
   if (!isTeacher && !isStaff) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">403 — No tenés acceso a calificaciones.</div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -122,8 +121,7 @@ export default function CalificacionesIndexPage() {
   }, [loading, primario.length, inicial.length]);
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <div className="space-y-2">
           <h2 className="text-3xl font-bold tracking-tight">Calificaciones</h2>
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
@@ -228,6 +226,6 @@ export default function CalificacionesIndexPage() {
           </Tabs>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { gestionAcademica } from "@/services/api/modules";
 import { Badge } from "@/components/ui/badge";
@@ -76,39 +75,39 @@ export default function CalificacionesSeccionPage() {
 
   if (accessStatus === "admin") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Calificaciones.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "forbidden") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">403 — No tenés acceso a esta sección.</div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "checking") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6">
           <LoadingState label="Verificando acceso a la sección…" />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "notAssigned") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — Esta sección no pertenece a tus asignaciones.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -131,8 +130,7 @@ export default function CalificacionesSeccionPage() {
   const turnoLabel = formatTurnoLabel(seccion?.turno);
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-4">
+    <div className="p-4 md:p-8 space-y-4">
         <div>
           <h2 className="text-2xl font-semibold">{heading}</h2>
           <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
@@ -165,6 +163,6 @@ export default function CalificacionesSeccionPage() {
           </>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/chat/page.tsx
+++ b/frontend-ecep/src/app/dashboard/chat/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import type React from "react";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -446,7 +445,7 @@ export default function ChatComponent() {
     }
 
     return (
-      <div className={`flex ${isOwn ? "justify-end" : "justify-start"} mb-3`}>
+    <div className={`flex ${isOwn ? "justify-end" : "justify-start"} mb-3`}>
         <div
           className={`
             max-w-xs lg:max-w-md px-4 py-2 rounded-lg
@@ -505,8 +504,7 @@ export default function ChatComponent() {
     : "";
 
   return (
-    <DashboardLayout>
-      <div className="flex h-full flex-col p-4 md:p-8 pt-6">
+    <div className="flex h-full flex-col p-4 md:p-8 pt-6">
         <div className="flex flex-1 min-h-0 overflow-hidden rounded-xl bg-background">
           {showChatList && (
             <div className="flex w-full min-h-0 flex-col bg-background md:w-1/3 md:flex-none md:border-r md:border-border">
@@ -694,6 +692,6 @@ export default function ChatComponent() {
           )}
         </div>
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/comunicados/page.tsx
+++ b/frontend-ecep/src/app/dashboard/comunicados/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -275,8 +274,7 @@ export default function ComunicadosPage() {
   const selectedFecha = selected ? fechaVisible(selected) : null;
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-6 p-4 md:p-8 pt-6">
+    <div className="flex-1 space-y-6 p-4 md:p-8 pt-6">
         {/* Header */}
         <div className="flex items-center justify-between gap-3">
           <div>
@@ -399,7 +397,7 @@ export default function ComunicadosPage() {
           </DialogContent>
         </Dialog>
       </div>
-    </DashboardLayout>
+    
   );
 }
 
@@ -418,7 +416,7 @@ function FeedList({
 }) {
   if (!items.length) {
     return (
-      <Card>
+    <Card>
         <CardContent className="p-6 text-sm text-muted-foreground">
           No hay comunicados para mostrar.
         </CardContent>
@@ -505,7 +503,7 @@ function TipoBadge({
 }) {
   if (c.alcance === "INSTITUCIONAL")
     return (
-      <Badge variant="default">
+    <Badge variant="default">
         <Megaphone className="h-3 w-3 mr-1" />
         Institucional
       </Badge>

--- a/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/examenes/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { gestionAcademica } from "@/services/api/modules";
 import type {
   EvaluacionDTO,
@@ -179,11 +178,11 @@ export default function ExamenDetailPage() {
 
   if (isAdmin) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Exámenes.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -385,15 +384,15 @@ export default function ExamenDetailPage() {
 
   if (loading) {
     return (
-      <DashboardLayout>
+      
         <LoadingState label="Cargando examen…" />
-      </DashboardLayout>
+      
     );
   }
 
   if (error) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 space-y-4">
           <Button variant="outline" onClick={() => router.back()}>
             Volver
@@ -402,13 +401,13 @@ export default function ExamenDetailPage() {
             {error}
           </div>
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (!evaluacion) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 space-y-4">
           <Button variant="outline" onClick={() => router.back()}>
             Volver
@@ -417,13 +416,12 @@ export default function ExamenDetailPage() {
             No encontramos datos para el examen solicitado.
           </div>
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button variant="outline" onClick={() => router.back()}>
           Volver
         </Button>
@@ -601,6 +599,6 @@ export default function ExamenDetailPage() {
           </DialogContent>
         </Dialog>
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { gestionAcademica } from "@/services/api/modules";
 import type {
   SeccionDTO,
@@ -176,7 +175,7 @@ export default function EvaluacionesIndexPage() {
 
   if (scope === "family" || scope === "student") {
     return (
-      <DashboardLayout>
+      
         <div className="p-4 md:p-8 space-y-6">
           <div className="flex items-center justify-between">
             <div>
@@ -198,25 +197,24 @@ export default function EvaluacionesIndexPage() {
             initialError={errorScope ? String(errorScope) : null}
           />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (isAdmin) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Exámenes.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   const title = scope === "teacher" ? "Exámenes" : "Exámenes";
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">{title}</h2>
@@ -295,6 +293,6 @@ export default function EvaluacionesIndexPage() {
           </div>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { gestionAcademica } from "@/services/api/modules";
 import type {
@@ -265,39 +264,39 @@ export default function SeccionEvaluacionesPage() {
 
   if (accessStatus === "admin") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Exámenes.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "forbidden") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">403 — No tenés acceso a esta sección.</div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "checking") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6">
           <LoadingState label="Verificando acceso a la sección…" />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "notAssigned") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — Esta sección no pertenece a tus asignaciones.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -374,15 +373,14 @@ export default function SeccionEvaluacionesPage() {
 
   if (loading) {
     return (
-      <DashboardLayout>
+      
         <LoadingState label="Cargando evaluaciones…" />
-      </DashboardLayout>
+      
     );
   }
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button
           variant="outline"
           onClick={() => router.push("/dashboard/evaluaciones")}
@@ -827,6 +825,6 @@ export default function SeccionEvaluacionesPage() {
           />
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardContent,
@@ -337,8 +336,7 @@ export default function FamiliarPerfilPage() {
   };
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button variant="outline" onClick={() => router.back()}>
           Volver
         </Button>
@@ -739,6 +737,6 @@ export default function FamiliarPerfilPage() {
           </div>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -1,5 +1,3 @@
-// src/app/(dashboard)/dashboard/layout.ts
-
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
@@ -16,7 +14,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { normalizeRole, normalizeRoles, displayRole } from "@/lib/auth-roles";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import { MENU, type MenuItem } from "@/lib/menu";
@@ -36,7 +33,7 @@ const getInitials = (name: string | undefined | null) => {
   return matches ? matches.join("") : "??";
 };
 
-export function DashboardLayout({ children }: DashboardLayoutProps) {
+export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
   const { logout, user, selectedRole, setSelectedRole, loading } = useAuth();

--- a/frontend-ecep/src/app/dashboard/materias/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/page.tsx
@@ -3,7 +3,6 @@
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import LoadingState from "@/components/common/LoadingState";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardHeader,
@@ -59,7 +58,7 @@ export default function MateriasPage() {
   if (scope === "family" || scope === "student") {
 
     return (
-      <DashboardLayout>
+      
         <div className="p-4 md:p-8 space-y-6">
           <div className="space-y-2">
             <h2 className="text-3xl font-bold tracking-tight">
@@ -79,27 +78,27 @@ export default function MateriasPage() {
             getPeriodoNombre={getPeriodoNombre}
           />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (isAdmin) {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Materias.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (scope !== "staff" && scope !== "teacher") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — No tenés acceso a la gestión de materias.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -116,8 +115,7 @@ export default function MateriasPage() {
   }, [q, seccionesPrimario]);
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">Materias</h2>
@@ -173,6 +171,6 @@ export default function MateriasPage() {
           </div>
         )}
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/seccion/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useParams, useRouter } from "next/navigation";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import {
   Card,
   CardHeader,
@@ -377,41 +376,41 @@ export default function MateriasSeccionPage() {
 
   if (accessStatus === "admin") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Materias.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "forbidden") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — No tenés acceso a esta sección.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "checking") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6">
           <LoadingState label="Verificando acceso a la sección…" />
         </div>
-      </DashboardLayout>
+      
     );
   }
 
   if (accessStatus === "notAssigned") {
     return (
-      <DashboardLayout>
+      
         <div className="p-6 text-sm">
           403 — Esta sección no pertenece a tus asignaciones.
         </div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -425,8 +424,7 @@ export default function MateriasSeccionPage() {
     );
 
   return (
-    <DashboardLayout>
-      <div className="p-4 md:p-8 space-y-6">
+    <div className="p-4 md:p-8 space-y-6">
         <Button
           variant="outline"
           onClick={() => router.push("/dashboard/materias")}
@@ -713,6 +711,6 @@ export default function MateriasSeccionPage() {
           onCreated={() => setRefreshKey((k) => k + 1)}
         />
       )}
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/page.tsx
+++ b/frontend-ecep/src/app/dashboard/page.tsx
@@ -21,7 +21,6 @@ import {
   CheckCircle,
 } from "lucide-react";
 import Link from "next/link";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { useAuth } from "@/hooks/useAuth";
 import { normalizeRole } from "@/lib/auth-roles";
 import { MENU, type MenuItem } from "@/lib/menu";
@@ -56,8 +55,7 @@ export default function DashboardPage() {
   );
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
         {/* Header */}
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -228,6 +226,6 @@ export default function DashboardPage() {
           </Card>
         </div>
       </div>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -8,7 +8,6 @@ import {
   useState,
   type FormEvent,
 } from "react";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { Button } from "@/components/ui/button";
 import {
@@ -840,7 +839,7 @@ export default function PagosPage() {
       }
 
       return (
-        <div className="space-y-6">
+    <div className="space-y-6">
           {cuotasError && (
             <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-2 text-sm text-destructive">
               <AlertCircle className="h-4 w-4" />
@@ -992,7 +991,7 @@ export default function PagosPage() {
 
     if (isAdmin) {
       return (
-        <div className="space-y-6">
+    <div className="space-y-6">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h2 className="text-lg font-semibold">Gestión de cuotas</h2>
@@ -1152,7 +1151,7 @@ export default function PagosPage() {
     }
 
     return (
-      <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+    <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
         No tenés permisos para visualizar cuotas en este momento.
       </div>
     );
@@ -1161,14 +1160,14 @@ export default function PagosPage() {
   const renderPagosTab = () => {
     if (!shouldLoadPagos) {
       return (
-        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+    <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
           No tenés acceso al registro de pagos.
         </div>
       );
     }
 
     return (
-      <div className="space-y-6">
+    <div className="space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold">Pagos registrados</h2>
@@ -1300,7 +1299,7 @@ export default function PagosPage() {
   const renderRecibosTab = () => {
     if (!shouldLoadRecibos) {
       return (
-        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+    <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
           No tenés acceso a los recibos de sueldo.
         </div>
       );
@@ -1309,7 +1308,7 @@ export default function PagosPage() {
     const listado = isAdmin ? recibosOrdenados : misRecibos;
 
     return (
-      <div className="space-y-6">
+    <div className="space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="text-lg font-semibold">
@@ -1500,8 +1499,7 @@ export default function PagosPage() {
         : "Registrá un pago asociado a la cuota seleccionada.";
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
+    <div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">
@@ -2270,7 +2268,7 @@ export default function PagosPage() {
           </DialogContent>
         </Dialog>
       </div>
-    </DashboardLayout>
+    
   );
 }
 

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import LoadingState from "@/components/common/LoadingState";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -484,21 +483,21 @@ function getSituacionBadge(situacion?: string | null) {
   const normalized = (situacion ?? "").toLowerCase();
   if (normalized === "activo") {
     return (
-      <Badge variant="default">
+    <Badge variant="default">
         <CheckCircle className="mr-1 h-3 w-3" /> Activo
       </Badge>
     );
   }
   if (normalized.includes("licencia")) {
     return (
-      <Badge variant="secondary">
+    <Badge variant="secondary">
         <Clock className="mr-1 h-3 w-3" /> En licencia
       </Badge>
     );
   }
   if (normalized.includes("baja")) {
     return (
-      <Badge variant="destructive">
+    <Badge variant="destructive">
         <AlertCircle className="mr-1 h-3 w-3" /> Baja
       </Badge>
     );
@@ -2263,7 +2262,7 @@ export default function PersonalPage() {
     const isDisabled = disabled || !empleadoId || saving;
 
     return (
-      <>
+    <>
         <div className="rounded-lg border bg-muted/40 p-4">
           <div className="flex items-center gap-2 text-sm font-semibold">
             <Users className="h-4 w-4 text-muted-foreground" />
@@ -3968,9 +3967,9 @@ export default function PersonalPage() {
 
   if (loading || !user) {
     return (
-      <DashboardLayout>
+      
         <div className="flex-1 p-4 pt-6 md:p-8">{renderLoadingState()}</div>
-      </DashboardLayout>
+      
     );
   }
 
@@ -3984,8 +3983,7 @@ export default function PersonalPage() {
   const canManageAccess = canCreatePersonal;
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
+    <div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight">
             Gestión de personal
@@ -6663,6 +6661,6 @@ export default function PersonalPage() {
           </form>
         </DialogContent>
       </Dialog>
-    </DashboardLayout>
+    
   );
 }

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 import { pageContent } from "@/lib/page-response";
-import { DashboardLayout } from "@/app/dashboard/dashboard-layout";
 import { BoletinesReport } from "./_components/BoletinesReport";
 import { ApprovalReport } from "./_components/ApprovalReport";
 import { AttendanceReport } from "./_components/AttendanceReport";
@@ -1698,8 +1697,7 @@ const handleExportCurrent = async () => {
   }
 
   return (
-    <DashboardLayout>
-      <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+    <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="text-3xl font-bold tracking-tight">Reportes</h2>
@@ -1831,6 +1829,6 @@ const handleExportCurrent = async () => {
       </div>
 
 
-    </DashboardLayout>
+    
   );
 }


### PR DESCRIPTION
## Summary
- move the dashboard layout implementation into app/dashboard/layout.tsx with a default export so the nested layout system handles wrapping
- remove all manual DashboardLayout imports/usages from dashboard pages so they rely on the new layout automatically

## Testing
- npm run lint *(fails: `next` binary missing because dependencies are unavailable; `npm install` blocked with 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d0462460832794b9c1dce7cf669d