### PR TITLE
Fix select item empty value for section selector

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -133,6 +133,8 @@ export default function AlumnoPerfilPage() {
     return `${grado} ${div} ${turno}`.trim();
   };
 
+  const NO_SECTION_VALUE = "__no-section__";
+
   const sectionOptions = useMemo(() => {
     if (!seccionesList.length) return [] as { id: string; label: string }[];
     return seccionesList
@@ -1134,15 +1136,23 @@ export default function AlumnoPerfilPage() {
                       <div className="space-y-2">
                         <Label>Sección (periodo actual)</Label>
                         <Select
-                          value={selectedSeccionId}
-                          onValueChange={setSelectedSeccionId}
+                          value={
+                            selectedSeccionId ? selectedSeccionId : NO_SECTION_VALUE
+                          }
+                          onValueChange={(value) =>
+                            setSelectedSeccionId(
+                              value === NO_SECTION_VALUE ? "" : value
+                            )
+                          }
                           disabled={!sectionOptions.length}
                         >
                           <SelectTrigger>
                             <SelectValue placeholder="Sin sección asignada" />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="">Sin sección asignada</SelectItem>
+                            <SelectItem value={NO_SECTION_VALUE}>
+                              Sin sección asignada
+                            </SelectItem>
                             {sectionOptions.map((option) => (
                               <SelectItem key={option.id} value={option.id}>
                                 {option.label}


### PR DESCRIPTION
## Summary
- prevent the alumno section selector from rendering a SelectItem with an empty value
- map the empty selection to a sentinel value so the selection can still be cleared

## Testing
- `npm run lint` *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e84f96688327afa0d886edff08a3