### PR TITLE
Fix boletin conceptual grade formatting

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/utils.ts
+++ b/frontend-ecep/src/app/dashboard/reportes/utils.ts
@@ -22,7 +22,7 @@ export const getBoletinGradeDisplay = (grade?: BoletinSubjectGrade | null) => {
 
   const conceptual = grade.notaConceptual?.trim();
   if (conceptual && conceptual !== "—") {
-    return conceptual;
+    return formatConceptualGrade(conceptual);
   }
 
   const numeric = typeof grade.notaNumerica === "number" ? grade.notaNumerica : null;
@@ -35,6 +35,23 @@ export const getBoletinGradeDisplay = (grade?: BoletinSubjectGrade | null) => {
 
 export const formatPercent = (value: number, digits = 0) =>
   `${(value * 100).toFixed(digits)}%`;
+
+function formatConceptualGrade(value: string) {
+  const hasUnderscores = value.includes("_");
+  const cleaned = value.replace(/_/g, " ").replace(/\s+/g, " ").trim();
+
+  if (!cleaned) return value;
+
+  if (!hasUnderscores) {
+    return cleaned;
+  }
+
+  return cleaned
+    .split(" ")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+}
 
 export const parseISO = (value: string) => new Date(`${value}T00:00:00`);
 


### PR DESCRIPTION
## Summary
- normalize boletín conceptual grades by stripping underscores and capitalizing each word when needed so they display legibly

## Testing
- `bun run lint` *(fails: next command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b6c5b1a8832797bab285d0028be9