### PR TITLE
Fix admission request detail error handling

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/solicitudes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/solicitudes/[id]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import LoadingState from "@/components/common/LoadingState";
 import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   Card,
   CardContent,
@@ -244,7 +245,7 @@ export default function SolicitudAdmisionDetailPage() {
       setComentariosEntrevista(enriched.comentariosEntrevista ?? "");
     } catch (err: any) {
       setSolicitud(null);
-      setError(err?.message ?? "No se pudo obtener la solicitud");
+      setError(err?.message ?? "No se pudo obtener la solicitud.");
     } finally {
       setLoading(false);
     }
@@ -589,15 +590,15 @@ export default function SolicitudAdmisionDetailPage() {
   if (error) {
     return (
       <div className="space-y-4 p-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Error al cargar la solicitud</CardTitle>
-            <CardDescription>{error}</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button onClick={fetchSolicitud}>Reintentar</Button>
-          </CardContent>
-        </Card>
+        <Alert variant="destructive">
+          <AlertTitle>Error al cargar la solicitud</AlertTitle>
+          <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            {error}
+            <Button type="button" variant="outline" size="sm" onClick={fetchSolicitud}>
+              Reintentar
+            </Button>
+          </AlertDescription>
+        </Alert>
       </div>
     );
   }

--- a/frontend-ecep/src/services/api/modules/admisiones/index.ts
+++ b/frontend-ecep/src/services/api/modules/admisiones/index.ts
@@ -22,10 +22,13 @@ const aspiranteFamiliares = {
   delete: (id: number) => http.delete<void>(`/api/aspirante-familiar/${id}`),
 };
 
+const getSolicitudAdmisionById = (id: number) =>
+  http.get<DTO.SolicitudAdmisionDTO>(`/api/solicitudes-admision/${id}`);
+
 const solicitudesAdmision = {
   list: () => http.get<DTO.SolicitudAdmisionDTO[]>("/api/solicitudes-admision"),
-  byId: (id: number) =>
-    http.get<DTO.SolicitudAdmisionDTO>("/api/solicitudes-admision/" + id),
+  getById: getSolicitudAdmisionById,
+  byId: getSolicitudAdmisionById,
   create: (body: Omit<DTO.SolicitudAdmisionDTO, "id">) =>
     http.post<number>("/api/solicitudes-admision", body),
   update: (id: number, body: Partial<DTO.SolicitudAdmisionDTO>) =>


### PR DESCRIPTION
## Summary
- add a destructive alert to show admission request loading errors with a retry action
- expose solicitudesAdmision.getById so the detail view can fetch a request without crashing

## Testing
- npm run lint *(fails: next binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7eca82774832789ae891af6a72027