### PR TITLE
Add dashboard comunicados panels and share visibility logic

### DIFF
--- a/frontend-ecep/src/app/dashboard/page.tsx
+++ b/frontend-ecep/src/app/dashboard/page.tsx
@@ -17,33 +17,181 @@ import {
   FileText,
   Ambulance,
   Bell,
+  Megaphone,
+  BellRing,
   TrendingUp,
   CircleCheck,
 } from "lucide-react";
 import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
-import { normalizeRole } from "@/lib/auth-roles";
-import { MENU, type MenuItem } from "@/lib/menu";
 import { useActivePeriod } from "@/hooks/scope/useActivePeriod"; // ← período activo + hoy
 import { useVisibleMenu } from "@/hooks/useVisibleMenu";
 import { useRecentMessages } from "@/hooks/useRecentMessages";
-
 import { useQuickStats } from "@/hooks/useQuickStats";
+import { useViewerScope } from "@/hooks/scope/useViewerScope";
+import { useScopedSecciones } from "@/hooks/scope/useScopedSecciones";
+import { useFamilyAlumnos } from "@/hooks/useFamilyAlumnos";
+import { comunicacion } from "@/services/api/modules";
+import type { ComunicadoDTO } from "@/types/api-generated";
+import {
+  buildMisNiveles,
+  buildMisSeccionesIds,
+  filterVisibleComunicados,
+  seccionIdFrom,
+  splitComunicadosPorAlcance,
+} from "@/lib/comunicados/visibility";
+
+const dateTimeFormatter = new Intl.DateTimeFormat("es-AR", {
+  dateStyle: "short",
+  timeStyle: "short",
+});
+
+function formatDateTime(value?: string | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return dateTimeFormatter.format(date);
+}
+
+function comunicadoFecha(c: ComunicadoDTO): string | null {
+  return c.fechaCreacion ?? c.fechaPublicacion ?? c.fechaProgPublicacion ?? null;
+}
+
+function preview(text?: string | null, max = 180) {
+  const clean = (text ?? "").replace(/\s+/g, " ").trim();
+  return clean.length <= max ? clean : `${clean.slice(0, max)}…`;
+}
+
+function seccionLabelFrom(item: any): string | null {
+  const grado =
+    item?.gradoSala ??
+    item?.grado ??
+    item?.seccionActual?.gradoSala ??
+    item?.seccion?.gradoSala ??
+    "";
+  const division =
+    item?.division ??
+    item?.seccionActual?.division ??
+    item?.seccion?.division ??
+    "";
+  const base = `${grado ?? ""} ${division ?? ""}`.trim();
+  const nombre =
+    item?.nombre ??
+    item?.seccionActual?.nombre ??
+    item?.seccion?.nombre ??
+    base;
+  const turno =
+    item?.turno ?? item?.seccionActual?.turno ?? item?.seccion?.turno ?? "";
+  const label = (nombre || base || null) as string | null;
+  if (!label) return null;
+  return turno ? `${label} (${turno})` : label;
+}
 
 // y usás: stats?.alumnosActivos, stats?.docentesActivos, etc.
 // con fallback 0 mientras carga
 export default function DashboardPage() {
-  const { user, selectedRole } = useAuth();
+  const { user } = useAuth();
+  const { type, activeRole } = useViewerScope();
+  const role = activeRole ?? null;
+
+  const { periodoEscolarId } = useActivePeriod();
+  const { secciones } = useScopedSecciones({
+    periodoEscolarId: periodoEscolarId ?? undefined,
+  });
+  const { alumnos: hijos } = useFamilyAlumnos();
+
+  const [comunicados, setComunicados] = useState<ComunicadoDTO[]>([]);
+  const [loadingComunicados, setLoadingComunicados] = useState(true);
 
   // --------- MENSAJES RECIENTES ----------
   const { items: recentMsgs, loading: loadingMsgs } = useRecentMessages(5);
-
-  const role = selectedRole ? normalizeRole(selectedRole) : null;
 
   const menuByRole = useVisibleMenu(role);
 
   // --------- STATS ----------
   const { data: stats, loading: loadingStats } = useQuickStats();
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        setLoadingComunicados(true);
+        const res = await comunicacion.comunicados.list();
+        if (!alive) return;
+        setComunicados(res.data ?? []);
+      } catch (error) {
+        console.error("No se pudieron cargar los comunicados", error);
+      } finally {
+        if (alive) setLoadingComunicados(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const misSeccionesIds = useMemo(
+    () => buildMisSeccionesIds(type, secciones, hijos) ?? new Set<number>(),
+    [type, secciones, hijos],
+  );
+
+  const misNiveles = useMemo(
+    () => buildMisNiveles(type, secciones, hijos) ?? new Set<string>(),
+    [type, secciones, hijos],
+  );
+
+  const visiblesComunicados = useMemo(
+    () =>
+      filterVisibleComunicados({
+        comunicados,
+        type,
+        role,
+        misSeccionesIds,
+        misNiveles,
+        secciones,
+        hijos,
+      }),
+    [comunicados, type, role, misSeccionesIds, misNiveles, secciones, hijos],
+  );
+
+  const sortedComunicados = useMemo(() => {
+    return [...visiblesComunicados].sort((a, b) => {
+      const fechaA = comunicadoFecha(a);
+      const fechaB = comunicadoFecha(b);
+      const timeA = fechaA ? new Date(fechaA).getTime() : 0;
+      const timeB = fechaB ? new Date(fechaB).getTime() : 0;
+      return timeB - timeA;
+    });
+  }, [visiblesComunicados]);
+
+  const { generales, especificos } = useMemo(
+    () => splitComunicadosPorAlcance(sortedComunicados),
+    [sortedComunicados],
+  );
+
+  const generalesPreview = useMemo(
+    () => generales.slice(0, 3),
+    [generales],
+  );
+
+  const especificosPreview = useMemo(
+    () => especificos.slice(0, 3),
+    [especificos],
+  );
+
+  const seccionNameById = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const item of secciones ?? []) {
+      const id = seccionIdFrom(item) ?? item?.id;
+      if (typeof id !== "number" || Number.isNaN(id)) continue;
+      const label = seccionLabelFrom(item);
+      if (label) {
+        map.set(id, label);
+      }
+    }
+    return map;
+  }, [secciones]);
 
   // --------- QUICK ACTIONS (filtrado correcto) ----------
   const visibleQuickActions = useMemo(
@@ -224,8 +372,154 @@ export default function DashboardPage() {
               )}
             </CardContent>
           </Card>
+
+          {/* Comunicados institucionales */}
+          <Card className="col-span-4">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Megaphone className="h-4 w-4" />
+                Comunicados institucionales
+              </CardTitle>
+              <CardDescription>
+                Últimos avisos publicados para toda la comunidad educativa.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loadingComunicados ? (
+                <LoadingState label="Cargando comunicados…" />
+              ) : generalesPreview.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No hay comunicados institucionales recientes.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {generalesPreview.map((comunicado) => (
+                    <ComunicadoListItem
+                      key={comunicado.id}
+                      comunicado={comunicado}
+                      seccionNameById={seccionNameById}
+                    />
+                  ))}
+                </div>
+              )}
+              <div className="mt-4 flex justify-end">
+                <Link
+                  href="/dashboard/comunicados"
+                  className="text-sm font-medium text-primary hover:underline"
+                >
+                  Ver todos los comunicados
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Comunicados para tu nivel/sección */}
+          <Card className="col-span-4 lg:col-span-3">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <BellRing className="h-4 w-4" />
+                Avisos para vos
+              </CardTitle>
+              <CardDescription>
+                Comunicados dirigidos a tus niveles o secciones asignadas.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loadingComunicados ? (
+                <LoadingState label="Cargando comunicados…" />
+              ) : especificosPreview.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No hay comunicados específicos para tu perfil.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {especificosPreview.map((comunicado) => (
+                    <ComunicadoListItem
+                      key={comunicado.id}
+                      comunicado={comunicado}
+                      seccionNameById={seccionNameById}
+                    />
+                  ))}
+                </div>
+              )}
+              <div className="mt-4 flex justify-end">
+                <Link
+                  href="/dashboard/comunicados"
+                  className="text-sm font-medium text-primary hover:underline"
+                >
+                  Gestionar comunicados
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
         </div>
       </div>
-    
+
   );
+}
+
+function ComunicadoListItem({
+  comunicado,
+  seccionNameById,
+}: {
+  comunicado: ComunicadoDTO;
+  seccionNameById: Map<number, string>;
+}) {
+  const fecha = comunicadoFecha(comunicado);
+
+  return (
+    <div className="rounded-lg border border-border p-3 transition-colors hover:bg-muted/70">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h4 className="text-sm font-semibold leading-snug">
+            {comunicado.titulo ?? "Sin título"}
+          </h4>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <ComunicadoScopeBadge
+              comunicado={comunicado}
+              seccionNameById={seccionNameById}
+            />
+          </div>
+        </div>
+        {fecha && (
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {formatDateTime(fecha)}
+          </span>
+        )}
+      </div>
+      <div className="mt-2 text-sm text-muted-foreground">
+        {preview(comunicado.cuerpo, 160)}
+      </div>
+    </div>
+  );
+}
+
+function ComunicadoScopeBadge({
+  comunicado,
+  seccionNameById,
+}: {
+  comunicado: ComunicadoDTO;
+  seccionNameById: Map<number, string>;
+}) {
+  if (comunicado.alcance === "INSTITUCIONAL") {
+    return (
+      <Badge variant="default">
+        <Megaphone className="mr-1 h-3 w-3" /> Institucional
+      </Badge>
+    );
+  }
+
+  if (comunicado.alcance === "POR_NIVEL") {
+    return <Badge variant="secondary">Nivel {comunicado.nivel}</Badge>;
+  }
+
+  if (comunicado.alcance === "POR_SECCION") {
+    const id = comunicado.seccionId;
+    const label =
+      (typeof id === "number" && seccionNameById.get(id)) ||
+      (typeof id === "number" ? `Sección ${id}` : "Sección");
+    return <Badge variant="outline">{label}</Badge>;
+  }
+
+  return <Badge variant="outline">Comunicado</Badge>;
 }

--- a/frontend-ecep/src/lib/comunicados/visibility.ts
+++ b/frontend-ecep/src/lib/comunicados/visibility.ts
@@ -1,0 +1,148 @@
+import type { useViewerScope } from "@/hooks/scope/useViewerScope";
+import { UserRole, type ComunicadoDTO } from "@/types/api-generated";
+
+type ViewerScopeType = ReturnType<typeof useViewerScope>["type"];
+
+type MaybeSet<T> = Set<T> | undefined;
+
+const ADMIN_LIKE_ROLES = new Set<UserRole>([
+  UserRole.DIRECTOR,
+  UserRole.ADMIN,
+  UserRole.SECRETARY,
+  UserRole.COORDINATOR,
+]);
+
+const TEACHER_ROLES = new Set<UserRole>([
+  UserRole.TEACHER,
+  UserRole.ALTERNATE,
+]);
+
+export function isAdminLikeRole(role: UserRole | null | undefined) {
+  return role != null && ADMIN_LIKE_ROLES.has(role);
+}
+
+export function isTeacherRole(role: UserRole | null | undefined) {
+  return role != null && TEACHER_ROLES.has(role);
+}
+
+export function nivelEnumFromSeccion(
+  s: any,
+): "INICIAL" | "PRIMARIO" {
+  const n = (
+    s?.nivel ??
+    s?.seccionActual?.nivel ??
+    s?.seccion?.nivel ??
+    ""
+  )
+    .toString()
+    .toUpperCase();
+  return n === "PRIMARIO" ? "PRIMARIO" : "INICIAL";
+}
+
+export function seccionIdFrom(item: any): number | null {
+  if (!item) return null;
+  if (typeof item.seccionId === "number") return item.seccionId;
+  if (typeof item.seccionId === "string") return Number(item.seccionId);
+  if (typeof item?.seccionActual?.id === "number") return item.seccionActual.id;
+  if (typeof item?.seccion?.id === "number") return item.seccion.id;
+  if (typeof item?.seccionId?.id === "number") return item.seccionId.id;
+  return null;
+}
+
+export function buildMisSeccionesIds(
+  type: ViewerScopeType,
+  secciones: any[] | undefined,
+  hijos: any[] | undefined,
+): MaybeSet<number> {
+  if (type === "teacher") {
+    return new Set<number>(
+      (secciones ?? [])
+        .map((s: any) => Number(seccionIdFrom(s) ?? s?.id))
+        .filter((id): id is number => Number.isFinite(id)),
+    );
+  }
+  if (type === "family" || type === "student") {
+    const ids = (hijos ?? [])
+      .map((h: any) => seccionIdFrom(h) ?? seccionIdFrom(h?.seccionActual))
+      .filter((id): id is number => typeof id === "number" && !Number.isNaN(id));
+    return new Set<number>(ids);
+  }
+  return undefined;
+}
+
+export function buildMisNiveles(
+  type: ViewerScopeType,
+  secciones: any[] | undefined,
+  hijos: any[] | undefined,
+): MaybeSet<string> {
+  const niveles: Array<"INICIAL" | "PRIMARIO"> = [];
+  if (type === "teacher") {
+    for (const s of secciones ?? []) niveles.push(nivelEnumFromSeccion(s));
+  } else if (type === "family" || type === "student") {
+    for (const h of hijos ?? []) niveles.push(nivelEnumFromSeccion(h));
+  }
+  return niveles.length ? new Set<string>(niveles) : undefined;
+}
+
+type VisibleParams = {
+  comunicados: ComunicadoDTO[] | undefined;
+  type: ViewerScopeType;
+  role: UserRole | null | undefined;
+  misSeccionesIds?: MaybeSet<number>;
+  misNiveles?: MaybeSet<string>;
+  secciones?: any[];
+  hijos?: any[];
+};
+
+export function filterVisibleComunicados({
+  comunicados,
+  type,
+  role,
+  misSeccionesIds,
+  misNiveles,
+  secciones,
+  hijos,
+}: VisibleParams) {
+  const todos = comunicados ?? [];
+
+  const adminLike = isAdminLikeRole(role);
+
+  if (type === "staff" || adminLike) {
+    return todos;
+  }
+
+  const seccionIds =
+    misSeccionesIds ?? buildMisSeccionesIds(type, secciones, hijos);
+  const niveles = misNiveles ?? buildMisNiveles(type, secciones, hijos);
+
+  return todos.filter((c) => {
+    if (c.alcance === "INSTITUCIONAL") return true;
+    if (c.alcance === "POR_NIVEL") {
+      if (!c.nivel) return false;
+      if (!niveles) return false;
+      return niveles.has(String(c.nivel).toUpperCase());
+    }
+    if (c.alcance === "POR_SECCION") {
+      const id = c.seccionId;
+      if (typeof id !== "number") return false;
+      if (!seccionIds) return false;
+      return seccionIds.has(id);
+    }
+    return false;
+  });
+}
+
+export function splitComunicadosPorAlcance(comunicados: ComunicadoDTO[]) {
+  const generales: ComunicadoDTO[] = [];
+  const especificos: ComunicadoDTO[] = [];
+
+  for (const c of comunicados) {
+    if (c.alcance === "INSTITUCIONAL") {
+      generales.push(c);
+    } else if (c.alcance === "POR_NIVEL" || c.alcance === "POR_SECCION") {
+      especificos.push(c);
+    }
+  }
+
+  return { generales, especificos };
+}


### PR DESCRIPTION
## Summary
- extract reusable helpers to compute comunicado visibility by user scope
- display institutional and targeted comunicado previews on the dashboard
- update the comunicados listing page to rely on the shared filtering utilities

## Testing
- npm run lint *(fails: local Next.js binary not available in container)*
- npx tsc --noEmit *(fails: pre-existing JSX syntax errors in src/app/dashboard/actas/seccion/[id]/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68decec810888327a9a849bd5940580e