### PR TITLE
Add API and UI flow to disable alumno credentials

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/PersonaController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/PersonaController.java
@@ -26,6 +26,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -161,6 +162,18 @@ public class PersonaController {
         }
 
         personaRepository.save(entity);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{personaId}/credenciales")
+    @PreAuthorize("hasAnyRole('ADMIN','DIRECTOR','SECRETARY','COORDINATOR')")
+    public ResponseEntity<Void> disableCredentials(@PathVariable Long personaId) {
+        Persona entity = personaRepository.findById(personaId)
+                .orElseThrow(() -> new NotFoundException("Persona no encontrada"));
+
+        entity.setPassword(null);
+        personaRepository.save(entity);
+
         return ResponseEntity.noContent().build();
     }
 

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -909,6 +909,36 @@ export default function AlumnoPerfilPage() {
     }
   };
 
+  const handleDisableCredentials = async () => {
+    if (!persona?.id) {
+      toast.error("No encontramos la persona vinculada al alumno");
+      return;
+    }
+
+    setSavingCredentials(true);
+    try {
+      await identidad.personasCore.disableCredentials(persona.id);
+      const { data: refreshed } = await identidad.personasCore.getById(persona.id);
+      setPersona(refreshed ?? null);
+      toast.success("Acceso del alumno desactivado");
+      setCredentialsForm({
+        email: refreshed?.email ?? "",
+        password: "",
+        confirmPassword: "",
+        roles: normalizeRoles(refreshed?.roles ?? []),
+      });
+    } catch (error: any) {
+      console.error(error);
+      toast.error(
+        error?.response?.data?.message ??
+          error?.message ??
+          "No pudimos desactivar el acceso del alumno",
+      );
+    } finally {
+      setSavingCredentials(false);
+    }
+  };
+
   const handleSaveFamily = async () => {
     if (!alumno) return;
 

--- a/frontend-ecep/src/services/api/modules/identidad/personas-core.ts
+++ b/frontend-ecep/src/services/api/modules/identidad/personas-core.ts
@@ -19,6 +19,8 @@ export const personasCore = {
   getById: (id: number) => http.get<DTO.PersonaDTO>(`/api/personas/${id}`),
   update: (id: number, patch: Partial<DTO.PersonaUpdateDTO>) =>
     http.put<void>(`/api/personas/${id}`, patch),
+  disableCredentials: (id: number) =>
+    http.delete<void>(`/api/personas/${id}/credenciales`),
   getResumen: (id: number) =>
     http.get<DTO.PersonaResumenDTO>(`/api/personas/credenciales/${id}`),
   searchCredenciales: (q?: string) =>


### PR DESCRIPTION
## Summary
- add a backend endpoint to disable persona credentials by clearing the stored password
- expose the disable endpoint in the personas API client and refresh persona data after calling it
- wire the alumno profile "Desactivar acceso" button to the new endpoint and reset the credential form

## Testing
- ./mvnw test *(fails in container: unable to download Maven distribution from repo.maven.apache.org)*
- npm run lint *(fails in container: Next.js CLI not available because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fa8e6e1083279eb0a1df2a91d4da