### PR TITLE
Improve green accents for readability

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -851,10 +851,10 @@ export default function AccidentesIndexPage() {
               <CardTitle className="text-sm font-medium">
                 Actas firmadas
               </CardTitle>
-              <CheckCircle className="h-4 w-4 text-green-600" />
+              <CheckCircle className="h-4 w-4 text-secondary" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-green-600">
+              <div className="text-2xl font-bold text-secondary">
                 {firmadas}
               </div>
               <p className="text-xs text-muted-foreground">

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
@@ -34,18 +34,18 @@ const attendancePriority: Record<AttendanceCategory, number> = {
 
 const calendarModifierClassNames: Record<AttendanceCategory, string> = {
   present:
-    "bg-emerald-500/15 text-emerald-700 hover:bg-emerald-500/20 focus:bg-emerald-500/20",
+    "bg-secondary/20 text-secondary hover:bg-secondary/25 focus:bg-secondary/25 dark:text-secondary-foreground dark:hover:bg-secondary/30 dark:focus:bg-secondary/30",
   absent:
     "bg-red-500/15 text-red-700 hover:bg-red-500/20 focus:bg-red-500/20",
 };
 
 const calendarLegend: { key: AttendanceCategory; label: string; dotClass: string }[] = [
-  { key: "present", label: "Presente", dotClass: "bg-emerald-500/70" },
+  { key: "present", label: "Presente", dotClass: "bg-secondary" },
   { key: "absent", label: "Ausente", dotClass: "bg-red-500/70" },
 ];
 
 const calendarDayBadge: Record<AttendanceCategory, { text: string; className: string }> = {
-  present: { text: "Presente", className: "bg-emerald-100 text-emerald-700" },
+  present: { text: "Presente", className: "bg-secondary text-secondary-foreground" },
   absent: { text: "Ausente", className: "bg-red-100 text-red-700" },
 };
 
@@ -621,7 +621,7 @@ export function FamilyAttendanceView() {
                     </div>
                     <div className="flex-1 space-y-3 text-sm">
                       <div className="flex items-center gap-2">
-                        <CheckCircle className="h-4 w-4 text-green-600" />
+                        <CheckCircle className="h-4 w-4 text-secondary" />
                         <span className="font-medium">
                           Presentes: {resumen.presentes}
                         </span>

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaConsultaAlumno.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaConsultaAlumno.tsx
@@ -87,7 +87,7 @@ export default function VistaConsultaAlumno() {
           </div>
           <div className="space-y-2 text-sm">
             <div className="flex items-center gap-2">
-              <CheckCircle className="h-4 w-4 text-green-600" />
+              <CheckCircle className="h-4 w-4 text-secondary" />
               <span>{presentes} presentes</span>
             </div>
             <div className="flex items-center gap-2">

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -783,7 +783,7 @@ export default function CierrePrimarioView({
                                   </div>
                                   <div className="h-2 overflow-hidden rounded-full bg-muted">
                                     <div
-                                      className="h-full bg-emerald-500"
+                                      className="h-full bg-secondary"
                                       style={{ width: `${row.safeAttendancePercent}%` }}
                                     />
                                   </div>
@@ -901,7 +901,7 @@ export default function CierrePrimarioView({
                             </div>
                             <div className="h-2 overflow-hidden rounded-full bg-muted">
                               <div
-                                className="h-full bg-emerald-500"
+                                className="h-full bg-secondary"
                                 style={{ width: `${row.safeAttendancePercent}%` }}
                               />
                             </div>

--- a/frontend-ecep/src/app/dashboard/chat/page.tsx
+++ b/frontend-ecep/src/app/dashboard/chat/page.tsx
@@ -396,7 +396,7 @@ export default function ChatComponent() {
         );
       case "connected":
         return (
-          <div className="flex items-center gap-2 text-green-600">
+          <div className="flex items-center gap-2 text-secondary">
             <Wifi className="h-4 w-4" />
             <span className="text-sm">Conectado</span>
           </div>

--- a/frontend-ecep/src/app/dashboard/page.tsx
+++ b/frontend-ecep/src/app/dashboard/page.tsx
@@ -78,7 +78,7 @@ export default function DashboardPage() {
             <CardContent>
               <div className="text-2xl font-bold">{stats?.alumnosActivos}</div>
               <p className="text-xs text-muted-foreground">
-                <span className="text-green-600 inline-flex items-center">
+                <span className="text-secondary inline-flex items-center">
                   <TrendingUp className="h-3 w-3 mr-1" />
                   {loadingStats ? "actualizando…" : "en período vigente"}
                 </span>

--- a/frontend-ecep/src/app/globals.css
+++ b/frontend-ecep/src/app/globals.css
@@ -11,8 +11,8 @@
   --popover-foreground: 222.2 84% 4.9%;
   --primary: 210 90% 58%;
   --primary-foreground: 210 40% 98%;
-  --secondary: 142 69% 58%;
-  --secondary-foreground: 142 40% 98%;
+  --secondary: 150 60% 32%;
+  --secondary-foreground: 0 0% 100%;
   --muted: 210 40% 98%;
   --muted-foreground: 215.4 16.3% 46.9%;
   --accent: 210 40% 98%;
@@ -34,8 +34,8 @@
   --popover-foreground: 210 40% 98%;
   --primary: 210 90% 58%;
   --primary-foreground: 210 40% 98%;
-  --secondary: 142 69% 58%;
-  --secondary-foreground: 142 40% 98%;
+  --secondary: 150 58% 33%;
+  --secondary-foreground: 0 0% 100%;
   --muted: 217.2 32.6% 17.5%;
   --muted-foreground: 215 20.2% 65.1%;
   --accent: 217.2 32.6% 17.5%;

--- a/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
+++ b/frontend-ecep/src/components/trimestres/TrimestreEstadoBadge.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 
 const CIRCLE_STYLES: Record<TrimestreEstado, string> = {
   activo:
-    "bg-emerald-100 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200",
+    "bg-secondary/20 text-secondary dark:bg-secondary/25 dark:text-secondary-foreground",
   inactivo: "bg-muted text-muted-foreground dark:bg-muted dark:text-muted-foreground",
   cerrado: "bg-red-100 text-red-500 dark:bg-red-500/20 dark:text-red-300",
 };

--- a/frontend-ecep/src/lib/menu.ts
+++ b/frontend-ecep/src/lib/menu.ts
@@ -33,7 +33,7 @@ export const MENU: MenuItem[] = [
     icon: MessageSquare,
     label: "Chat",
     href: "/dashboard/chat",
-    color: "bg-green-500",
+    color: "bg-secondary",
     group: "primary",
   },
   {


### PR DESCRIPTION
## Summary
- darken the secondary color palette so secondary badges and controls have stronger contrast in light and dark themes
- update green status indicators, calendars, and progress bars to consume the refreshed secondary palette for consistent legibility

## Testing
- bun run lint *(fails: `next` command unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d704cb31248327a8621a245c3ee9ba