### PR TITLE
Make student edit dialog scrollable

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -969,7 +969,7 @@ export default function AlumnoPerfilPage() {
                 <DialogTrigger asChild>
                   <Button variant="default">Editar datos</Button>
                 </DialogTrigger>
-                <DialogContent className="max-w-3xl">
+                <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto sm:max-h-[80vh]">
                   <DialogHeader>
                     <DialogTitle>Editar perfil del alumno</DialogTitle>
                     <DialogDescription>


### PR DESCRIPTION
## Summary
- cap the student profile edit dialog height so it stays within the viewport and becomes scrollable when needed

## Testing
- npm run lint *(fails: `next` command not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ea9e2ce08327a8a27f438b8e09dd