### PR TITLE
Harden solicitudes filtering and expose client params

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/application/SolicitudAdmisionService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/application/SolicitudAdmisionService.java
@@ -44,7 +44,6 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Sort;
 import org.springframework.mail.MailException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,10 +74,16 @@ public class SolicitudAdmisionService {
     private final EmailService emailService;
 
     public List<SolicitudAdmisionDTO> findAll() {
-        return repository.findAll(Sort.by(Sort.Direction.DESC, "dateCreated"))
-                .stream()
-                .map(this::toDto)
-                .toList();
+        return findAll(null);
+    }
+
+    public List<SolicitudAdmisionDTO> findAll(Long aspiranteId) {
+        List<SolicitudAdmision> solicitudes =
+                aspiranteId == null
+                        ? repository.findAll(SolicitudAdmisionRepository.DEFAULT_SORT)
+                        : repository.findAllByAspiranteId(aspiranteId, SolicitudAdmisionRepository.DEFAULT_SORT);
+
+        return solicitudes.stream().map(this::toDto).toList();
     }
 
     public SolicitudAdmisionDTO get(Long id) {

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/infrastructure/persistence/SolicitudAdmisionRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/infrastructure/persistence/SolicitudAdmisionRepository.java
@@ -3,17 +3,22 @@ package edu.ecep.base_app.admisiones.infrastructure.persistence;
 import edu.ecep.base_app.admisiones.domain.SolicitudAdmision;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.domain.Sort;
 
 public interface SolicitudAdmisionRepository extends JpaRepository<SolicitudAdmision, Long> {
 
     boolean existsByAspiranteId(Long id);
 
+    Sort DEFAULT_SORT = Sort.by(Sort.Direction.DESC, "dateCreated");
+
     @Override
     @EntityGraph(attributePaths = {"aspirante", "aspirante.persona"})
     List<SolicitudAdmision> findAll(Sort sort);
+
+    @EntityGraph(attributePaths = {"aspirante", "aspirante.persona"})
+    List<SolicitudAdmision> findAllByAspiranteId(Long aspiranteId, Sort sort);
 
     @Override
     @EntityGraph(attributePaths = {"aspirante", "aspirante.persona"})

--- a/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/SolicitudAdmisionController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/admisiones/presentation/rest/SolicitudAdmisionController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 
 @RestController
@@ -18,11 +19,34 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 public class SolicitudAdmisionController {
     private final SolicitudAdmisionService service;
-    @GetMapping public List<SolicitudAdmisionDTO> list(){ return service.findAll(); }
-    @GetMapping("/{id}") public SolicitudAdmisionDTO get(@PathVariable Long id){ return service.get(id); }
-    @PostMapping public ResponseEntity<Long> create(@RequestBody @Valid SolicitudAdmisionDTO dto){ return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED); }
-    @PutMapping("/{id}") public ResponseEntity<Void> update(@PathVariable Long id, @RequestBody @Valid SolicitudAdmisionDTO dto){ service.update(id, dto); return ResponseEntity.noContent().build(); }
-    @DeleteMapping("/{id}") public ResponseEntity<Void> delete(@PathVariable Long id){ service.delete(id); return ResponseEntity.noContent().build(); }
+    @GetMapping
+    public List<SolicitudAdmisionDTO> list(
+            @RequestParam(name = "aspiranteId", required = false) String aspiranteIdParam) {
+        Long aspiranteId = parseLongOrNull(aspiranteIdParam);
+        return service.findAll(aspiranteId);
+    }
+
+    @GetMapping("/{id}")
+    public SolicitudAdmisionDTO get(@PathVariable Long id) {
+        return service.get(id);
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> create(@RequestBody @Valid SolicitudAdmisionDTO dto) {
+        return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable Long id, @RequestBody @Valid SolicitudAdmisionDTO dto) {
+        service.update(id, dto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 
     @PostMapping("/{id}/rechazar")
     public ResponseEntity<Void> rechazar(@PathVariable Long id, @RequestBody @Valid SolicitudAdmisionRechazoDTO dto) {
@@ -37,8 +61,8 @@ public class SolicitudAdmisionController {
     }
 
     @PostMapping("/{id}/reprogramar")
-    public ResponseEntity<Void> solicitarReprogramacion(@PathVariable Long id,
-            @RequestBody @Valid SolicitudAdmisionReprogramacionDTO dto) {
+    public ResponseEntity<Void> solicitarReprogramacion(
+            @PathVariable Long id, @RequestBody @Valid SolicitudAdmisionReprogramacionDTO dto) {
         service.solicitarReprogramacion(id, dto);
         return ResponseEntity.noContent().build();
     }
@@ -50,7 +74,8 @@ public class SolicitudAdmisionController {
     }
 
     @PostMapping("/{id}/entrevista")
-    public ResponseEntity<Void> registrarEntrevista(@PathVariable Long id, @RequestBody @Valid SolicitudAdmisionEntrevistaDTO dto) {
+    public ResponseEntity<Void> registrarEntrevista(
+            @PathVariable Long id, @RequestBody @Valid SolicitudAdmisionEntrevistaDTO dto) {
         service.registrarEntrevista(id, dto);
         return ResponseEntity.noContent().build();
     }
@@ -63,8 +88,22 @@ public class SolicitudAdmisionController {
 
     @PostMapping("/{id}/alta")
     public ResponseEntity<SolicitudAdmisionAltaResultDTO> darDeAlta(
-            @PathVariable Long id,
-            @RequestBody @Valid SolicitudAdmisionAltaDTO dto) {
+            @PathVariable Long id, @RequestBody @Valid SolicitudAdmisionAltaDTO dto) {
         return ResponseEntity.ok(service.darDeAlta(id, dto));
+    }
+
+    private Long parseLongOrNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.valueOf(trimmed);
+        } catch (NumberFormatException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "aspiranteId inválido", ex);
+        }
     }
 }

--- a/frontend-ecep/src/services/api/modules/admisiones/index.ts
+++ b/frontend-ecep/src/services/api/modules/admisiones/index.ts
@@ -25,8 +25,14 @@ const aspiranteFamiliares = {
 const getSolicitudAdmisionById = (id: number) =>
   http.get<DTO.SolicitudAdmisionDTO>(`/api/solicitudes-admision/${id}`);
 
+const fetchSolicitudesAdmision = (params?: { aspiranteId?: number | null }) =>
+  http.get<DTO.SolicitudAdmisionDTO[]>("/api/solicitudes-admision", {
+    params:
+      params?.aspiranteId != null ? { aspiranteId: params.aspiranteId } : undefined,
+  });
+
 const solicitudesAdmision = {
-  list: () => http.get<DTO.SolicitudAdmisionDTO[]>("/api/solicitudes-admision"),
+  list: fetchSolicitudesAdmision,
   getById: getSolicitudAdmisionById,
   byId: getSolicitudAdmisionById,
   create: (body: Omit<DTO.SolicitudAdmisionDTO, "id">) =>
@@ -35,9 +41,7 @@ const solicitudesAdmision = {
     http.put<void>("/api/solicitudes-admision/" + id, body),
   delete: (id: number) => http.delete<void>("/api/solicitudes-admision/" + id),
   byAspiranteId: (aspiranteId: number) =>
-    http.get<DTO.SolicitudAdmisionDTO[]>("/api/solicitudes-admision", {
-      params: { aspiranteId },
-    }),
+    fetchSolicitudesAdmision({ aspiranteId }),
   rechazar: (id: number, body: DTO.SolicitudAdmisionRechazoDTO) =>
     http.post<void>(`/api/solicitudes-admision/${id}/rechazar`, body),
   programar: (id: number, body: DTO.SolicitudAdmisionProgramarDTO) =>


### PR DESCRIPTION
## Summary
- normalize aspiranteId query parsing in the solicitudes controller so blank values are ignored and invalid ones yield a clear 400 error
- expose optional query parameters in the frontend solicitudes API helper and reuse the shared helper for aspirante-specific lookups

## Testing
- ./mvnw -q test *(fails: Maven distribution download is blocked in the execution environment)*
- npm run lint *(fails: Next.js CLI is unavailable because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fbf25e9483279bc3cb5bfa32879b