### PR TITLE
Center convive checkbox in add family modal

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -1675,7 +1675,7 @@ export default function AlumnoPerfilPage() {
                               </SelectContent>
                             </Select>
                           </div>
-                          <div className="flex items-center space-x-2">
+                          <div className="flex items-center justify-center gap-2 md:justify-start md:place-self-center">
                             <Checkbox
                               id="add-convive"
                               checked={addConvive}


### PR DESCRIPTION
## Summary
- center the Convive checkbox and label within the add family modal grid layout for better visual alignment

## Testing
- not run (npm install blocked by registry access restrictions)

------
https://chatgpt.com/codex/tasks/task_e_68d6f75aa0a08327b045d3e1141a0157