### PR TITLE
Fix tab overflow behavior on desktop

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -126,7 +126,7 @@ export function ConfiguracionDialog({
                 onValueChange={(value) => setActiveTab(value as ConfigTabValue)}
                 className="space-y-6"
               >
-                <TabsList className="w-full justify-start overflow-x-auto">
+                <TabsList className="w-full justify-start overflow-x-auto md:overflow-visible">
                   {availableTabs.map((tab) => (
                     <TabsTrigger
                       key={tab.value}

--- a/frontend-ecep/src/app/dashboard/alumnos/solicitudes/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/solicitudes/[id]/page.tsx
@@ -834,7 +834,7 @@ export default function SolicitudAdmisionDetailPage() {
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="aspirante" className="space-y-4">
-            <TabsList className="flex flex-wrap gap-2 overflow-x-auto">
+            <TabsList className="flex flex-wrap gap-2 overflow-x-auto md:overflow-visible">
               <TabsTrigger value="aspirante">Datos del aspirante</TabsTrigger>
               <TabsTrigger value="hogar">Condiciones del hogar</TabsTrigger>
               <TabsTrigger value="salud">Información de salud</TabsTrigger>

--- a/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/FamilyAttendanceView.tsx
@@ -584,7 +584,7 @@ export function FamilyAttendanceView() {
           }}
           className="w-full"
         >
-          <TabsList className="flex flex-wrap gap-2 overflow-x-auto">
+          <TabsList className="flex flex-wrap gap-2 overflow-x-auto md:overflow-visible">
             {alumnos.map((al) => (
               <TabsTrigger
                 key={al.matriculaId}

--- a/frontend-ecep/src/app/dashboard/asistencia/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/page.tsx
@@ -248,7 +248,7 @@ function TeacherView() {
         onValueChange={(value) => setTab(value as "primario" | "inicial")}
         className="space-y-4"
       >
-        <TabsList className="justify-start overflow-x-auto">
+        <TabsList className="justify-start overflow-x-auto md:overflow-visible">
           <TabsTrigger value="primario">Primario</TabsTrigger>
           <TabsTrigger value="inicial">Inicial</TabsTrigger>
         </TabsList>
@@ -413,7 +413,7 @@ function DirectivoView() {
           onValueChange={(value) => setTab(value as "primario" | "inicial")}
           className="space-y-4"
         >
-          <TabsList className="justify-start overflow-x-auto">
+          <TabsList className="justify-start overflow-x-auto md:overflow-visible">
             <TabsTrigger value="primario">Primario</TabsTrigger>
             <TabsTrigger value="inicial">Inicial</TabsTrigger>
           </TabsList>

--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -474,7 +474,7 @@ export default function SeccionHistorialPage() {
           onValueChange={setSelectedTrimestreId}
           className="space-y-4"
         >
-          <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap">
+          <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap md:overflow-visible">
             {trimestresDelPeriodo.map((tri, index) => {
               const label =
                 tri.orden != null

--- a/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
@@ -356,7 +356,7 @@ export default function FamilyCalificacionesView({
       onValueChange={(value) => setSelectedMatriculaId(Number(value))}
       className="space-y-6"
     >
-      <TabsList className="w-full justify-start overflow-x-auto">
+      <TabsList className="w-full justify-start overflow-x-auto md:overflow-visible">
         {alumnos.map((alumno) => (
           <TabsTrigger
             key={alumno.matriculaId}

--- a/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/page.tsx
@@ -152,7 +152,7 @@ export default function CalificacionesIndexPage() {
             onValueChange={(value) => setTab(value as "primario" | "inicial")}
             className="space-y-4"
           >
-            <TabsList className="justify-start overflow-x-auto">
+            <TabsList className="justify-start overflow-x-auto md:overflow-visible">
               <TabsTrigger value="primario">Primario</TabsTrigger>
               <TabsTrigger value="inicial">Inicial</TabsTrigger>
             </TabsList>

--- a/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/seccion/[id]/_views/CierrePrimarioView.tsx
@@ -617,7 +617,7 @@ export default function CierrePrimarioView({
                     onValueChange={(value) => setTriId(String(value))}
                     className="w-full"
                   >
-                    <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap">
+                    <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap md:overflow-visible">
                       {triOpts.map((o) => (
                         <TabsTrigger key={o.id} value={String(o.id)}>
                           {o.label}

--- a/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/seccion/[id]/page.tsx
@@ -556,7 +556,7 @@ export default function SeccionEvaluacionesPage() {
                 onValueChange={(value) => setSelectedTrimestreId(value)}
                 className="space-y-4"
               >
-                <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap">
+                <TabsList className="flex gap-2 overflow-x-auto md:flex-wrap md:overflow-visible">
                   {trimestresDelPeriodo.map((tri, index) => {
                     const label =
                       tri.orden != null

--- a/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
+++ b/frontend-ecep/src/app/dashboard/materias/_components/FamilyMateriasView.tsx
@@ -321,7 +321,7 @@ export default function FamilyMateriasView({
       onValueChange={(value) => setSelectedMatriculaId(Number(value))}
       className="space-y-6"
     >
-      <TabsList className="w-full justify-start overflow-x-auto">
+      <TabsList className="w-full justify-start overflow-x-auto md:overflow-visible">
         {alumnos.map((alumno) => (
           <TabsTrigger key={alumno.matriculaId} value={String(alumno.matriculaId)}>
             {alumno.nombreCompleto}

--- a/frontend-ecep/src/app/dashboard/pagos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/pagos/page.tsx
@@ -1525,7 +1525,7 @@ export default function PagosPage() {
             onValueChange={(value) => setSelectedTab(value)}
             className="space-y-6"
           >
-            <TabsList className="justify-start overflow-x-auto">
+            <TabsList className="justify-start overflow-x-auto md:overflow-visible">
               {availableTabs.map((tab) => (
                 <TabsTrigger key={tab.value} value={tab.value}>
                   {tab.label}

--- a/frontend-ecep/src/app/dashboard/reportes/page.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/page.tsx
@@ -1690,7 +1690,7 @@ const handleExportCurrent = async () => {
         </div>
 
         <Tabs value={tab} onValueChange={setTab} className="space-y-5">
-          <TabsList className="w-full h-auto flex gap-2 overflow-x-auto md:flex-wrap">
+          <TabsList className="w-full h-auto flex gap-2 overflow-x-auto md:flex-wrap md:overflow-visible">
             <TabsTrigger value="boletines" className="flex flex-1 min-w-[8rem]">
               Boletines
             </TabsTrigger>


### PR DESCRIPTION
## Summary
- add responsive overflow handling to dashboard tab lists to prevent horizontal scrolling on desktop while preserving mobile support

## Testing
- npm run lint *(fails: next command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d80bd820788327b6188c54fbd52741