### PR TITLE
Ajusta fondo de solicitud de admisión para modo oscuro

### DIFF
--- a/frontend-ecep/src/app/postulacion/page.tsx
+++ b/frontend-ecep/src/app/postulacion/page.tsx
@@ -910,16 +910,20 @@ export default function PostulacionPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 p-4">
+    <div
+      className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900 p-4 transition-colors"
+    >
       <div className="max-w-4xl mx-auto space-y-6">
         <Button variant="outline" asChild>
           <Link href="/">Volver</Link>
         </Button>
         <div className="text-center">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          <h1 className="text-3xl font-bold text-foreground mb-2">
             Postulación de Alumno
           </h1>
-          <p className="text-gray-600">Escuela Complejo Evangélico Pilar</p>
+          <p className="text-muted-foreground">
+            Escuela Complejo Evangélico Pilar
+          </p>
         </div>
 
         <Card className="shadow-lg">


### PR DESCRIPTION
## Summary
- actualiza el fondo de la página de postulación para reutilizar el gradiente del inicio y añadir variantes dark
- ajusta los textos principales para que utilicen colores compatibles con el tema oscuro

## Testing
- npm run lint *(falla: next no disponible antes de instalar dependencias)*
- npm install *(falla: 403 Forbidden al descargar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68d5eaeae7748327be167db712412067