### PR TITLE
Fix syntax error in AspirantesTabs

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
@@ -433,8 +433,6 @@ export default function AspirantesTab({ searchTerm }: Props) {
   );
 }
 
-}
-
 type AltaModalProps = {
   open: boolean;
   solicitud: SolicitudAdmisionItem;


### PR DESCRIPTION
## Summary
- remove the stray closing brace left after the AspirantesTab component to restore valid syntax

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7eb837e048327b36045a8bba30ac8