### PR TITLE
Implement email sending for admission workflow

### DIFF
--- a/backend-ecep/pom.xml
+++ b/backend-ecep/pom.xml
@@ -96,6 +96,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.32</version>

--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/notification/EmailService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/notification/EmailService.java
@@ -1,0 +1,50 @@
+package edu.ecep.base_app.shared.notification;
+
+import jakarta.mail.MessagingException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.NonNull;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${app.notifications.mail.enabled:true}")
+    private boolean enabled;
+
+    @Value("${app.notifications.mail.from:}")
+    private String defaultFrom;
+
+    public void sendPlainText(@NonNull String to, @NonNull String subject, @NonNull String body)
+            throws MessagingException, MailException {
+        if (!enabled) {
+            log.info("[EMAIL][DISABLED] to={} subject={}", to, subject);
+            return;
+        }
+        if (!StringUtils.hasText(to)) {
+            throw new IllegalArgumentException("El destinatario del correo es obligatorio");
+        }
+
+        var message = mailSender.createMimeMessage();
+        var helper = new MimeMessageHelper(message, false, StandardCharsets.UTF_8.name());
+        helper.setTo(to);
+        helper.setSubject(subject);
+        helper.setText(body, false);
+        if (StringUtils.hasText(defaultFrom)) {
+            helper.setFrom(defaultFrom);
+        }
+
+        mailSender.send(message);
+        log.info("[EMAIL][SENT] to={} subject={}", to, subject);
+    }
+}

--- a/backend-ecep/src/main/resources/application.yml
+++ b/backend-ecep/src/main/resources/application.yml
@@ -34,6 +34,18 @@ spring:
           min-idle: 0
         shutdown-timeout: 100ms
 
+  mail:
+    host: ${SPRING_MAIL_HOST:localhost}
+    port: ${SPRING_MAIL_PORT:1025}
+    username: ${SPRING_MAIL_USERNAME:}
+    password: ${SPRING_MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: ${SPRING_MAIL_SMTP_AUTH:false}
+          starttls:
+            enable: ${SPRING_MAIL_SMTP_STARTTLS_ENABLE:false}
+
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
 
@@ -51,6 +63,12 @@ springdoc:
 jwt:
   secret: secretClaveMuySegura123456789012345678901234567890
   expiration: 86400000
+
+app:
+  notifications:
+    mail:
+      enabled: ${APP_NOTIFICATIONS_MAIL_ENABLED:true}
+      from: ${APP_NOTIFICATIONS_MAIL_FROM:notificaciones@ecep.edu.ar}
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- add a shared email service backed by Spring's JavaMailSender
- wire admission notifications to the new email service and persist when the first email is sent
- expose mail configuration defaults in application.yml and include the starter dependency

## Testing
- ./mvnw test *(fails: Maven wrapper cannot download Maven distribution without external network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ec1661ac8327b52c644fe994b47e