### PR TITLE
Fix calendar month change callback duplication

### DIFF
--- a/frontend-ecep/src/components/ui/calendar.tsx
+++ b/frontend-ecep/src/components/ui/calendar.tsx
@@ -136,11 +136,6 @@ function CalendarCaption({
         goToMonth(targetDate);
       } else if (typeof contextGoToMonth === 'function') {
         contextGoToMonth(targetDate);
-        return;
-      }
-
-      if (typeof onMonthChange === 'function') {
-        onMonthChange(targetDate);
       }
 
       if (typeof onMonthChange === 'function') {


### PR DESCRIPTION
## Summary
- prevent the calendar caption from returning early when using the DayPicker context navigation so the external month change callback still runs
- ensure the external onMonthChange callback is invoked only once per navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a9fcccc8832782729a9ab6fd4f40