### PR TITLE
Adjust asistencia section header badges

### DIFF
--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -415,19 +415,21 @@ export default function SeccionHistorialPage() {
 
       <div className="space-y-3">
         <div>
-          <h2 className="text-2xl font-bold">
-            Historial — Sección{" "}
-            {seccion
-              ? `${seccion.gradoSala} ${seccion.division}`
-              : loadingSec
-                ? "cargando…"
-                : `#${seccionId}`}
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Turno: {seccion?.turno ?? "—"}
-          </p>
+          <h2 className="text-2xl font-bold">Historial</h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Badge variant="outline">
+              {seccion
+                ? `Sección ${seccion.gradoSala} ${seccion.division}`
+                : loadingSec
+                  ? "Sección cargando…"
+                  : `Sección #${seccionId}`}
+            </Badge>
+            <Badge variant="secondary">
+              Turno {seccion?.turno ?? "—"}
+            </Badge>
+          </div>
           {secErr && <p className="text-sm text-red-600">{secErr}</p>}
-          <ActiveTrimestreBadge className="mt-2" />
+          <ActiveTrimestreBadge className="mt-3" />
         </div>
         {periodError && <p className="text-sm text-red-600">{periodError}</p>}
       </div>


### PR DESCRIPTION
## Summary
- show the sección information beneath the Historial heading using a badge
- render the turno value as a badge alongside the sección badge on the asistencia sección view

## Testing
- npm install *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d6956b4483278149baa43f7680c2