### PR TITLE
Fix configuration dialog sizing

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -110,8 +110,8 @@ export function ConfiguracionDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl overflow-hidden p-0 sm:max-h-[85vh]">
-        <div className="flex h-full max-h-[85vh] flex-col">
+      <DialogContent className="flex h-[80vh] w-full max-w-4xl overflow-hidden p-0">
+        <div className="flex h-full flex-col">
           <DialogHeader className="px-6 py-4">
             <DialogTitle>Configuración</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
## Summary
- give the configuration modal a fixed viewport-based height and rely on its scroll area when content is long

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d80c6c559c8327894b3bc1cd8a1398