### PR TITLE
Allow multiple active trimestres

### DIFF
--- a/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/_components/ConfiguracionDialog.tsx
@@ -768,15 +768,7 @@ function DireccionConfig({
 
     const previo = idx > 0 ? trimestresOrdenados[idx - 1] : undefined;
     const estadoPrevio = previo ? getTrimestreEstado(previo) : null;
-    const hayOtroActivo = trimestresOrdenados.some(
-      (t) => t.id !== tri.id && getTrimestreEstado(t) === "activo",
-    );
-
     if (estado === "activo") {
-      if (hayOtroActivo) {
-        toast.error("Cerrá el trimestre activo antes de abrir otro");
-        return;
-      }
       if (previo && estadoPrevio !== "cerrado") {
         toast.error(
           `Primero debés cerrar el trimestre ${previo.orden ?? "anterior"}`,
@@ -889,18 +881,13 @@ function DireccionConfig({
           const previo = idx > 0 ? trimestresOrdenados[idx - 1] : undefined;
           const estado = getTrimestreEstado(tri);
           const estadoPrevio = previo ? getTrimestreEstado(previo) : null;
-          const hayOtroActivo = trimestresOrdenados.some(
-            (t) => t.id !== tri.id && getTrimestreEstado(t) === "activo",
-          );
           const draft = drafts[tri.id] ?? { inicio: "", fin: "" };
           const activarDisabledReason =
             estado === "activo"
               ? "Este trimestre ya está activo."
-              : hayOtroActivo
-                ? "Cerrá el trimestre activo antes de abrir otro."
-                : previo && estadoPrevio !== "cerrado"
-                  ? `Primero debés cerrar el trimestre ${previo.orden ?? "anterior"}`
-                  : null;
+              : previo && estadoPrevio !== "cerrado"
+                ? `Primero debés cerrar el trimestre ${previo.orden ?? "anterior"}`
+                : null;
           const activarDisabled =
             loading ||
             togglingTrimestreId === tri.id ||


### PR DESCRIPTION
## Summary
- remove the Dirección configuration guard that forced only a single active trimestre
- update activation button messaging to reflect the new behavior

## Testing
- npm install *(fails: react-day-picker peer dependency requires React <=18)*

------
https://chatgpt.com/codex/tasks/task_e_68dafec6a3948327bae12910fa4991c7