### PR TITLE
Match sidebar close control to mobile menu button

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -8,7 +8,6 @@ import {
   ChevronsUpDown,
   LogOut,
   School,
-  X,
   Menu,
   Settings,
 } from "lucide-react";
@@ -236,19 +235,20 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
             </div>
             <Button
               variant="ghost"
-              size="sm"
+              size="icon"
               onClick={toggleSidebar}
               className="lg:hidden"
+              aria-label="Cerrar menú"
             >
-              <X className="h-5 w-5" />
+              <Menu className="h-5 w-5" />
             </Button>
           </div>
 
           {/* MENÚ por grupos + separador entre grupos */}
           <div
             className={cn(
-              "flex-1 py-4 lg:pr-0",
-              isNavCollapsed ? "px-2 lg:pl-2" : "px-4 lg:pl-4",
+              "flex-1 py-4",
+              isNavCollapsed ? "px-2 lg:px-2" : "px-4 lg:px-4",
             )}
           >
             <div className="flex h-full flex-col justify-center overflow-y-auto">
@@ -300,7 +300,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           {/* PERFIL ABAJO + dropdown hacia arriba */}
           <div
             className={cn(
-              "mt-auto lg:pr-0",
+              "mt-auto",
               isNavCollapsed ? "p-2" : "p-4",
             )}
           >


### PR DESCRIPTION
## Summary
- replace the sidebar close control with the same ghost icon button style used for the mobile menu trigger
- swap the close icon to the shared hamburger icon so open and close affordances match across layouts

## Testing
- not run (npm install blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68d822eb9e008327b285a4985642fd7e