### PR TITLE
Restringir informes iniciales a trimestres cerrados

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/InformeInicialService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/application/InformeInicialService.java
@@ -1,25 +1,35 @@
 package edu.ecep.base_app.gestionacademica.application;
 
 import edu.ecep.base_app.gestionacademica.domain.InformeInicial;
+import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
 import edu.ecep.base_app.gestionacademica.presentation.dto.InformeInicialCreateDTO;
 import edu.ecep.base_app.gestionacademica.presentation.dto.InformeInicialDTO;
 import edu.ecep.base_app.gestionacademica.infrastructure.mapper.InformeInicialMapper;
 import edu.ecep.base_app.gestionacademica.infrastructure.persistence.InformeInicialRepository;
-import edu.ecep.base_app.gestionacademica.infrastructure.persistence.TrimestreRepository;
+import edu.ecep.base_app.identidad.application.PersonaAccountService;
+import edu.ecep.base_app.identidad.domain.enums.UserRole;
 import edu.ecep.base_app.shared.exception.NotFoundException;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 
 @Service @RequiredArgsConstructor
 public class InformeInicialService {
-    private final InformeInicialRepository repo; private final InformeInicialMapper mapper; private final TrimestreRepository trimRepo;
-    public List<InformeInicialDTO> findAll(){ return repo.findAll().stream().map(mapper::toDto).toList(); }
+    private final InformeInicialRepository repo; private final InformeInicialMapper mapper; private final PersonaAccountService personaAccountService;
+    public List<InformeInicialDTO> findAll(){
+        var informes = shouldRestrictToClosedTrimestres()
+                ? repo.findByTrimestreEstado(TrimestreEstado.CERRADO)
+                : repo.findAll();
+        return informes.stream().map(mapper::toDto).toList();
+    }
     public InformeInicialDTO get(Long id){
-        return repo.findById(id).map(mapper::toDto).orElseThrow(NotFoundException::new);
+        var informe = shouldRestrictToClosedTrimestres()
+                ? repo.findByIdAndTrimestreEstado(id, TrimestreEstado.CERRADO)
+                : repo.findById(id);
+        return informe.map(mapper::toDto).orElseThrow(NotFoundException::new);
     }
     public Long create(InformeInicialCreateDTO dto) {
         return repo.save(mapper.toEntity(dto)).getId();
@@ -32,5 +42,25 @@ public class InformeInicialService {
     public void delete(Long id){
         if(!repo.existsById(id)) throw new NotFoundException();
         repo.deleteById(id);
+    }
+
+    private boolean shouldRestrictToClosedTrimestres() {
+        try {
+            var persona = personaAccountService.getCurrentPersona();
+            if(persona == null || persona.getRoles() == null || persona.getRoles().isEmpty()) {
+                return false;
+            }
+            if(!persona.getRoles().contains(UserRole.FAMILY)) {
+                return false;
+            }
+            for (UserRole role : persona.getRoles()) {
+                if(role != UserRole.FAMILY && role != UserRole.USER) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (ResponseStatusException ex) {
+            return false;
+        }
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/InformeInicialRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/gestionacademica/infrastructure/persistence/InformeInicialRepository.java
@@ -1,9 +1,16 @@
 package edu.ecep.base_app.gestionacademica.infrastructure.persistence;
 
 import edu.ecep.base_app.gestionacademica.domain.InformeInicial;
+import edu.ecep.base_app.gestionacademica.domain.TrimestreEstado;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
 
 public interface InformeInicialRepository extends JpaRepository<InformeInicial, Long> {
     boolean existsByTrimestreIdAndMatriculaId(Long trimestreId, Long matriculaId);
+
+    List<InformeInicial> findByTrimestreEstado(TrimestreEstado estado);
+
+    Optional<InformeInicial> findByIdAndTrimestreEstado(Long id, TrimestreEstado estado);
 }

--- a/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
+++ b/frontend-ecep/src/app/dashboard/calificaciones/_components/FamilyCalificacionesView.tsx
@@ -287,14 +287,21 @@ export default function FamilyCalificacionesView({
 
         const informesFiltrados = (informesRes.data ?? []).filter((inf) => {
           if (!matriculaIds.includes(inf.matriculaId ?? -1)) return false;
-          if (!allowedTrimestreIds || allowedTrimestreIds.size === 0)
-            return true;
           const triId =
             inf.trimestreId ??
             (inf as any).trimestreId ??
             (inf as any).trimestre?.id ??
             null;
-          return typeof triId === "number" && allowedTrimestreIds.has(triId);
+          if (typeof triId !== "number") return false;
+          if (
+            allowedTrimestreIds &&
+            allowedTrimestreIds.size > 0 &&
+            !allowedTrimestreIds.has(triId)
+          ) {
+            return false;
+          }
+          const trimestre = allTrimestresById.get(triId);
+          return getTrimestreEstado(trimestre) === "cerrado";
         });
         setInformes(informesFiltrados);
       } catch (error: any) {

--- a/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
+++ b/frontend-ecep/src/app/dashboard/evaluaciones/_components/FamilyEvaluationsView.tsx
@@ -30,6 +30,7 @@ import type {
 } from "@/types/api-generated";
 import { NivelAcademico as NivelAcademicoEnum } from "@/types/api-generated";
 import { calendario, gestionAcademica } from "@/services/api/modules";
+import { getTrimestreEstado } from "@/lib/trimestres";
 import { useCalendarRefresh } from "@/hooks/useCalendarRefresh";
 import { CheckCircle2, Clock, FileText, GraduationCap } from "lucide-react";
 
@@ -206,9 +207,9 @@ export function FamilyEvaluationsView({
             if (inf.trimestreId != null) map.set(inf.trimestreId, inf);
           }
 
-          const ordenados = Array.from(mapaTrimestres.values()).sort(
-            (a, b) => (a.orden ?? 0) - (b.orden ?? 0),
-          );
+          const ordenados = Array.from(mapaTrimestres.values())
+            .filter((tri) => getTrimestreEstado(tri) === "cerrado")
+            .sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0));
 
           setInformesInicial(
             ordenados.map((tri) => ({


### PR DESCRIPTION
## Summary
- filtrar los informes iniciales que entrega el backend para familias a trimestres cerrados
- agregar consultas de repositorio para validar el estado del trimestre asociado
- ocultar en la interfaz familiar los informes de trimestres abiertos en calificaciones y evaluaciones

## Testing
- ./mvnw -q test *(falla: no se pudo descargar dependencias de Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68decf9aa3f88327ac8b5616ef981bb2