### PR TITLE
Simplify admissions interview workflow

### DIFF
--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -843,6 +843,8 @@ export interface SolicitudAdmisionDecisionDTO {
 export interface SolicitudAdmisionAltaDTO {
   seccionId?: number;
   turno?: Turno;
+  periodoEscolarId?: number;
+  autoAsignarSiguientePeriodo?: boolean;
 }
 
 export interface SolicitudAdmisionAltaResultDTO {


### PR DESCRIPTION
## Summary
- update the scheduling flow so the email asks families to reply with their preferred time and allow manual confirmation of interview dates and times
- enable acceptance once an interview date is recorded, show a follow-up prompt to launch the enrollment flow, and surface alerts when an automatic enrollment is pending
- extend the admissions high modal to capture the academic period (including a pending "next period" option) and update the DTO to send the chosen period information

## Testing
- bun run lint *(fails: next command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db133afca88327b9e2969e3abc53e0