### PR TITLE
Fix DTO runtime reference in alumnos page

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import LoadingState from "@/components/common/LoadingState";
 import { useRouter } from "next/navigation";
-import type * as DTO from "@/types/api-generated";
+import * as DTO from "@/types/api-generated";
 import { UserRole } from "@/types/api-generated";
 import {
   Card,


### PR DESCRIPTION
## Summary
- switch the alumnos dashboard page to use a value import for the DTO namespace so runtime enums are available

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dedfc7461083279c088d12009ebdea