### PR TITLE
Fix calendar navigation availability

### DIFF
--- a/frontend-ecep/src/components/ui/calendar.tsx
+++ b/frontend-ecep/src/components/ui/calendar.tsx
@@ -119,17 +119,12 @@ function CalendarCaption({
   }, [currentYear, maxMonth, minMonth]);
 
   const canNavigate = React.useMemo(
-    () =>
-      typeof goToMonth === 'function' ||
-      typeof contextGoToMonth === 'function' ||
-      typeof onMonthChange === 'function',
+    () => Boolean(goToMonth ?? contextGoToMonth ?? onMonthChange),
     [contextGoToMonth, goToMonth, onMonthChange]
   );
 
   const navigateToMonth = React.useCallback(
     (nextDate: Date) => {
-      if (!canNavigate) return;
-
       const targetDate = clampMonth(nextDate);
 
       if (typeof goToMonth === 'function') {
@@ -142,7 +137,7 @@ function CalendarCaption({
         onMonthChange(targetDate);
       }
     },
-    [canNavigate, clampMonth, contextGoToMonth, goToMonth, onMonthChange]
+    [clampMonth, contextGoToMonth, goToMonth, onMonthChange]
   );
 
   const handleMonthChange = React.useCallback(


### PR DESCRIPTION
## Summary
- ensure the calendar caption treats navigation callbacks as available when provided by the DayPicker context
- allow the month and year controls to stay enabled so the student birth date picker can change months and years

## Testing
- npm run lint *(fails: next binary not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ebc912d88327aaf0a6f8d9686e79