### PR TITLE
Ensure conceptual boletin grades render in uppercase

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/utils.ts
+++ b/frontend-ecep/src/app/dashboard/reportes/utils.ts
@@ -37,20 +37,11 @@ export const formatPercent = (value: number, digits = 0) =>
   `${(value * 100).toFixed(digits)}%`;
 
 function formatConceptualGrade(value: string) {
-  const hasUnderscores = value.includes("_");
   const cleaned = value.replace(/_/g, " ").replace(/\s+/g, " ").trim();
 
   if (!cleaned) return value;
 
-  if (!hasUnderscores) {
-    return cleaned;
-  }
-
-  return cleaned
-    .split(" ")
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(" ");
+  return cleaned.toUpperCase();
 }
 
 export const parseISO = (value: string) => new Date(`${value}T00:00:00`);


### PR DESCRIPTION
## Summary
- normalize the conceptual boletín grade formatter so all values are displayed in uppercase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e45668d48327b01db154535a5af7