### PR TITLE
Remove legal guardian option from family management

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoFamiliarMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoFamiliarMapper.java
@@ -20,13 +20,11 @@ public interface AlumnoFamiliarMapper {
     // CREATE
     @Mapping(target = "alumno", source = "alumnoId")
     @Mapping(target = "familiar", source = "familiarId")
-    @Mapping(target = "convive", constant = "false")
     AlumnoFamiliar toEntity(AlumnoFamiliarCreateDTO dto);
 
     // UPDATE
     @Mapping(target = "alumno", source = "alumnoId")
     @Mapping(target = "familiar", source = "familiarId")
-    @Mapping(target = "convive", ignore = true)
     @Mapping(target = "id", ignore = true)
     void update(@MappingTarget AlumnoFamiliar e, AlumnoFamiliarDTO dto);
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoFamiliarMapper.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/mapper/AlumnoFamiliarMapper.java
@@ -15,19 +15,18 @@ public interface AlumnoFamiliarMapper {
 
     @Mapping(target = "alumnoId", source = "alumno.id")
     @Mapping(target = "familiarId", source = "familiar.id")
-    @Mapping(target = "esTutorLegal", source = "convive")
     AlumnoFamiliarDTO toDto(AlumnoFamiliar e);
 
     // CREATE
     @Mapping(target = "alumno", source = "alumnoId")
     @Mapping(target = "familiar", source = "familiarId")
-    @Mapping(target = "convive", source = "esTutorLegal")
+    @Mapping(target = "convive", constant = "false")
     AlumnoFamiliar toEntity(AlumnoFamiliarCreateDTO dto);
 
     // UPDATE
     @Mapping(target = "alumno", source = "alumnoId")
     @Mapping(target = "familiar", source = "familiarId")
-    @Mapping(target = "convive", source = "esTutorLegal")
+    @Mapping(target = "convive", ignore = true)
     @Mapping(target = "id", ignore = true)
     void update(@MappingTarget AlumnoFamiliar e, AlumnoFamiliarDTO dto);
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarCreateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarCreateDTO.java
@@ -16,5 +16,4 @@ public class AlumnoFamiliarCreateDTO {
     Long familiarId;
     @NotBlank
     String rolVinculo;
-    boolean esTutorLegal;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarCreateDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarCreateDTO.java
@@ -16,4 +16,5 @@ public class AlumnoFamiliarCreateDTO {
     Long familiarId;
     @NotBlank
     String rolVinculo;
+    boolean convive;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarDTO.java
@@ -21,4 +21,5 @@ public class AlumnoFamiliarDTO {
     @NotBlank
     @Enumerated(EnumType.STRING)
     RolVinculo rolVinculo;
+    boolean convive;
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoFamiliarDTO.java
@@ -21,5 +21,4 @@ public class AlumnoFamiliarDTO {
     @NotBlank
     @Enumerated(EnumType.STRING)
     RolVinculo rolVinculo;
-    boolean esTutorLegal;
 }

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -68,6 +68,7 @@ type FamiliarConVinculo = FamiliarDTO & {
   parentesco?: string;
   _persona?: PersonaDTO | null;
   rolVinculo?: RolVinculo | null;
+  convive?: boolean;
 };
 
 type HistorialVM = {
@@ -208,6 +209,7 @@ export default function AlumnoPerfilPage() {
   const [addPersonaId, setAddPersonaId] = useState<number | null>(null);
   const [addFamiliarId, setAddFamiliarId] = useState<number | null>(null);
   const [addRol, setAddRol] = useState<RolVinculo | "">("");
+  const [addConvive, setAddConvive] = useState(false);
   const [savingFamily, setSavingFamily] = useState(false);
   const [familiaresCatalog, setFamiliaresCatalog] = useState<FamiliarDTO[]>([]);
 
@@ -365,6 +367,7 @@ export default function AlumnoPerfilPage() {
                   ...f,
                   parentesco: link.rolVinculo ?? undefined,
                   rolVinculo: link.rolVinculo ?? null,
+                  convive: Boolean(link.convive),
                   _persona: fp,
                 } as FamiliarConVinculo;
               } catch (error) {
@@ -474,6 +477,7 @@ export default function AlumnoPerfilPage() {
     setAddPersonaId(null);
     setAddFamiliarId(null);
     setAddRol("");
+    setAddConvive(false);
     setAddLookupLoading(false);
     setAddLookupCompleted(false);
     setSavingFamily(false);
@@ -916,6 +920,7 @@ export default function AlumnoPerfilPage() {
         alumnoId,
         familiarId,
         rolVinculo: addRol,
+        convive: addConvive,
       } as any);
 
       toast.success("Familiar agregado correctamente");
@@ -1508,7 +1513,7 @@ export default function AlumnoPerfilPage() {
                         )}
 
                         <Separator />
-                        <div className="grid gap-3">
+                        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_200px]">
                           <div className="space-y-2">
                             <Label>Rol familiar</Label>
                             <Select
@@ -1527,6 +1532,15 @@ export default function AlumnoPerfilPage() {
                                 ))}
                               </SelectContent>
                             </Select>
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            <Checkbox
+                              id="add-convive"
+                              checked={addConvive}
+                              onCheckedChange={(value) => setAddConvive(Boolean(value))}
+                              disabled={savingFamily || !addPersonaReady}
+                            />
+                            <Label htmlFor="add-convive">Convive</Label>
                           </div>
                         </div>
                       </div>
@@ -1583,6 +1597,7 @@ export default function AlumnoPerfilPage() {
                             {f.rolVinculo && (
                               <Badge variant="outline">{formatRol(f.rolVinculo)}</Badge>
                             )}
+                            {f.convive && <Badge variant="default">Convive</Badge>}
                           </div>
                         </div>
                         <Separator />

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -66,7 +66,6 @@ import { RolVinculo, UserRole } from "@/types/api-generated";
 
 type FamiliarConVinculo = FamiliarDTO & {
   parentesco?: string;
-  esTutorLegal?: boolean;
   _persona?: PersonaDTO | null;
   rolVinculo?: RolVinculo | null;
 };
@@ -209,7 +208,6 @@ export default function AlumnoPerfilPage() {
   const [addPersonaId, setAddPersonaId] = useState<number | null>(null);
   const [addFamiliarId, setAddFamiliarId] = useState<number | null>(null);
   const [addRol, setAddRol] = useState<RolVinculo | "">("");
-  const [addEsTutor, setAddEsTutor] = useState(false);
   const [savingFamily, setSavingFamily] = useState(false);
   const [familiaresCatalog, setFamiliaresCatalog] = useState<FamiliarDTO[]>([]);
 
@@ -366,7 +364,6 @@ export default function AlumnoPerfilPage() {
                 return {
                   ...f,
                   parentesco: link.rolVinculo ?? undefined,
-                  esTutorLegal: link.esTutorLegal ?? false,
                   rolVinculo: link.rolVinculo ?? null,
                   _persona: fp,
                 } as FamiliarConVinculo;
@@ -477,7 +474,6 @@ export default function AlumnoPerfilPage() {
     setAddPersonaId(null);
     setAddFamiliarId(null);
     setAddRol("");
-    setAddEsTutor(false);
     setAddLookupLoading(false);
     setAddLookupCompleted(false);
     setSavingFamily(false);
@@ -920,7 +916,6 @@ export default function AlumnoPerfilPage() {
         alumnoId,
         familiarId,
         rolVinculo: addRol,
-        esTutorLegal: addEsTutor,
       } as any);
 
       toast.success("Familiar agregado correctamente");
@@ -1513,7 +1508,7 @@ export default function AlumnoPerfilPage() {
                         )}
 
                         <Separator />
-                        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_200px]">
+                        <div className="grid gap-3">
                           <div className="space-y-2">
                             <Label>Rol familiar</Label>
                             <Select
@@ -1532,15 +1527,6 @@ export default function AlumnoPerfilPage() {
                                 ))}
                               </SelectContent>
                             </Select>
-                          </div>
-                          <div className="flex items-center space-x-2">
-                            <Checkbox
-                              id="add-es-tutor"
-                              checked={addEsTutor}
-                              onCheckedChange={(value) => setAddEsTutor(Boolean(value))}
-                              disabled={savingFamily || !addPersonaReady}
-                            />
-                            <Label htmlFor="add-es-tutor">Tutor legal</Label>
                           </div>
                         </div>
                       </div>
@@ -1596,9 +1582,6 @@ export default function AlumnoPerfilPage() {
                           <div className="flex flex-wrap items-center gap-2">
                             {f.rolVinculo && (
                               <Badge variant="outline">{formatRol(f.rolVinculo)}</Badge>
-                            )}
-                            {f.esTutorLegal && (
-                              <Badge variant="default">Tutor legal</Badge>
                             )}
                           </div>
                         </div>

--- a/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
@@ -555,9 +555,6 @@ export default function FamiliarPerfilPage() {
                             {link?.rolVinculo && (
                               <Badge variant="outline">{formatRol(link.rolVinculo)}</Badge>
                             )}
-                            {link?.esTutorLegal && (
-                              <Badge variant="default">Tutor legal</Badge>
-                            )}
                             <Button
                               variant="secondary"
                               onClick={() => router.push(`/dashboard/alumnos/${alumnoLite.alumnoId}`)}

--- a/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
@@ -555,6 +555,7 @@ export default function FamiliarPerfilPage() {
                             {link?.rolVinculo && (
                               <Badge variant="outline">{formatRol(link.rolVinculo)}</Badge>
                             )}
+                            {link?.convive && <Badge variant="default">Convive</Badge>}
                             <Button
                               variant="secondary"
                               onClick={() => router.push(`/dashboard/alumnos/${alumnoLite.alumnoId}`)}


### PR DESCRIPTION
## Summary
- remove the "Tutor legal" checkbox and badge from the student and family dashboards when managing relatives
- stop sending the legal guardian flag when creating alumno-familiar links on the frontend
- drop the backend DTO field and mapstruct mappings for the legal guardian flag, defaulting new links to convive=false

## Testing
- `./mvnw test` *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f1a034f88327a628b453b50d8910