### PR TITLE
Fix dashboard redirect when switching roles

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -72,7 +72,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   useEffect(() => {
     if (!role) return;
-    const item = MENU.find((i) => i.href === pathname);
+    const item = MENU.find((i) => isItemActive(pathname, i.href));
     if (item?.roles && !item.roles.includes(role)) {
       router.replace("/dashboard");
     }


### PR DESCRIPTION
## Summary
- ensure the dashboard layout checks role permissions against the active menu entry using the existing helper
- redirect users back to the dashboard home when their new role cannot access the current section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d68125446c8327bcb8dfe3d3bbc105