### PR TITLE
Fix hook order in dashboard layout

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -50,6 +50,17 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     ? normalizeRole(selectedRole)
     : (rolesNormalized[0] ?? null);
 
+  const role = currentRole;
+  const visibleMenu = useVisibleMenu(role);
+
+  useEffect(() => {
+    if (!role) return;
+    const item = MENU.find((i) => isItemActive(pathname, i.href));
+    if (item?.roles && !item.roles.includes(role)) {
+      router.replace("/dashboard");
+    }
+  }, [role, pathname, router]);
+
   useEffect(() => {
     if (loading || !user) return;
     if (rolesNormalized.length > 1 && !selectedRole) {
@@ -65,18 +76,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   if (user && rolesNormalized.length > 1 && !selectedRole) return null;
 
   const displayName = user?.nombreCompleto || user?.email || "Usuario";
-
-  const role = currentRole;
-
-  const visibleMenu = useVisibleMenu(role);
-
-  useEffect(() => {
-    if (!role) return;
-    const item = MENU.find((i) => isItemActive(pathname, i.href));
-    if (item?.roles && !item.roles.includes(role)) {
-      router.replace("/dashboard");
-    }
-  }, [role, pathname, router]);
 
   const handleChangeRole = (r: UserRole) => {
     if (currentRole === r) return;


### PR DESCRIPTION
## Summary
- ensure the dashboard layout always executes its hooks before any conditional return so role selection no longer triggers hook order errors

## Testing
- not run (dependencies failed to install due to npm registry 403s)


------
https://chatgpt.com/codex/tasks/task_e_68d694f44060832788aea2285ebda64c