### PR TITLE
Fix DTO import usage in aspirantes tabs

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
@@ -57,7 +57,7 @@ import {
   X,
   Loader2,
 } from "lucide-react";
-import type * as DTO from "@/types/api-generated";
+import * as DTO from "@/types/api-generated";
 import { admisiones, gestionAcademica, identidad } from "@/services/api/modules";
 
 const ESTADOS = {


### PR DESCRIPTION
## Summary
- switch the DTO namespace import in the aspirantes tabs component to a runtime import so the Turno enum is available when formatting labels

## Testing
- npm install *(fails: registry access returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d76b1664208327afba4f92a5a2848b