### PR TITLE
Avoid remapping persona when updating students

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoMapper.java
@@ -29,6 +29,6 @@ public interface AlumnoMapper {
 
     // Update (no tocar id; re-resolver persona desde personaId)
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "persona", source = "personaId")
+    @Mapping(target = "persona", ignore = true)
     void update(@MappingTarget Alumno e, AlumnoDTO dto);
 }


### PR DESCRIPTION
## Summary
- prevent the alumno MapStruct update method from replacing the managed persona instance
- ensure edited students reuse the already-attached persona to avoid detached entity errors

## Testing
- `./mvnw -q -DskipTests package` *(fails: wget unable to fetch Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ec4c75448327bff7e066f2f86935