### PR TITLE
Align sidebar drag handle with content card ring

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -370,21 +370,21 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         role="separator"
         aria-orientation="vertical"
         className={cn(
-          "group hidden lg:flex relative -ml-2 w-5 cursor-ew-resize items-center justify-center transition-colors duration-300",
+          "group hidden lg:flex relative -ml-2 w-5 cursor-ew-resize items-center justify-center transition-colors duration-300 z-30",
           isDragging ? "bg-muted/80" : "bg-transparent",
         )}
       >
         <span
           aria-hidden
           className={cn(
-            "pointer-events-none absolute inset-y-2 left-1/2 w-px -translate-x-1/2 rounded-full bg-border transition-opacity duration-200",
+            "pointer-events-none absolute inset-y-2 -right-4 w-px translate-x-1/2 rounded-full bg-border transition-opacity duration-200",
             isDragging ? "opacity-100" : "opacity-0 group-hover:opacity-70",
           )}
         />
         <span
           aria-hidden
           className={cn(
-            "pointer-events-none h-3.5 w-3.5 rounded-full bg-card shadow-sm ring-1 ring-border transition-transform duration-300",
+            "pointer-events-none absolute top-1/2 -right-4 h-3.5 w-3.5 -translate-y-1/2 translate-x-1/2 rounded-full bg-card shadow-sm ring-1 ring-border transition-transform duration-300",
             isCollapsed ? "scale-110" : "scale-100",
           )}
         />

--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -384,7 +384,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         <span
           aria-hidden
           className={cn(
-            "pointer-events-none h-3.5 w-3.5 rounded-full border border-border bg-background shadow-sm transition-transform duration-300",
+            "pointer-events-none h-3.5 w-3.5 rounded-full bg-card shadow-sm ring-1 ring-border transition-transform duration-300",
             isCollapsed ? "scale-110" : "scale-100",
           )}
         />


### PR DESCRIPTION
## Summary
- update the desktop sidebar drag handle indicator to mirror the card ring styling so the dot aligns visually with the main content container

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68d80ec6473483278320fd4ba46faff4