### PR TITLE
Fix UserRole import for visible menu hook

### DIFF
--- a/frontend-ecep/src/hooks/useVisibleMenu.ts
+++ b/frontend-ecep/src/hooks/useVisibleMenu.ts
@@ -2,7 +2,7 @@
 "use client";
 import { useMemo } from "react";
 import { MENU, type MenuItem } from "@/lib/menu";
-import type { UserRole } from "@/types/api-generated";
+import { UserRole } from "@/types/api-generated";
 
 const HIDDEN_ITEMS_BY_ROLE: Partial<Record<UserRole, string[]>> = {
   [UserRole.ADMIN]: [


### PR DESCRIPTION
## Summary
- update the visible menu hook to import the UserRole enum as a runtime value
- ensure hidden menu items by role resolve the admin entry without runtime errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d682396e6c8327ae69f6e0dac2493d