### PR TITLE
Wrap personal page content in fragment

### DIFF
--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -3983,7 +3983,8 @@ export default function PersonalPage() {
   const canManageAccess = canCreatePersonal;
 
   return (
-    <div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
+    <>
+      <div className="flex-1 space-y-6 p-4 pt-6 md:p-8">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight">
             Gestión de personal
@@ -6661,6 +6662,6 @@ export default function PersonalPage() {
           </form>
         </DialogContent>
       </Dialog>
-    
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the personal dashboard page content in a React fragment so multiple dialogs can render alongside the main layout

## Testing
- npm run lint *(fails: `next` command not found in the environment)*
- npm install *(fails: 403 when downloading @hookform/resolvers)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ec65e7c48327bef7e4a0e48a520c