### PR TITLE
Add occupation and workplace fields to familiar workflows

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Familiar.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/Familiar.java
@@ -21,6 +21,7 @@ public class Familiar {
     Persona persona;
 
     String ocupacion;
+    String lugarTrabajo;
 
     @OneToMany(mappedBy="familiar") Set<AlumnoFamiliar> familiarAlumnoFamiliares = new HashSet<>();
     @OneToMany(mappedBy="familiar") Set<AspiranteFamiliar> familiarAspiranteFamiliares = new HashSet<>();

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/FamiliarDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/FamiliarDTO.java
@@ -1,6 +1,5 @@
 package edu.ecep.base_app.identidad.presentation.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,4 +14,5 @@ public class FamiliarDTO {
     Long personaId;
 
     String ocupacion;
+    String lugarTrabajo;
 }

--- a/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/familiares/[id]/page.tsx
@@ -97,6 +97,7 @@ export default function FamiliarPerfilPage() {
     observaciones: "",
   });
   const [ocupacion, setOcupacion] = useState<string>("");
+  const [lugarTrabajo, setLugarTrabajo] = useState<string>("");
 
   const [reloadKey, setReloadKey] = useState(0);
 
@@ -152,6 +153,7 @@ export default function FamiliarPerfilPage() {
         if (!alive) return;
         setPersona(personaData);
         setOcupacion((familiarData as any)?.ocupacion ?? "");
+        setLugarTrabajo((familiarData as any)?.lugarTrabajo ?? "");
 
         let linksData: AlumnoFamiliarDTO[] = [];
         try {
@@ -221,6 +223,7 @@ export default function FamiliarPerfilPage() {
       observaciones: (persona as any)?.observacionesGenerales ?? "",
     });
     setOcupacion((familiar as any)?.ocupacion ?? "");
+    setLugarTrabajo((familiar as any)?.lugarTrabajo ?? "");
   }, [editOpen, persona, familiar]);
 
   const handleSaveProfile = async () => {
@@ -256,6 +259,7 @@ export default function FamiliarPerfilPage() {
         id: familiar.id,
         personaId: persona.id,
         ocupacion: ocupacion.trim() || undefined,
+        lugarTrabajo: lugarTrabajo.trim() || undefined,
       } as any);
 
       toast.success("Datos del familiar actualizados");
@@ -452,6 +456,13 @@ export default function FamiliarPerfilPage() {
                     <Input value={ocupacion} onChange={(e) => setOcupacion(e.target.value)} />
                   </div>
                   <div className="md:col-span-2 space-y-2">
+                    <Label>Lugar de trabajo</Label>
+                    <Input
+                      value={lugarTrabajo}
+                      onChange={(e) => setLugarTrabajo(e.target.value)}
+                    />
+                  </div>
+                  <div className="md:col-span-2 space-y-2">
                     <Label>Observaciones</Label>
                     <Textarea
                       rows={3}
@@ -536,6 +547,10 @@ export default function FamiliarPerfilPage() {
                 <div>
                   <span className="text-muted-foreground">Ocupación: </span>
                   <span className="font-medium">{ocupacion || "—"}</span>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Lugar de trabajo: </span>
+                  <span className="font-medium">{lugarTrabajo || "—"}</span>
                 </div>
                 <div>
                   <span className="text-muted-foreground">Alumno(s) vinculados: </span>

--- a/frontend-ecep/src/app/postulacion/Step2.tsx
+++ b/frontend-ecep/src/app/postulacion/Step2.tsx
@@ -333,6 +333,60 @@ export function Step2({
                 />
               </div>
 
+              {/* Ocupación */}
+              <div className="md:col-span-2">
+                <Label htmlFor={`familiar-ocupacion-${i}`}>Ocupación</Label>
+                <Input
+                  id={`familiar-ocupacion-${i}`}
+                  value={f.familiar?.ocupacion ?? ""}
+                  onChange={(e) =>
+                    handleInputChange(
+                      "familiares",
+                      familiares.map((x, j) =>
+                        j === i
+                          ? {
+                              ...x,
+                              familiar: {
+                                ...x.familiar!,
+                                ocupacion: e.target.value,
+                              },
+                            }
+                          : x,
+                      ),
+                    )
+                  }
+                  placeholder="Profesión u ocupación"
+                />
+              </div>
+
+              {/* Lugar de trabajo */}
+              <div className="md:col-span-2">
+                <Label htmlFor={`familiar-lugar-trabajo-${i}`}>
+                  Lugar de trabajo
+                </Label>
+                <Input
+                  id={`familiar-lugar-trabajo-${i}`}
+                  value={f.familiar?.lugarTrabajo ?? ""}
+                  onChange={(e) =>
+                    handleInputChange(
+                      "familiares",
+                      familiares.map((x, j) =>
+                        j === i
+                          ? {
+                              ...x,
+                              familiar: {
+                                ...x.familiar!,
+                                lugarTrabajo: e.target.value,
+                              },
+                            }
+                          : x,
+                      ),
+                    )
+                  }
+                  placeholder="Empresa o institución"
+                />
+              </div>
+
               {/* Domicilio */}
               <div>
                 <Label htmlFor={`familiar-domicilio-${i}`}>Domicilio</Label>

--- a/frontend-ecep/src/app/postulacion/page.tsx
+++ b/frontend-ecep/src/app/postulacion/page.tsx
@@ -93,7 +93,8 @@ const completionMessages = {
     "Te invitamos a mantenerte atento a tu bandeja de entrada y revisar tu carpeta de correo no deseado.",
 };
 
-type FamiliarRecordDTO = DTO.FamiliarDTO & { ocupacion?: string | null };
+type FamiliarRecordDTO =
+  DTO.FamiliarDTO & { ocupacion?: string | null; lugarTrabajo?: string | null };
 
 type FamiliarPromptInfo = {
   index: number;
@@ -387,7 +388,8 @@ export default function PostulacionPage() {
           celular: persona.celular ?? basePersona.celular ?? "",
           email: persona.email ?? basePersona.email ?? "",
           emailContacto: persona.email ?? basePersona.emailContacto ?? "",
-          lugarTrabajo: basePersona.lugarTrabajo ?? "",
+          lugarTrabajo:
+            familiar?.lugarTrabajo ?? basePersona.lugarTrabajo ?? "",
           ocupacion: familiar?.ocupacion ?? basePersona.ocupacion ?? "",
         },
       };
@@ -558,11 +560,13 @@ export default function PostulacionPage() {
   const ensureFamiliarRecord = async (
     personaId: number,
     ocupacion?: string,
+    lugarTrabajo?: string,
   ): Promise<number> => {
     const payload: DTO.FamiliarDTO = {
       id: personaId,
       personaId,
       ocupacion,
+      lugarTrabajo,
     };
 
     try {
@@ -571,7 +575,11 @@ export default function PostulacionPage() {
       return data?.id ?? personaId;
     } catch (error: any) {
       if (error?.response?.status === 404) {
-        const { data } = await identidad.familiares.create({ personaId, ocupacion });
+        const { data } = await identidad.familiares.create({
+          personaId,
+          ocupacion,
+          lugarTrabajo,
+        });
         return Number(data);
       }
       throw error;
@@ -857,6 +865,7 @@ export default function PostulacionPage() {
         await ensureFamiliarRecord(
           familiarPersonaId,
           familiarPersona.ocupacion || undefined,
+          familiarPersona.lugarTrabajo || undefined,
         );
 
         const parentesco = isValidRolVinculo(familiarEntry.tipoRelacion)

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -975,8 +975,8 @@ export interface FamiliarDTO {
   id: number; // == personaId
   personaId: number;
   // campos propios de Familiar (si existen):
-  // ocupacion?: string | null;
-  // observaciones?: string | null;
+  ocupacion?: string | null;
+  lugarTrabajo?: string | null;
 }
 export interface FamiliarCreateDTO extends Omit<FamiliarDTO, "id"> {}
 export interface FamiliarUpdateDTO extends Partial<FamiliarCreateDTO> {}


### PR DESCRIPTION
## Summary
- add occupation and workplace inputs to the postulacion flow and map them through the familiares mappers
- extend the Familiar DTO/entity to persist occupation and workplace information
- surface and edit the new fields from the dashboard familiar profile

## Testing
- npm run lint *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68decb5ccbe083279c7d8b4913b5a111