### PR TITLE
Add manual action to mark admission interview as completed

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
@@ -889,6 +889,15 @@ function SolicitudDetailDialog({
             )}
 
             <div className="flex flex-wrap gap-2 pt-2">
+              {estado === ESTADOS.PROGRAMADA && (
+                <Button
+                  variant="secondary"
+                  onClick={() => handleResultadoEntrevista(true)}
+                  disabled={loading}
+                >
+                  Marcar entrevista realizada
+                </Button>
+              )}
               {puedeDarDeAlta && (
                 <Button onClick={handleDarDeAlta}>Dar de alta</Button>
               )}

--- a/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
@@ -335,6 +335,22 @@ export default function AspirantesTab({ searchTerm }: Props) {
     }
   }, [detailOpen, selected]);
 
+  useEffect(() => {
+    if (!detailOpen || !selected) return;
+    const next = solicitudes.find((item) => item.id === selected.id);
+    if (next && next !== selected) {
+      setSelected(next);
+    }
+  }, [detailOpen, selected, solicitudes]);
+
+  useEffect(() => {
+    if (!altaOpen || !altaSolicitud) return;
+    const next = solicitudes.find((item) => item.id === altaSolicitud.id);
+    if (next && next !== altaSolicitud) {
+      setAltaSolicitud(next);
+    }
+  }, [altaOpen, altaSolicitud, solicitudes]);
+
   if (loading) {
     return <LoadingState label="Cargando solicitudes…" />;
   }


### PR DESCRIPTION
## Summary
- add a manual control in the admission request dialog to mark the interview as completed so the enrollment flow can continue

## Testing
- npm run lint *(fails: next not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d7668f21a883279acea37609f7ee1f