### PR TITLE
Allow nested aspirante GET endpoints

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/security/SecurityConfig.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/security/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                                 HttpMethod.GET,
                                 "/api/personas/dni/**",
                                 "/api/personas/*",
-                                "/api/aspirantes/*",
+                                "/api/aspirantes/**",
                                 "/api/familiares/*"
                         ).permitAll()
 


### PR DESCRIPTION
## Summary
- permit GET requests to /api/aspirantes/** without authentication so nested endpoints remain public

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ec25000483278ce1ee4e01a1c77b