### PR TITLE
Fix Calificaciones hook ordering regression

### DIFF
--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -53,9 +53,37 @@ export default function CalificacionesIndexPage() {
 
   const isAdmin = activeRole === UserRole.ADMIN;
 
+  const isTeacher = scope === "teacher";
+  const isStaff = scope === "staff";
+  const hasDocenteAccess = isTeacher || isStaff;
+
+  const primario = useMemo(
+    () => (secciones ?? []).filter(isPrimario),
+    [secciones],
+  );
+  const inicial = useMemo(
+    () => (secciones ?? []).filter(isInicial),
+    [secciones],
+  );
+
+  const primarioCount = primario.length;
+  const inicialCount = inicial.length;
+
+  const [tab, setTab] = useState<"primario" | "inicial">("primario");
+
+  useEffect(() => {
+    if (!hasDocenteAccess) return;
+    if (loading) return;
+    if (!primarioCount && inicialCount) {
+      setTab("inicial");
+    } else if (!inicialCount && primarioCount) {
+      setTab("primario");
+    }
+  }, [hasDocenteAccess, loading, primarioCount, inicialCount]);
+
   if (scope === "family" || scope === "student") {
     return (
-      
+
         <div className="p-4 md:p-8 space-y-6">
           <div className="space-y-2">
             <h2 className="text-3xl font-bold tracking-tight">
@@ -75,50 +103,27 @@ export default function CalificacionesIndexPage() {
             getPeriodoNombre={getPeriodoNombre}
           />
         </div>
-      
+
     );
   }
 
   if (isAdmin) {
     return (
-      
+
         <div className="p-6 text-sm">
           403 — El perfil de Administración no tiene acceso a Calificaciones.
         </div>
-      
+
     );
   }
 
-  const isTeacher = scope === "teacher";
-  const isStaff = scope === "staff";
-
-  if (!isTeacher && !isStaff) {
+  if (!hasDocenteAccess) {
     return (
-      
+
         <div className="p-6 text-sm">403 — No tenés acceso a calificaciones.</div>
-      
+
     );
   }
-
-  const primario = useMemo(
-    () => (secciones ?? []).filter(isPrimario),
-    [secciones],
-  );
-  const inicial = useMemo(
-    () => (secciones ?? []).filter(isInicial),
-    [secciones],
-  );
-
-  const [tab, setTab] = useState<"primario" | "inicial">("primario");
-
-  useEffect(() => {
-    if (loading) return;
-    if (!primario.length && inicial.length) {
-      setTab("inicial");
-    } else if (!inicial.length && primario.length) {
-      setTab("primario");
-    }
-  }, [loading, primario.length, inicial.length]);
 
   return (
     <div className="p-4 md:p-8 space-y-6">
@@ -126,10 +131,10 @@ export default function CalificacionesIndexPage() {
           <h2 className="text-3xl font-bold tracking-tight">Calificaciones</h2>
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <Badge variant="outline">
-              Primario: {loading ? "—" : primario.length}
+              Primario: {loading ? "—" : primarioCount}
             </Badge>
             <Badge variant="outline">
-              Inicial: {loading ? "—" : inicial.length}
+              Inicial: {loading ? "—" : inicialCount}
             </Badge>
             {periodoNombre && (
               <Badge variant="outline">Período {periodoNombre}</Badge>

--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -174,7 +174,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <div className="p-4 lg:pr-0 mt-auto">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button className="w-full inline-flex items-center justify-between gap-3 rounded-md p-2 hover:bg-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
+                <button
+                  id="dashboard-user-menu-trigger"
+                  className="w-full inline-flex items-center justify-between gap-3 rounded-md p-2 hover:bg-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                >
                   <div className="flex items-center gap-3">
                     <div className="w-9 h-9 bg-primary rounded-full flex items-center justify-center text-white font-semibold text-sm">
                       {getInitials(displayName)}
@@ -192,7 +195,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
                 </button>
               </DropdownMenuTrigger>
 
-              <DropdownMenuContent side="top" align="end" className="w-60 p-3">
+              <DropdownMenuContent
+                side="top"
+                align="end"
+                className="w-60 p-3"
+                aria-labelledby="dashboard-user-menu-trigger"
+              >
                 <DropdownMenuLabel className="truncate">
                   {displayName}
                 </DropdownMenuLabel>


### PR DESCRIPTION
## Summary
- always initialize teacher view hooks so their order stays consistent when switching scopes
- guard the tab auto-selection effect behind the teacher/staff roles and reuse memoized section counts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6962f600483279587c4bdf98540b8