### PR TITLE
feat: add email verification step to login

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AuthService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AuthService.java
@@ -30,12 +30,17 @@ public class AuthService {
 
     public AuthResponse login(String email, String password) {
         Persona persona = personaRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("Credenciales inválidas"));
+                .orElseThrow(() -> new UsernameNotFoundException("No existe un usuario registrado con ese correo electrónico"));
         if (persona.getPassword() == null || !passwordEncoder.matches(password, persona.getPassword())) {
-            throw new BadCredentialsException("Credenciales inválidas");
+            throw new BadCredentialsException("La contraseña ingresada es incorrecta");
         }
         String token = jwtService.generateToken(persona);
         return AuthResponse.fromPersona(token, persona);
+    }
+
+    public void ensureEmailExists(String email) {
+        personaRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("No existe un usuario registrado con ese correo electrónico"));
     }
 
     public AuthResponse register(PersonaCreateDTO request) {

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/EmailCheckRequest.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/EmailCheckRequest.java
@@ -1,0 +1,12 @@
+package edu.ecep.base_app.identidad.presentation.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class EmailCheckRequest {
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/AuthController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/AuthController.java
@@ -1,6 +1,7 @@
 package edu.ecep.base_app.identidad.presentation.rest;
 
 import edu.ecep.base_app.identidad.presentation.dto.AuthResponse;
+import edu.ecep.base_app.identidad.presentation.dto.EmailCheckRequest;
 import edu.ecep.base_app.identidad.presentation.dto.LoginRequest;
 import edu.ecep.base_app.identidad.presentation.dto.PersonaCreateDTO;
 import edu.ecep.base_app.identidad.presentation.dto.PersonaResumenDTO;
@@ -50,6 +51,12 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(response);
+    }
+
+    @PostMapping("/check-email")
+    public ResponseEntity<Map<String, Object>> checkEmail(@RequestBody @Validated EmailCheckRequest request) {
+        authService.ensureEmailExists(request.getEmail());
+        return ResponseEntity.ok(Map.of("exists", Boolean.TRUE));
     }
 
     @PostMapping("/register")

--- a/backend-ecep/src/main/java/edu/ecep/base_app/shared/web/GlobalExceptionHandler.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/shared/web/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import edu.ecep.base_app.shared.exception.ReferencedException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -43,6 +45,22 @@ public class GlobalExceptionHandler {
         body.put("error", code);
         body.put("message", message);
         return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleUsernameNotFound(UsernameNotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", "EMAIL_NOT_FOUND");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Map<String, Object>> handleBadCredentials(BadCredentialsException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", "INVALID_PASSWORD");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
     }
 }
 

--- a/frontend-ecep/src/services/api/modules/identidad/auth.ts
+++ b/frontend-ecep/src/services/api/modules/identidad/auth.ts
@@ -7,3 +7,6 @@ export const login = (email: string, password: string) =>
 export const logout = () => http.post("/api/auth/logout");
 
 export const me = () => http.get<DTO.PersonaResumenDTO>("/api/auth/me");
+
+export const checkEmail = (email: string) =>
+  http.post<{ exists: boolean }>("/api/auth/check-email", { email });

--- a/frontend-ecep/src/services/api/modules/identidad/index.ts
+++ b/frontend-ecep/src/services/api/modules/identidad/index.ts
@@ -1,4 +1,4 @@
-import { login, logout, me } from "./auth";
+import { login, logout, me, checkEmail } from "./auth";
 import {
   alumnos,
   familiares,
@@ -12,6 +12,7 @@ export const identidad = {
   login,
   logout,
   me,
+  checkEmail,
   alumnos,
   familiares,
   alumnoFamiliares,
@@ -26,6 +27,7 @@ export {
   login,
   logout,
   me,
+  checkEmail,
   alumnos,
   familiares,
   alumnoFamiliares,


### PR DESCRIPTION
## Summary
- add a dedicated endpoint to validate login emails and return detailed auth errors
- update the login flow to verify the email before requesting the password and surface server messages via toast
- expose the new API client utilities and adjust auth context error propagation

## Testing
- ./mvnw -q test *(fails: repository download blocked in environment)*
- npm run lint *(fails: Next.js binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dafed3294883278a15def2b80b9dd5