### PR TITLE
Fix light mode postulacion background

### DIFF
--- a/frontend-ecep/src/app/postulacion/page.tsx
+++ b/frontend-ecep/src/app/postulacion/page.tsx
@@ -911,7 +911,7 @@ export default function PostulacionPage() {
 
   return (
     <div
-      className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900 p-4 transition-colors"
+      className="min-h-screen bg-background dark:bg-gradient-to-br dark:from-slate-950 dark:via-slate-950 dark:to-slate-900 p-4 transition-colors"
     >
       <div className="max-w-4xl mx-auto space-y-6">
         <Button variant="outline" asChild>


### PR DESCRIPTION
## Summary
- replace the postulacion page light theme gradient with the standard background color so it renders as pure white
- keep the dark theme gradient styling unchanged

## Testing
- `pnpm lint` *(fails: next binary missing because dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f845439883279cffca36347311b4