### PR TITLE
Hide academic items from admin sidebar

### DIFF
--- a/frontend-ecep/src/hooks/useVisibleMenu.ts
+++ b/frontend-ecep/src/hooks/useVisibleMenu.ts
@@ -4,9 +4,22 @@ import { useMemo } from "react";
 import { MENU, type MenuItem } from "@/lib/menu";
 import type { UserRole } from "@/types/api-generated";
 
+const HIDDEN_ITEMS_BY_ROLE: Partial<Record<UserRole, string[]>> = {
+  [UserRole.ADMIN]: [
+    "/dashboard/calificaciones",
+    "/dashboard/asistencia",
+    "/dashboard/evaluaciones",
+  ],
+};
+
 export function useVisibleMenu(role?: UserRole | null) {
   return useMemo<MenuItem[]>(() => {
     if (!role) return MENU.filter((i) => !i.roles);
-    return MENU.filter((i) => !i.roles || i.roles.includes(role));
+
+    const hiddenItems = new Set(HIDDEN_ITEMS_BY_ROLE[role] ?? []);
+
+    return MENU.filter(
+      (i) => (!i.roles || i.roles.includes(role)) && !hiddenItems.has(i.href),
+    );
   }, [role]);
 }


### PR DESCRIPTION
## Summary
- add role-specific hidden menu entries for administrators
- prevent admin users from seeing calificaciones, asistencia, and evaluaciones in the sidebar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d681165c7083279b6107e1c1f9be2d