### PR TITLE
Enable month/year dropdowns on birth date pickers

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -1025,6 +1025,8 @@ export default function AlumnoPerfilPage() {
                             }))
                           }
                           required
+                          showMonthDropdown
+                          showYearDropdown
                         />
                       </div>
                       <div className="space-y-2">

--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -501,6 +501,8 @@ function PersonaFormFields({ values, onChange }: PersonaFormFieldsProps) {
               value={values.fechaNacimiento || undefined}
               onChange={(value) => onChange("fechaNacimiento", value ?? "")}
               required
+              showMonthDropdown
+              showYearDropdown
             />
           </div>
           <div className="space-y-1">

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -5146,6 +5146,8 @@ export default function PersonalPage() {
                         }))
                       }
                       required
+                      showMonthDropdown
+                      showYearDropdown
                     />
                   </div>
                   <div className="space-y-2">
@@ -5863,6 +5865,8 @@ export default function PersonalPage() {
                         }))
                       }
                       required
+                      showMonthDropdown
+                      showYearDropdown
                     />
                   </div>
                   <div className="space-y-2">

--- a/frontend-ecep/src/app/postulacion/Step1.tsx
+++ b/frontend-ecep/src/app/postulacion/Step1.tsx
@@ -112,6 +112,8 @@ export function Step1({
             }
             error={Boolean(errors.fechaNacimiento)}
             required
+            showMonthDropdown
+            showYearDropdown
           />
         </div>
 

--- a/frontend-ecep/src/app/postulacion/Step2.tsx
+++ b/frontend-ecep/src/app/postulacion/Step2.tsx
@@ -246,6 +246,8 @@ export function Step2({
                     }
                     error={Boolean(fechaNacimientoError)}
                     required
+                    showMonthDropdown
+                    showYearDropdown
                   />
                 </div>
 

--- a/frontend-ecep/src/components/ui/date-picker.tsx
+++ b/frontend-ecep/src/components/ui/date-picker.tsx
@@ -22,6 +22,8 @@ export interface DatePickerProps {
   required?: boolean;
   error?: boolean;
   align?: "start" | "center" | "end";
+  showMonthDropdown?: boolean;
+  showYearDropdown?: boolean;
 }
 
 const formatDisplay = (value: string) => {
@@ -61,6 +63,8 @@ export const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
       required,
       error,
       align = "start",
+      showMonthDropdown,
+      showYearDropdown,
     },
     ref,
   ) => {
@@ -128,6 +132,12 @@ export const DatePicker = React.forwardRef<HTMLButtonElement, DatePickerProps>(
               }}
               fromDate={minDate}
               toDate={maxDate}
+              {...(showMonthDropdown !== undefined
+                ? { disableMonthDropdown: !showMonthDropdown }
+                : {})}
+              {...(showYearDropdown !== undefined
+                ? { disableYearDropdown: !showYearDropdown }
+                : {})}
               initialFocus
             />
             {!required && value ? (


### PR DESCRIPTION
## Summary
- allow the shared DatePicker to optionally toggle month and year dropdowns
- enable the dropdown navigation on every birth date picker used in admissions, staff, and student flows

## Testing
- `npm run lint` *(fails: next binary missing because dependencies could not be installed in the execution environment)*
- `npm install` *(fails: 403 Forbidden while downloading packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dede5c9c832797368143055a4c00