### PR TITLE
Switch dashboard indicators to CircleCheck icon

### DIFF
--- a/frontend-ecep/src/app/dashboard/actas/page.tsx
+++ b/frontend-ecep/src/app/dashboard/actas/page.tsx
@@ -24,7 +24,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   Search,
   FileText,
-  CheckCircle,
+  CircleCheck,
   AlertTriangle,
   Eye,
   Download,
@@ -855,7 +855,7 @@ export default function AccidentesIndexPage() {
               <CardTitle className="text-sm font-medium">
                 Actas firmadas
               </CardTitle>
-              <CheckCircle className="h-4 w-4 text-secondary" />
+              <CircleCheck className="h-4 w-4 text-secondary" />
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold text-secondary">

--- a/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/_components/AspirantesTabs.tsx
@@ -22,7 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Calendar, CheckCircle, Clock, ChevronLeft, ChevronRight, Loader2, X } from "lucide-react";
+import { Calendar, CircleCheck, Clock, ChevronLeft, ChevronRight, Loader2, X } from "lucide-react";
 import * as DTO from "@/types/api-generated";
 import { admisiones, gestionAcademica, identidad } from "@/services/api/modules";
 
@@ -79,7 +79,7 @@ const estadoBadge = (estado?: string | null) => {
   if (e === ESTADOS.ENTREVISTA_REALIZADA || e === ESTADOS.ACEPTADA) {
     return (
       <Badge variant="default" className="gap-1">
-        <CheckCircle className="h-3 w-3" /> {e === ESTADOS.ACEPTADA ? "Aceptada" : "Entrevista"}
+        <CircleCheck className="h-3 w-3" /> {e === ESTADOS.ACEPTADA ? "Aceptada" : "Entrevista"}
       </Badge>
     );
   }

--- a/frontend-ecep/src/app/dashboard/alumnos/solicitudes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/solicitudes/[id]/page.tsx
@@ -29,7 +29,7 @@ import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Calendar, CalendarDays, CheckCircle, Clock, FileText, Mail, Phone, RefreshCw, StickyNote, X, ArrowLeft } from "lucide-react";
+import { Calendar, CalendarDays, CircleCheck, Clock, FileText, Mail, Phone, RefreshCw, StickyNote, X, ArrowLeft } from "lucide-react";
 import * as DTO from "@/types/api-generated";
 import { admisiones, identidad } from "@/services/api/modules";
 import { AltaModal } from "../../_components/AspirantesTabs";
@@ -87,7 +87,7 @@ const estadoBadge = (estado?: string | null) => {
   if (e === ESTADOS.ENTREVISTA_REALIZADA || e === ESTADOS.ACEPTADA) {
     return (
       <Badge variant="default" className="gap-1">
-        <CheckCircle className="h-3 w-3" />
+        <CircleCheck className="h-3 w-3" />
         {e === ESTADOS.ACEPTADA ? "Aceptada" : "Entrevista"}
       </Badge>
     );
@@ -955,7 +955,7 @@ function Timeline({ items }: { items: TimelineItem[] }) {
                 className={`flex h-8 w-8 items-center justify-center rounded-full border text-sm ${TIMELINE_VARIANTS[item.status]}`}
               >
                 {item.status === "done" ? (
-                  <CheckCircle className="h-4 w-4" />
+                  <CircleCheck className="h-4 w-4" />
                 ) : item.status === "current" ? (
                   <Clock className="h-4 w-4" />
                 ) : item.status === "skipped" ? (

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
@@ -22,7 +22,7 @@ import type {
   NivelAcademico,
 } from "@/types/api-generated";
 import { NivelAcademico as NivelAcademicoEnum, UserRole } from "@/types/api-generated";
-import { CheckCircle, X } from "lucide-react";
+import { CircleCheck, X } from "lucide-react";
 import type { DayContentProps } from "react-day-picker";
 
 type AttendanceCategory = "present" | "absent";
@@ -621,7 +621,7 @@ export function FamilyAttendanceView() {
                     </div>
                     <div className="flex-1 space-y-3 text-sm">
                       <div className="flex items-center gap-2">
-                        <CheckCircle className="h-4 w-4 text-secondary" />
+                        <CircleCheck className="h-4 w-4 text-secondary" />
                         <span className="font-medium">
                           Presentes: {resumen.presentes}
                         </span>

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/VistaConsultaAlumno.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/VistaConsultaAlumno.tsx
@@ -9,7 +9,7 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { CheckCircle, X } from "lucide-react";
+import { CircleCheck, X } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { useAsistenciasData } from "@/hooks/useAsistenciasData";
 
@@ -87,7 +87,7 @@ export default function VistaConsultaAlumno() {
           </div>
           <div className="space-y-2 text-sm">
             <div className="flex items-center gap-2">
-              <CheckCircle className="h-4 w-4 text-secondary" />
+              <CircleCheck className="h-4 w-4 text-secondary" />
               <span>{presentes} presentes</span>
             </div>
             <div className="flex items-center gap-2">

--- a/frontend-ecep/src/app/dashboard/page.tsx
+++ b/frontend-ecep/src/app/dashboard/page.tsx
@@ -18,7 +18,7 @@ import {
   Ambulance,
   Bell,
   TrendingUp,
-  CheckCircle,
+  CircleCheck,
 } from "lucide-react";
 import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
@@ -97,7 +97,7 @@ export default function DashboardPage() {
               <div className="text-2xl font-bold">{stats?.docentesActivos}</div>
               <p className="text-xs text-muted-foreground">
                 <span className="text-blue-600 inline-flex items-center">
-                  <CheckCircle className="h-3 w-3 mr-1" />
+                  <CircleCheck className="h-3 w-3 mr-1" />
                   con asignación vigente
                 </span>
               </p>

--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -41,7 +41,7 @@ import { Label } from "@/components/ui/label";
 import {
   AlertCircle,
   Calendar,
-  CheckCircle,
+  CircleCheck,
   DollarSign,
   Download,
   FileText,
@@ -1257,7 +1257,7 @@ export default function PagosPage() {
                               )
                             }
                           >
-                            <CheckCircle className="mr-2 h-4 w-4" /> Acreditar
+                            <CircleCheck className="mr-2 h-4 w-4" /> Acreditar
                           </Button>
                           <Button
                             size="sm"

--- a/frontend-ecep/src/app/dashboard/personal/page.tsx
+++ b/frontend-ecep/src/app/dashboard/personal/page.tsx
@@ -112,7 +112,7 @@ import {
   Calendar,
   ChevronDown,
   ChevronUp,
-  CheckCircle,
+  CircleCheck,
   Clock,
   Eye,
   FileText,
@@ -484,7 +484,7 @@ function getSituacionBadge(situacion?: string | null) {
   if (normalized === "activo") {
     return (
     <Badge variant="default">
-        <CheckCircle className="mr-1 h-3 w-3" /> Activo
+        <CircleCheck className="mr-1 h-3 w-3" /> Activo
       </Badge>
     );
   }

--- a/frontend-ecep/src/app/dashboard/reportes/_components/LicenseSummaryCards.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/LicenseSummaryCards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CheckCircle, Clock, FileText, Users } from "lucide-react";
+import { CircleCheck, Clock, FileText, Users } from "lucide-react";
 
 const CARD_DESCRIPTIONS = {
   personal: "Total de docentes y personal administrativo con legajo activo.",
@@ -35,7 +35,7 @@ export function LicenseSummaryCards({
     },
     {
       title: "Activos",
-      icon: CheckCircle,
+      icon: CircleCheck,
       value: activos,
       description: CARD_DESCRIPTIONS.activos,
       iconClassName: "text-primary",

--- a/frontend-ecep/src/components/ui/sonner.tsx
+++ b/frontend-ecep/src/components/ui/sonner.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from 'next-themes';
 import { Toaster as Sonner } from 'sonner';
+import { CircleCheck } from 'lucide-react';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
@@ -21,6 +22,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
             'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
           cancelButton:
             'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+        },
+        icons: {
+          success: <CircleCheck className="h-5 w-5 text-primary" />,
         },
       }}
       {...props}


### PR DESCRIPTION
## Summary
- replace lucide-react CheckCircle usages with CircleCheck across admissions, attendance, staff, payments, and dashboard views to keep iconography consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7fcbe13188327936672d859ba4b2c