### PR TITLE
Adjust dashboard logo visibility for collapsed sidebar

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -173,26 +173,50 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           {/* LOGO ARRIBA */}
           <div
             className={cn(
-              "flex items-center h-16 m-2",
-              isNavCollapsed ? "justify-center" : "justify-between px-4",
+              "flex items-center h-16 m-2 px-2",
+              isDesktop ? "justify-between" : "justify-between px-4",
+              isDesktop && isNavCollapsed ? "justify-center" : "",
             )}
           >
-            <div className={cn("flex items-center", isNavCollapsed ? "justify-center" : "")}>
-              <div
-                className={cn(
-                  "bg-primary text-primary-foreground rounded-full p-2",
-                  isNavCollapsed ? "" : "mr-3",
-                )}
+            {isDesktop && isNavCollapsed ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleNavigationToggle}
+                aria-label={navigationToggleLabel}
               >
-                <School className="h-6 w-6" />
-              </div>
-              {!isNavCollapsed && (
-                <div>
-                  <h1 className="text-lg font-bold">ECEP</h1>
-                  <p className="text-xs text-muted-foreground">Sistema Escolar</p>
+                <NavigationToggleIcon className="h-5 w-5" />
+              </Button>
+            ) : (
+              <>
+                <div className="flex items-center">
+                  <div
+                    className={cn(
+                      "bg-primary text-primary-foreground rounded-full p-2",
+                      !isDesktop ? "mr-3" : "",
+                    )}
+                  >
+                    <School className="h-6 w-6" />
+                  </div>
+                  {!isDesktop && !isNavCollapsed && (
+                    <div>
+                      <h1 className="text-lg font-bold">ECEP</h1>
+                      <p className="text-xs text-muted-foreground">Sistema Escolar</p>
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
+                {isDesktop && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleNavigationToggle}
+                    aria-label={navigationToggleLabel}
+                  >
+                    <NavigationToggleIcon className="h-5 w-5" />
+                  </Button>
+                )}
+              </>
+            )}
           </div>
 
           {/* MENÚ por grupos + separador entre grupos */}
@@ -348,9 +372,9 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col bg-white dark:bg-background overflow-hidden">
+      <div className="flex-1 flex flex-col bg-white dark:bg-background overflow-y-hidden">
         {/* Botón de navegación principal */}
-        <div className="sticky top-0 z-40 p-4 pb-0">
+        <div className="sticky top-0 z-40 p-4 pb-0 pl-0 lg:hidden">
           <div className="h-12 flex items-center px-2">
             <Button
               variant="ghost"
@@ -362,7 +386,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
             </Button>
           </div>
         </div>
-        <div className="flex-1 p-4">
+        <div className="flex-1 p-4 pl-0">
           <div className="rounded-xl bg-card text-card-foreground ring-1 ring-border overflow-hidden">
             <main className="scrollarea  h-[calc(100vh-6rem)] lg:h-[calc(107vh-6rem)] overflow-y-auto">
               {children}


### PR DESCRIPTION
## Summary
- Show only the navigation toggle button in the desktop sidebar header when it is collapsed, hiding the dashboard logo in compact mode.
- Keep the logo and desktop toggle visible together while the sidebar is expanded, preserving existing mobile behaviour.

## Testing
- Not run (environment lacks required frontend dependencies in this container).


------
https://chatgpt.com/codex/tasks/task_e_68d82f213ca48327b1c37ba0ae6052d1