### PR TITLE
Propagate aspirante family ties during alta

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionAltaDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionAltaDTO.java
@@ -1,0 +1,15 @@
+package edu.ecep.base_app.admisiones.presentation.dto;
+
+import edu.ecep.base_app.shared.domain.enums.Turno;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SolicitudAdmisionAltaDTO {
+    private Long seccionId;
+    private Turno turno;
+}
+

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionAltaResultDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/dto/SolicitudAdmisionAltaResultDTO.java
@@ -1,0 +1,15 @@
+package edu.ecep.base_app.admisiones.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SolicitudAdmisionAltaResultDTO {
+    private Long alumnoId;
+    private Long matriculaId;
+    private Long seccionId;
+}
+

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/SolicitudAdmisionController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/SolicitudAdmisionController.java
@@ -60,4 +60,11 @@ public class SolicitudAdmisionController {
         service.decidir(id, dto);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{id}/alta")
+    public ResponseEntity<SolicitudAdmisionAltaResultDTO> darDeAlta(
+            @PathVariable Long id,
+            @RequestBody @Valid SolicitudAdmisionAltaDTO dto) {
+        return ResponseEntity.ok(service.darDeAlta(id, dto));
+    }
 }

--- a/frontend-ecep/src/services/api/modules/admisiones/index.ts
+++ b/frontend-ecep/src/services/api/modules/admisiones/index.ts
@@ -49,6 +49,11 @@ const solicitudesAdmision = {
     http.post<void>(`/api/solicitudes-admision/${id}/entrevista`, body),
   decidir: (id: number, body: DTO.SolicitudAdmisionDecisionDTO) =>
     http.post<void>(`/api/solicitudes-admision/${id}/decision`, body),
+  alta: (id: number, body: DTO.SolicitudAdmisionAltaDTO) =>
+    http.post<DTO.SolicitudAdmisionAltaResultDTO>(
+      `/api/solicitudes-admision/${id}/alta`,
+      body,
+    ),
 };
 
 export const admisiones = {

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -836,6 +836,17 @@ export interface SolicitudAdmisionDecisionDTO {
   mensaje?: string;
 }
 
+export interface SolicitudAdmisionAltaDTO {
+  seccionId?: number;
+  turno?: Turno;
+}
+
+export interface SolicitudAdmisionAltaResultDTO {
+  alumnoId?: number;
+  matriculaId?: number;
+  seccionId?: number;
+}
+
 export interface SolicitudBajaAlumnoCreateDTO {
   id?: number;
   matriculaId?: number;


### PR DESCRIPTION
## Summary
- ensure the dar-de-alta workflow also migrates each aspirante familiar into AlumnoFamiliar vínculos when creating or reusing the alumno
- update the alta service to reuse existing vínculos when present and refresh their convive/rol information while keeping matricula creation logic unchanged

## Testing
- ./mvnw test *(fails: wget cannot download Maven distribution in the offline environment)*
- bun run lint *(fails: Next.js CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70d33c69483279a4535c70f924f0d