### PR TITLE
Move login back button to form header

### DIFF
--- a/frontend-ecep/src/app/page.tsx
+++ b/frontend-ecep/src/app/page.tsx
@@ -185,13 +185,26 @@ export default function LoginPage() {
 
         {/* Formulario de login */}
         <Card className="shadow-lg">
-          <CardHeader>
-            <CardTitle className="text-2xl text-center text-foreground">
-              Iniciar Sesión
-            </CardTitle>
-            <CardDescription className="text-center">
-              Ingrese sus credenciales para acceder al sistema
-            </CardDescription>
+          <CardHeader className="space-y-4">
+            {isValidEmail && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={handleGoBackToEmail}
+                disabled={isLoggingIn}
+                className="self-start"
+              >
+                Volver
+              </Button>
+            )}
+            <div className="space-y-2 text-center">
+              <CardTitle className="text-2xl text-center text-foreground">
+                Iniciar Sesión
+              </CardTitle>
+              <CardDescription className="text-center">
+                Ingrese sus credenciales para acceder al sistema
+              </CardDescription>
+            </div>
           </CardHeader>
           <CardContent>
             <form
@@ -247,16 +260,6 @@ export default function LoginPage() {
                     </p>
                   </div>
 
-                  <div className="flex justify-start">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={handleGoBackToEmail}
-                      disabled={isLoggingIn}
-                    >
-                      Volver
-                    </Button>
-                  </div>
                 </>
               )}
 


### PR DESCRIPTION
## Summary
- move the login screen's Volver button from the bottom of the form to the top of the card header
- keep the button available only when the password step is visible

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db0a81a30883278872d29aa5f6ce06