### PR TITLE
Fix firmante select empty value handling

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/_components/ViewActaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/_components/ViewActaDialog.tsx
@@ -43,6 +43,8 @@ type ActaVM = {
   informanteId?: number | null;
 };
 
+const UNASSIGNED_FIRMANTE_VALUE = "unassigned";
+
 export default function ViewActaDialog({
   acta,
   onClose,
@@ -184,10 +186,14 @@ export default function ViewActaDialog({
                     value={
                       acta.firmanteId != null
                         ? String(acta.firmanteId)
-                        : ""
+                        : UNASSIGNED_FIRMANTE_VALUE
                     }
                     onValueChange={(value) =>
-                      onFirmanteChange?.(value ? Number(value) : null)
+                      onFirmanteChange?.(
+                        value === UNASSIGNED_FIRMANTE_VALUE
+                          ? null
+                          : Number(value)
+                      )
                     }
                     disabled={firmanteUpdating}
                   >
@@ -195,7 +201,9 @@ export default function ViewActaDialog({
                       <SelectValue placeholder="Seleccioná directivo" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">Sin asignar</SelectItem>
+                      <SelectItem value={UNASSIGNED_FIRMANTE_VALUE}>
+                        Sin asignar
+                      </SelectItem>
                       {(firmanteOptions ?? []).map((option) => (
                         <SelectItem key={option.value} value={option.value}>
                           {option.label}


### PR DESCRIPTION
## Summary
- replace the empty value used for the firmante select with a dedicated sentinel to comply with the Select component requirements
- normalize the firmante change handler so the sentinel maps back to a null firmante assignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5efd460b083278a5631cd38215450