### PR TITLE
Block existing DNI in admission step

### DIFF
--- a/frontend-ecep/src/app/postulacion/Step1.tsx
+++ b/frontend-ecep/src/app/postulacion/Step1.tsx
@@ -29,7 +29,7 @@ interface Props {
     options?: { errorKeys?: string | string[] },
   ) => void;
   errors: Record<string, boolean>;
-  personaDetectadaId?: number | null;
+  dniRegistrado?: boolean;
   dniLookupLoading?: boolean;
 }
 
@@ -37,9 +37,14 @@ export function Step1({
   formData,
   handleInputChange,
   errors,
-  personaDetectadaId,
+  dniRegistrado,
   dniLookupLoading,
 }: Props) {
+  const helperTextClassName = cn(
+    "mt-1 text-xs min-h-[16px]",
+    dniLookupLoading || !dniRegistrado ? "text-muted-foreground" : "text-destructive",
+  );
+
   return (
     <div className="space-y-4">
       {/* Título del paso */}
@@ -91,11 +96,11 @@ export function Step1({
             aria-invalid={errors.dni || undefined}
             className={cn(errors.dni && "border-destructive")}
           />
-          <div className="mt-1 text-xs text-muted-foreground min-h-[16px]">
+          <div className={helperTextClassName}>
             {dniLookupLoading
               ? "Verificando DNI…"
-              : personaDetectadaId
-                ? `Persona existente detectada (ID #${personaDetectadaId}).`
+              : dniRegistrado
+                ? "DNI no válido."
                 : ""}
           </div>
         </div>

--- a/frontend-ecep/src/app/postulacion/page.tsx
+++ b/frontend-ecep/src/app/postulacion/page.tsx
@@ -619,6 +619,7 @@ export default function PostulacionPage() {
     let ok = true;
     let missingRequired = false;
     let invalidBirthDate = false;
+    const dniRegistrado = Boolean(aspirantePersonaPreview?.id);
     for (const f of fields) {
       if (!formData[f as keyof typeof formData]) {
         newErrors[f] = true;
@@ -629,6 +630,10 @@ export default function PostulacionPage() {
     const dniValue = formatDni(formData.dni ?? "");
     const dniInvalid = !dniValue || dniValue.length < 7 || dniValue.length > 10;
     if (dniInvalid) {
+      newErrors.dni = true;
+      ok = false;
+    }
+    if (dniRegistrado) {
       newErrors.dni = true;
       ok = false;
     }
@@ -648,6 +653,9 @@ export default function PostulacionPage() {
           ? "La fecha de nacimiento debe ser al menos dos años anterior a hoy."
           : null,
         dniInvalid ? "El DNI debe tener entre 7 y 10 dígitos." : null,
+        dniRegistrado
+          ? "El DNI ingresado ya se encuentra registrado en el sistema."
+          : null,
       ]
         .filter(Boolean)
         .join(" ");
@@ -923,7 +931,7 @@ export default function PostulacionPage() {
             formData={formData}
             handleInputChange={handleInputChange}
             errors={errors}
-            personaDetectadaId={formData.personaId ?? aspirantePersonaPreview?.id ?? null}
+            dniRegistrado={Boolean(aspirantePersonaPreview?.id)}
             dniLookupLoading={dniLookupLoading}
           />
         );


### PR DESCRIPTION
## Summary
- show an error helper message when the DNI already exists during the first admission step
- prevent advancing past step 1 when the DNI belongs to an existing person in the system

## Testing
- pnpm lint *(fails: next executable not found because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68db0566a6408327a25185fd716553c9