### PR TITLE
Update toast success icon

### DIFF
--- a/frontend-ecep/src/components/ui/sonner.tsx
+++ b/frontend-ecep/src/components/ui/sonner.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from 'next-themes';
 import { Toaster as Sonner } from 'sonner';
+import { CircleCheck } from 'lucide-react';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
@@ -21,6 +22,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
             'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton:
             'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+        },
+        icons: {
+          success: <CircleCheck className="h-5 w-5 text-primary" />,
         },
       }}
       {...props}


### PR DESCRIPTION
## Summary
- replace the Sonner toast success icon with lucide-react's CircleCheck to match the desired symbol

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7fcbe13188327936672d859ba4b2c