### PR TITLE
Add aspirant data capture to manual student creation

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoDTO.java
@@ -19,6 +19,16 @@ public class AlumnoDTO {
     LocalDate fechaInscripcion;
     String observacionesGenerales;
     String motivoRechazoBaja;
+    String conectividadInternet;
+    String dispositivosDisponibles;
+    String idiomasHabladosHogar;
+    String enfermedadesAlergias;
+    String medicacionHabitual;
+    String limitacionesFisicas;
+    String tratamientosTerapeuticos;
+    Boolean usoAyudasMovilidad;
+    String coberturaMedica;
+    String observacionesSalud;
 
     // Datos visibles para listados
     String nombre;

--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -37,6 +37,20 @@ import {
 import { Loader2 } from "lucide-react";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod";
 import { logger } from "@/lib/logger";
+import { Step3 as HogarForm } from "@/app/postulacion/Step3";
+import { Step4 as SaludForm } from "@/app/postulacion/Step4";
+import type { PostulacionFormData } from "@/app/postulacion/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RolVinculo } from "@/types/api-generated";
 
 const alumnosAltaLogger = logger.child({ module: "dashboard-alumnos-alta" });
 
@@ -90,6 +104,60 @@ const emptyAlumno: AlumnoForm = {
   seccionId: "",
 };
 
+type AspiranteComplementoForm = Pick<
+  PostulacionFormData,
+  |
+    | "conectividadInternet"
+    | "dispositivosDisponibles"
+    | "idiomasHabladosHogar"
+    | "enfermedadesAlergias"
+    | "medicacionHabitual"
+    | "limitacionesFisicasNeurologicas"
+    | "tratamientosTerapeuticos"
+    | "usoAyudasMovilidad"
+    | "coberturaMedica"
+    | "observacionesAdicionalesSalud"
+>;
+
+const emptyAspiranteComplemento: AspiranteComplementoForm = {
+  conectividadInternet: "",
+  dispositivosDisponibles: "",
+  idiomasHabladosHogar: "",
+  enfermedadesAlergias: "",
+  medicacionHabitual: "",
+  limitacionesFisicasNeurologicas: "",
+  tratamientosTerapeuticos: "",
+  usoAyudasMovilidad: false,
+  coberturaMedica: "",
+  observacionesAdicionalesSalud: "",
+};
+
+type TutorForm = {
+  personaId: number | null;
+  familiarId: number | null;
+  nombre: string;
+  apellido: string;
+  dni: string;
+  email: string;
+  telefono: string;
+  celular: string;
+  rolVinculo: RolVinculo | "";
+  convive: boolean;
+};
+
+const emptyTutor: TutorForm = {
+  personaId: null,
+  familiarId: null,
+  nombre: "",
+  apellido: "",
+  dni: "",
+  email: "",
+  telefono: "",
+  celular: "",
+  rolVinculo: "",
+  convive: false,
+};
+
 export default function AltaAlumnoPage() {
   const router = useRouter();
   const [personaId, setPersonaId] = useState<number | null>(null);
@@ -101,6 +169,18 @@ export default function AltaAlumnoPage() {
   const [lastLookupDni, setLastLookupDni] = useState<string>("");
 
   const [alumnoForm, setAlumnoForm] = useState<AlumnoForm>(emptyAlumno);
+  const [aspiranteForm, setAspiranteForm] =
+    useState<AspiranteComplementoForm>(emptyAspiranteComplemento);
+  const [tutores, setTutores] = useState<TutorForm[]>([]);
+  const [familiaresCatalog, setFamiliaresCatalog] = useState<DTO.FamiliarDTO[]>(
+    [],
+  );
+  const [tutorModalOpen, setTutorModalOpen] = useState(false);
+  const [tutorDraft, setTutorDraft] = useState<TutorForm>(emptyTutor);
+  const [tutorLookupLoading, setTutorLookupLoading] = useState(false);
+  const [tutorLookupCompleted, setTutorLookupCompleted] = useState(false);
+  const [tutorPersonaExists, setTutorPersonaExists] = useState(false);
+  const [savingTutorDraft, setSavingTutorDraft] = useState(false);
   const [creatingAlumno, setCreatingAlumno] = useState(false);
   const [secciones, setSecciones] = useState<DTO.SeccionDTO[]>([]);
   const { periodoEscolarId: activePeriodId } = useActivePeriod();
@@ -110,13 +190,28 @@ export default function AltaAlumnoPage() {
     const apellidoOk = Boolean(personaForm.apellido.trim());
     const dniOk = formatDni(personaForm.dni).length >= 7;
     const seccionOk = Boolean(alumnoForm.seccionId);
-    return nombreOk && apellidoOk && dniOk && seccionOk;
+    const hogarOk =
+      Boolean(aspiranteForm.conectividadInternet?.trim()) &&
+      Boolean(aspiranteForm.dispositivosDisponibles?.trim()) &&
+      Boolean(aspiranteForm.idiomasHabladosHogar?.trim());
+    return nombreOk && apellidoOk && dniOk && seccionOk && hogarOk;
   }, [
     personaForm.nombre,
     personaForm.apellido,
     personaForm.dni,
     alumnoForm.seccionId,
+    aspiranteForm.conectividadInternet,
+    aspiranteForm.dispositivosDisponibles,
+    aspiranteForm.idiomasHabladosHogar,
   ]);
+
+  const rolOptions = useMemo(() => Object.values(RolVinculo), []);
+
+  const formatRol = useCallback((value?: RolVinculo | string | null) => {
+    if (!value) return "Sin vínculo";
+    const formatted = String(value).replace(/_/g, " ").toLowerCase();
+    return formatted.replace(/\b\w/g, (char) => char.toUpperCase());
+  }, []);
 
   useEffect(() => {
     if (!activePeriodId) {
@@ -203,6 +298,108 @@ export default function AltaAlumnoPage() {
     };
   }, [personaForm.dni, personaPreview, lastLookupDni]);
 
+  useEffect(() => {
+    if (!tutorModalOpen) return;
+    let alive = true;
+    setTutorDraft(emptyTutor);
+    setTutorLookupLoading(false);
+    setTutorLookupCompleted(false);
+    setTutorPersonaExists(false);
+    setSavingTutorDraft(false);
+    (async () => {
+      try {
+        const { data } = await identidad.familiares.list();
+        if (!alive) return;
+        setFamiliaresCatalog(data ?? []);
+      } catch (error) {
+        logAltaError(error);
+        if (!alive) return;
+        setFamiliaresCatalog([]);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [tutorModalOpen]);
+
+  useEffect(() => {
+    if (!tutorModalOpen) return;
+    const dni = formatDni(tutorDraft.dni);
+    if (dni.length < 7 || dni.length > 10) {
+      setTutorDraft((prev) => ({
+        ...prev,
+        personaId: null,
+        familiarId: null,
+      }));
+      setTutorLookupLoading(false);
+      setTutorLookupCompleted(false);
+      setTutorPersonaExists(false);
+      return;
+    }
+    setTutorLookupLoading(true);
+    setTutorLookupCompleted(false);
+    let alive = true;
+    const handler = setTimeout(async () => {
+      try {
+        const { data: personaId } = await identidad.personasCore.findIdByDni(
+          dni,
+        );
+        if (!alive) return;
+        if (personaId) {
+          const personaData = await identidad.personasCore
+            .getById(Number(personaId))
+            .then((res) => res.data ?? null)
+            .catch(() => null);
+          if (!alive) return;
+          setTutorDraft((prev) => ({
+            ...prev,
+            personaId: Number(personaId),
+            familiarId:
+              familiaresCatalog.find(
+                (fam) => fam.personaId === Number(personaId),
+              )?.id ?? null,
+            nombre: personaData?.nombre ?? prev.nombre,
+            apellido: personaData?.apellido ?? prev.apellido,
+            dni,
+            email: personaData?.email ?? prev.email,
+            telefono: personaData?.telefono ?? prev.telefono,
+            celular: personaData?.celular ?? prev.celular,
+          }));
+          setTutorPersonaExists(true);
+        } else {
+          setTutorDraft((prev) => ({
+            ...prev,
+            personaId: null,
+            familiarId: null,
+            dni,
+          }));
+          setTutorPersonaExists(false);
+        }
+      } catch (error: any) {
+        if (!alive) return;
+        if (error?.response?.status === 404) {
+          setTutorDraft((prev) => ({
+            ...prev,
+            personaId: null,
+            familiarId: null,
+            dni,
+          }));
+          setTutorPersonaExists(false);
+        } else {
+          logAltaError(error);
+        }
+      } finally {
+        if (!alive) return;
+        setTutorLookupLoading(false);
+        setTutorLookupCompleted(true);
+      }
+    }, 400);
+    return () => {
+      alive = false;
+      clearTimeout(handler);
+    };
+  }, [familiaresCatalog, tutorDraft.dni, tutorModalOpen]);
+
   const persistPersona = async (): Promise<number> => {
     const dniValue = formatDni(personaForm.dni);
     if (!personaForm.nombre || !personaForm.apellido || !dniValue) {
@@ -237,6 +434,74 @@ export default function AltaAlumnoPage() {
     setLastLookupDni(createPayload.dni);
     return newId;
   };
+
+  const handlePersistTutores = useCallback(
+    async (alumnoId: number) => {
+      for (const tutor of tutores) {
+        const dniValue = formatDni(tutor.dni);
+        if (!dniValue) {
+          throw new Error("No pudimos determinar el DNI del tutor");
+        }
+
+        let personaId = tutor.personaId ?? null;
+        const personaPayload: DTO.PersonaCreateDTO = {
+          nombre: tutor.nombre.trim(),
+          apellido: tutor.apellido.trim(),
+          dni: dniValue,
+          email: tutor.email.trim() || undefined,
+          telefono: tutor.telefono.trim() || undefined,
+          celular: tutor.celular.trim() || undefined,
+        };
+
+        if (personaId) {
+          await identidad.personasCore.update(personaId, personaPayload);
+        } else {
+          const { data: created } = await identidad.personasCore.create(
+            personaPayload,
+          );
+          personaId = Number(created);
+        }
+
+        if (!personaId) {
+          throw new Error("No pudimos guardar la persona del tutor");
+        }
+
+        let familiarId = tutor.familiarId ?? null;
+        if (familiarId) {
+          await identidad.familiares.update(
+            familiarId,
+            { id: familiarId, personaId } as any,
+          );
+        } else {
+          try {
+            const { data: familiarCreated } = await identidad.familiares.create({
+              personaId,
+            } as any);
+            familiarId = Number(familiarCreated);
+          } catch (error: any) {
+            if (error?.response?.status === 400) {
+              familiarId = personaId;
+            } else {
+              throw error;
+            }
+          }
+        }
+
+        familiarId = familiarId ?? personaId;
+        if (!familiarId) {
+          throw new Error("No pudimos registrar el familiar vinculado");
+        }
+
+        await identidad.alumnoFamiliares.create({
+          alumnoId,
+          familiarId,
+          rolVinculo: tutor.rolVinculo as RolVinculo,
+          convive: Boolean(tutor.convive),
+        } as any);
+      }
+    },
+    [tutores],
+  );
 
   const handleAsignarSeccion = useCallback(
     async (matriculaId: number) => {
@@ -274,6 +539,18 @@ export default function AltaAlumnoPage() {
       toast.error("No hay un período escolar activo disponible");
       return;
     }
+    if (!aspiranteForm.conectividadInternet?.trim()) {
+      toast.error("Completá la conectividad del hogar");
+      return;
+    }
+    if (!aspiranteForm.dispositivosDisponibles?.trim()) {
+      toast.error("Indicá los dispositivos disponibles");
+      return;
+    }
+    if (!aspiranteForm.idiomasHabladosHogar?.trim()) {
+      toast.error("Completá los idiomas hablados en el hogar");
+      return;
+    }
     setCreatingAlumno(true);
     try {
       const personaPersistidaId = await persistPersona();
@@ -285,6 +562,23 @@ export default function AltaAlumnoPage() {
         observacionesGenerales:
           alumnoForm.observacionesGenerales || undefined,
         motivoRechazoBaja: alumnoForm.motivoRechazoBaja || undefined,
+        conectividadInternet: aspiranteForm.conectividadInternet || undefined,
+        dispositivosDisponibles:
+          aspiranteForm.dispositivosDisponibles || undefined,
+        idiomasHabladosHogar:
+          aspiranteForm.idiomasHabladosHogar || undefined,
+        enfermedadesAlergias:
+          aspiranteForm.enfermedadesAlergias || undefined,
+        medicacionHabitual: aspiranteForm.medicacionHabitual || undefined,
+        limitacionesFisicas:
+          aspiranteForm.limitacionesFisicasNeurologicas || undefined,
+        tratamientosTerapeuticos:
+          aspiranteForm.tratamientosTerapeuticos || undefined,
+        usoAyudasMovilidad:
+          aspiranteForm.usoAyudasMovilidad ?? undefined,
+        coberturaMedica: aspiranteForm.coberturaMedica || undefined,
+        observacionesSalud:
+          aspiranteForm.observacionesAdicionalesSalud || undefined,
       };
       const { data: alumnoId } = await identidad.alumnos.create(payload);
       const matriculaPayload: DTO.MatriculaCreateDTO = {
@@ -295,6 +589,9 @@ export default function AltaAlumnoPage() {
         matriculaPayload,
       );
       await handleAsignarSeccion(matriculaId);
+      if (tutores.length) {
+        await handlePersistTutores(alumnoId);
+      }
       toast.success("Alumno matriculado correctamente");
       router.push(`/dashboard/alumnos/${alumnoId}`);
     } catch (error: any) {
@@ -304,155 +601,492 @@ export default function AltaAlumnoPage() {
     }
   };
 
+  const postulacionAdapter = useMemo(() => {
+    return {
+      ...aspiranteForm,
+      familiares: [],
+    } as PostulacionFormData;
+  }, [aspiranteForm]);
+
+  const handleAspiranteFieldChange = useCallback(
+    (field: string, value: any) => {
+      setAspiranteForm((prev) => {
+        if (field === "usoAyudasMovilidad") {
+          return { ...prev, usoAyudasMovilidad: Boolean(value) };
+        }
+        return { ...prev, [field]: value ?? "" } as AspiranteComplementoForm;
+      });
+    },
+    [],
+  );
+
+  const handleAddTutorToList = () => {
+    const dniValue = formatDni(tutorDraft.dni);
+    if (!dniValue || dniValue.length < 7 || dniValue.length > 10) {
+      toast.error("Ingresá un DNI válido para el tutor");
+      return;
+    }
+    if (
+      !tutorPersonaExists &&
+      (!tutorDraft.nombre.trim() || !tutorDraft.apellido.trim())
+    ) {
+      toast.error("Completá nombre y apellido del tutor");
+      return;
+    }
+    if (!tutorDraft.rolVinculo) {
+      toast.error("Seleccioná el rol del tutor");
+      return;
+    }
+    if (
+      tutores.some(
+        (existing) =>
+          formatDni(existing.dni) === dniValue &&
+          String(existing.rolVinculo) === String(tutorDraft.rolVinculo),
+      )
+    ) {
+      toast.error("Ya agregaste un tutor con este DNI y rol");
+      return;
+    }
+    setSavingTutorDraft(true);
+    setTutores((prev) => [
+      ...prev,
+      {
+        personaId: tutorDraft.personaId,
+        familiarId: tutorDraft.familiarId,
+        nombre: tutorDraft.nombre.trim(),
+        apellido: tutorDraft.apellido.trim(),
+        dni: dniValue,
+        email: tutorDraft.email.trim(),
+        telefono: tutorDraft.telefono.trim(),
+        celular: tutorDraft.celular.trim(),
+        rolVinculo: tutorDraft.rolVinculo,
+        convive: tutorDraft.convive,
+      },
+    ]);
+    setTutorModalOpen(false);
+    setSavingTutorDraft(false);
+  };
+
+  const handleRemoveTutor = (dni: string, rol: RolVinculo | "") => {
+    const dniValue = formatDni(dni);
+    setTutores((prev) =>
+      prev.filter(
+        (tutor) =>
+          !(formatDni(tutor.dni) === dniValue && String(tutor.rolVinculo) === String(rol)),
+      ),
+    );
+  };
+
   return (
     <div className="flex-1 space-y-6 p-4 md:p-8">
-        <Button variant="outline" onClick={() => router.push("/dashboard/alumnos")}>
-          Volver
-        </Button>
-        <div>
-          <h1 className="text-3xl font-bold">Alta manual de alumno</h1>
-          <p className="text-muted-foreground">
-            Cargá la persona y los datos básicos para vincularla como alumno.
-          </p>
-        </div>
+      <Button
+        variant="outline"
+        onClick={() => router.push("/dashboard/alumnos")}
+      >
+        Volver
+      </Button>
+      <div>
+        <h1 className="text-3xl font-bold">Alta manual de alumno</h1>
+        <p className="text-muted-foreground">
+          Cargá la persona y los datos básicos para vincularla como alumno.
+        </p>
+      </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Identificación del alumno</CardTitle>
-            <CardDescription>
-              Ingresá los datos personales. Si el DNI ya está registrado, completaremos la información automáticamente.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="relative space-y-6">
-              <PersonaFormFields
-                values={personaForm}
-                onChange={(field, value) =>
-                  setPersonaForm((prev) => ({
-                    ...prev,
-                    [field]:
-                      field === "dni" && typeof value === "string"
-                        ? formatDni(value)
-                        : value,
-                  }))
-                }
-              />
-              {dniLookupLoading && (
-                <div className="absolute right-0 top-0 flex items-center text-xs text-muted-foreground">
-                  <Loader2 className="mr-2 h-3 w-3 animate-spin" /> Buscando persona…
-                </div>
-              )}
-            </div>
-            {personaId && (
-              <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
-                Persona existente detectada (ID #{personaId}). Actualizá los datos si es necesario antes de registrar al alumno.
+      <Card>
+        <CardHeader>
+          <CardTitle>Identificación del alumno</CardTitle>
+          <CardDescription>
+            Ingresá los datos personales. Si el DNI ya está registrado, completaremos la información automáticamente.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="relative space-y-6">
+            <PersonaFormFields
+              values={personaForm}
+              onChange={(field, value) =>
+                setPersonaForm((prev) => ({
+                  ...prev,
+                  [field]:
+                    field === "dni" && typeof value === "string"
+                      ? formatDni(value)
+                      : value,
+                }))
+              }
+            />
+            {dniLookupLoading && (
+              <div className="absolute right-0 top-0 flex items-center text-xs text-muted-foreground">
+                <Loader2 className="mr-2 h-3 w-3 animate-spin" /> Buscando persona…
               </div>
             )}
-          </CardContent>
-        </Card>
+          </div>
+          {personaId && (
+            <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+              Persona existente detectada (ID #{personaId}). Actualizá los datos si es necesario antes de registrar al alumno.
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Información académica</CardTitle>
-            <CardDescription>
-              Definí la matriculación inicial y registrá cualquier observación relevante para el legajo del alumno.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="grid gap-4 md:grid-cols-3">
+      <Card>
+        <CardHeader>
+          <CardTitle>Información académica</CardTitle>
+          <CardDescription>
+            Definí la matriculación inicial y registrá cualquier observación relevante para el legajo del alumno.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground">
+                Fecha de inscripción
+              </label>
+              <DatePicker
+                value={alumnoForm.fechaInscripcion || undefined}
+                onChange={(value) =>
+                  setAlumnoForm((prev) => ({
+                    ...prev,
+                    fechaInscripcion: value ?? "",
+                  }))
+                }
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground">
+                Sección
+              </label>
+              <Select
+                value={alumnoForm.seccionId}
+                onValueChange={(value) =>
+                  setAlumnoForm((prev) => ({
+                    ...prev,
+                    seccionId: value,
+                  }))
+                }
+                disabled={!secciones.length}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Seleccioná la sección" />
+                </SelectTrigger>
+                <SelectContent>
+                  {secciones.map((sec) => (
+                    <SelectItem key={sec.id} value={String(sec.id)}>
+                      {sec.nivel} — {sec.gradoSala} {sec.division} ({sec.turno})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {!secciones.length && (
+                <p className="text-xs text-muted-foreground">
+                  No hay secciones disponibles para el período escolar activo.
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground">
+                Motivo de rechazo (opcional)
+              </label>
+              <Textarea
+                rows={3}
+                value={alumnoForm.motivoRechazoBaja}
+                onChange={(e) =>
+                  setAlumnoForm((prev) => ({
+                    ...prev,
+                    motivoRechazoBaja: e.target.value,
+                  }))
+                }
+                placeholder="Por ejemplo, si se rechazó una baja previa o requiere seguimiento especial"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">
+              Observaciones generales
+            </label>
+            <Textarea
+              rows={4}
+              value={alumnoForm.observacionesGenerales}
+              onChange={(e) =>
+                setAlumnoForm((prev) => ({
+                  ...prev,
+                  observacionesGenerales: e.target.value,
+                }))
+              }
+              placeholder="Notas internas, antecedentes o información complementaria"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Condiciones del hogar</CardTitle>
+          <CardDescription>
+            Registrá la información del entorno familiar para la ficha del aspirante.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <HogarForm
+            formData={postulacionAdapter}
+            handleInputChange={handleAspiranteFieldChange}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Información de salud</CardTitle>
+          <CardDescription>
+            Indicá antecedentes y observaciones médicas relevantes para el seguimiento institucional.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <SaludForm
+            formData={postulacionAdapter}
+            handleInputChange={handleAspiranteFieldChange}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tutores y familiares responsables</CardTitle>
+          <CardDescription>
+            Agregá los tutores principales que acompañarán la trayectoria del alumno.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex justify-end">
+            <Button variant="outline" onClick={() => setTutorModalOpen(true)}>
+              Agregar tutor
+            </Button>
+          </div>
+          {tutores.length ? (
+            <div className="space-y-3">
+              {tutores.map((tutor) => (
+                <div
+                  key={`${tutor.dni}-${tutor.rolVinculo}`}
+                  className="flex flex-col gap-2 rounded-md border p-3 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <p className="font-medium">
+                      {tutor.apellido}, {tutor.nombre}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      DNI {formatDni(tutor.dni)} · {formatRol(tutor.rolVinculo)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {tutor.convive ? "Convive" : "No convive"}
+                    </p>
+                    {(tutor.telefono || tutor.celular || tutor.email) && (
+                      <p className="text-xs text-muted-foreground">
+                        {[tutor.telefono, tutor.celular, tutor.email]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </p>
+                    )}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleRemoveTutor(tutor.dni, tutor.rolVinculo)}
+                  >
+                    Quitar
+                  </Button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Aún no cargaste tutores. Podés agregarlos ahora o más tarde desde el perfil del alumno.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          onClick={() => router.push("/dashboard/alumnos")}
+        >
+          Cancelar
+        </Button>
+        <Button onClick={handleCrearAlumno} disabled={creatingAlumno || !canSubmit}>
+          {creatingAlumno && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Registrar alumno
+        </Button>
+      </div>
+
+      <Dialog open={tutorModalOpen} onOpenChange={setTutorModalOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Agregar tutor</DialogTitle>
+            <DialogDescription>
+              Buscá por DNI para reutilizar fichas existentes o completá los datos para crear un nuevo tutor.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>DNI</Label>
+              <Input
+                value={tutorDraft.dni}
+                onChange={(e) =>
+                  setTutorDraft((prev) => ({
+                    ...prev,
+                    dni: formatDni(e.target.value),
+                  }))
+                }
+                placeholder="Documento del tutor"
+                disabled={savingTutorDraft}
+                inputMode="numeric"
+                pattern="\d*"
+                minLength={7}
+                maxLength={10}
+              />
+              {tutorLookupLoading && (
+                <p className="text-xs text-muted-foreground">Buscando persona…</p>
+              )}
+              {!tutorLookupLoading && tutorPersonaExists && tutorLookupCompleted && (
+                <p className="text-xs text-muted-foreground">
+                  Encontramos una persona registrada con este DNI. Revisá y completá los datos de contacto si es necesario.
+                </p>
+              )}
+              {!tutorLookupLoading && !tutorPersonaExists && tutorLookupCompleted && (
+                <p className="text-xs text-muted-foreground">
+                  No encontramos un registro previo. Completá los datos para crear al tutor.
+                </p>
+              )}
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
               <div className="space-y-2">
-                <label className="text-sm font-medium text-muted-foreground">
-                  Fecha de inscripción
-                </label>
-                <DatePicker
-                  value={alumnoForm.fechaInscripcion || undefined}
-                  onChange={(value) =>
-                    setAlumnoForm((prev) => ({
+                <Label>Nombre</Label>
+                <Input
+                  value={tutorDraft.nombre}
+                  onChange={(e) =>
+                    setTutorDraft((prev) => ({
                       ...prev,
-                      fechaInscripcion: value ?? "",
+                      nombre: e.target.value,
                     }))
                   }
-                  required
+                  disabled={savingTutorDraft}
                 />
               </div>
               <div className="space-y-2">
-                <label className="text-sm font-medium text-muted-foreground">
-                  Sección
-                </label>
-                <Select
-                  value={alumnoForm.seccionId}
-                  onValueChange={(value) =>
-                    setAlumnoForm((prev) => ({
+                <Label>Apellido</Label>
+                <Input
+                  value={tutorDraft.apellido}
+                  onChange={(e) =>
+                    setTutorDraft((prev) => ({
                       ...prev,
-                      seccionId: value,
+                      apellido: e.target.value,
                     }))
                   }
-                  disabled={!secciones.length}
+                  disabled={savingTutorDraft}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Email</Label>
+                <Input
+                  type="email"
+                  value={tutorDraft.email}
+                  onChange={(e) =>
+                    setTutorDraft((prev) => ({
+                      ...prev,
+                      email: e.target.value,
+                    }))
+                  }
+                  disabled={savingTutorDraft}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Teléfono</Label>
+                <Input
+                  value={tutorDraft.telefono}
+                  onChange={(e) =>
+                    setTutorDraft((prev) => ({
+                      ...prev,
+                      telefono: e.target.value,
+                    }))
+                  }
+                  disabled={savingTutorDraft}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Celular</Label>
+                <Input
+                  value={tutorDraft.celular}
+                  onChange={(e) =>
+                    setTutorDraft((prev) => ({
+                      ...prev,
+                      celular: e.target.value,
+                    }))
+                  }
+                  disabled={savingTutorDraft}
+                />
+              </div>
+            </div>
+
+            <Separator />
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
+              <div className="space-y-2">
+                <Label>Rol familiar</Label>
+                <Select
+                  value={tutorDraft.rolVinculo || ""}
+                  onValueChange={(value) =>
+                    setTutorDraft((prev) => ({
+                      ...prev,
+                      rolVinculo: value as RolVinculo,
+                    }))
+                  }
+                  disabled={savingTutorDraft}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder="Seleccioná la sección" />
+                    <SelectValue placeholder="Seleccioná un rol" />
                   </SelectTrigger>
                   <SelectContent>
-                    {secciones.map((sec) => (
-                      <SelectItem key={sec.id} value={String(sec.id)}>
-                        {sec.nivel} — {sec.gradoSala} {sec.division} ({sec.turno})
+                    {rolOptions.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {formatRol(option)}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
-                {!secciones.length && (
-                  <p className="text-xs text-muted-foreground">
-                    No hay secciones disponibles para el período escolar activo.
-                  </p>
-                )}
               </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-muted-foreground">
-                  Motivo de rechazo (opcional)
-                </label>
-                <Textarea
-                  rows={3}
-                  value={alumnoForm.motivoRechazoBaja}
-                  onChange={(e) =>
-                    setAlumnoForm((prev) => ({
+              <div className="flex items-center gap-2 md:justify-center">
+                <Checkbox
+                  id="tutor-convive"
+                  checked={tutorDraft.convive}
+                  onCheckedChange={(checked) =>
+                    setTutorDraft((prev) => ({
                       ...prev,
-                      motivoRechazoBaja: e.target.value,
+                      convive: Boolean(checked),
                     }))
                   }
-                  placeholder="Por ejemplo, si se rechazó una baja previa o requiere seguimiento especial"
+                  disabled={savingTutorDraft}
                 />
+                <Label htmlFor="tutor-convive">Convive</Label>
               </div>
             </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-muted-foreground">
-                Observaciones generales
-              </label>
-              <Textarea
-                rows={4}
-                value={alumnoForm.observacionesGenerales}
-                onChange={(e) =>
-                  setAlumnoForm((prev) => ({
-                    ...prev,
-                    observacionesGenerales: e.target.value,
-                  }))
-                }
-                placeholder="Notas internas, antecedentes o información complementaria"
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        <div className="flex justify-end gap-2">
-          <Button variant="outline" onClick={() => router.push("/dashboard/alumnos")}>
-            Cancelar
-          </Button>
-          <Button onClick={handleCrearAlumno} disabled={creatingAlumno || !canSubmit}>
-            {creatingAlumno && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Registrar alumno
-          </Button>
-        </div>
-      </div>
-    
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setTutorModalOpen(false)}
+              disabled={savingTutorDraft}
+            >
+              Cancelar
+            </Button>
+            <Button onClick={handleAddTutorToList} disabled={savingTutorDraft}>
+              {savingTutorDraft && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Agregar tutor
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }
 

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -180,6 +180,16 @@ export interface AlumnoDTO {
   fechaInscripcion?: ISODate;
   observacionesGenerales?: string;
   motivoRechazoBaja?: string;
+  conectividadInternet?: string;
+  dispositivosDisponibles?: string;
+  idiomasHabladosHogar?: string;
+  enfermedadesAlergias?: string;
+  medicacionHabitual?: string;
+  limitacionesFisicas?: string;
+  tratamientosTerapeuticos?: string;
+  usoAyudasMovilidad?: boolean;
+  coberturaMedica?: string;
+  observacionesSalud?: string;
   nombre?: string;
   apellido?: string;
   dni?: string;


### PR DESCRIPTION
## Summary
- add household, health, and tutor sections to the manual student creation flow while reusing existing postulacion components
- persist tutor links and aspirant complementary data when creating students and their associated records
- extend shared DTOs to surface the new aspirant-related fields across front-end and back-end layers

## Testing
- `./mvnw test` *(fails: unable to download Maven distribution in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dece7ce19c832790e0ac8452b02ba6