### PR TITLE
Automate interview confirmation handling

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/persistence/EmpleadoRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/infrastructure/persistence/EmpleadoRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EmpleadoRepository extends JpaRepository<Empleado, Long> {
@@ -15,6 +16,7 @@ public interface EmpleadoRepository extends JpaRepository<Empleado, Long> {
     boolean existsByPersonaId(Long id);
     Optional<Empleado> findByLegajoIgnoreCase(String legajo);
     Optional<Empleado> findByCuil(String cuil);
+    List<Empleado> findByRolEmpleado(RolEmpleado rolEmpleado);
 
     @Query("""
         select e


### PR DESCRIPTION
## Summary
- remove the manual confirmation action from the admissions detail page so dirección no longer picks a date
- send an email notification to dirección employees when a family confirms an interview
- add repository support to fetch dirección staff for interview notifications
- display the confirmed interview date together with the selected time in the admissions dashboard

## Testing
- npm run lint *(fails: `next` binary not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2dd007a88327a2fd9fe7fe1cb2d5