### PR TITLE
Fix calendar navigation callbacks

### DIFF
--- a/frontend-ecep/src/components/ui/calendar.tsx
+++ b/frontend-ecep/src/components/ui/calendar.tsx
@@ -27,6 +27,7 @@ type CalendarCaptionProps = CaptionProps & {
   maxDate?: Date;
   disableMonthDropdown?: boolean;
   disableYearDropdown?: boolean;
+  onMonthChange?: (month: Date) => void;
 };
 
 const monthStart = (date: Date) => new Date(date.getFullYear(), date.getMonth(), 1);
@@ -35,6 +36,7 @@ function CalendarCaption({
   displayMonth,
   locale,
   goToMonth,
+  onMonthChange,
   minDate,
   maxDate,
   disableMonthDropdown,
@@ -117,8 +119,11 @@ function CalendarCaption({
   }, [currentYear, maxMonth, minMonth]);
 
   const canNavigate = React.useMemo(
-    () => typeof goToMonth === 'function' || typeof contextGoToMonth === 'function',
-    [contextGoToMonth, goToMonth]
+    () =>
+      typeof goToMonth === 'function' ||
+      typeof contextGoToMonth === 'function' ||
+      typeof onMonthChange === 'function',
+    [contextGoToMonth, goToMonth, onMonthChange]
   );
 
   const navigateToMonth = React.useCallback(
@@ -129,14 +134,15 @@ function CalendarCaption({
 
       if (typeof goToMonth === 'function') {
         goToMonth(targetDate);
-        return;
-      }
-
-      if (typeof contextGoToMonth === 'function') {
+      } else if (typeof contextGoToMonth === 'function') {
         contextGoToMonth(targetDate);
       }
+
+      if (typeof onMonthChange === 'function') {
+        onMonthChange(targetDate);
+      }
     },
-    [canNavigate, clampMonth, contextGoToMonth, goToMonth]
+    [canNavigate, clampMonth, contextGoToMonth, goToMonth, onMonthChange]
   );
 
   const handleMonthChange = React.useCallback(
@@ -208,17 +214,17 @@ function CalendarCaption({
   );
 
   return (
-    <div className="flex w-full items-center justify-between gap-2">
+    <div className="grid w-full grid-cols-[auto_1fr_auto] items-center gap-2">
       <button
         type="button"
-        className={navButtonClassName}
+        className={cn(navButtonClassName, 'justify-self-start')}
         onClick={handlePreviousMonth}
         aria-label="Mes anterior"
         disabled={isPreviousDisabled || !canNavigate}
       >
         <ChevronLeft className="h-4 w-4" />
       </button>
-      <div className="flex flex-col items-center gap-2 sm:flex-row">
+      <div className="flex flex-col items-center gap-2 justify-self-center sm:flex-row">
         {disableMonthDropdown ? (
           renderMonthLabel()
         ) : (
@@ -273,7 +279,7 @@ function CalendarCaption({
       </div>
       <button
         type="button"
-        className={navButtonClassName}
+        className={cn(navButtonClassName, 'justify-self-end')}
         onClick={handleNextMonth}
         aria-label="Mes siguiente"
         disabled={isNextDisabled || !canNavigate}
@@ -349,6 +355,7 @@ function Calendar({
             maxDate={maxDate}
             disableMonthDropdown={disableMonthDropdown}
             disableYearDropdown={disableYearDropdown}
+            onMonthChange={props.onMonthChange}
           />
         ),
         ...components,


### PR DESCRIPTION
## Summary
- always call a provided `onMonthChange` handler when navigating the calendar so controlled views update correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a51d3b908327bd14f111003ffb8a