### PR TITLE
Redirect dashboard to root when switching roles

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -79,7 +79,13 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   }, [role, pathname, router]);
 
   const handleChangeRole = (r: UserRole) => {
+    if (currentRole === r) return;
+
     setSelectedRole(r);
+
+    // Siempre mandamos al usuario al inicio del dashboard para evitar rutas
+    // incompatibles con el nuevo rol seleccionado.
+    router.replace("/dashboard");
   };
 
   const handleLogout = async (e?: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- prevent redundant role changes in the dashboard layout
- redirect users to the dashboard root after changing role to avoid incompatible routes

## Testing
- `npm run lint` *(fails: `next` binary unavailable because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d67f75556c8327b70a701e06a21d19