### PR TITLE
Avoid chat persona search without query

### DIFF
--- a/frontend-ecep/src/app/dashboard/chat/page.tsx
+++ b/frontend-ecep/src/app/dashboard/chat/page.tsx
@@ -137,9 +137,14 @@ export default function ChatComponent() {
     if (!user) return;
     const query = searchTerm.trim();
 
+    if (!query) {
+      setPersonas([]);
+      return () => undefined;
+    }
+
     const debounceTimer = setTimeout(() => {
       identidad.personasCore
-        .searchCredenciales(query || undefined)
+        .searchCredenciales(query)
         .then(({ data }) => {
           const results = (data ?? []).filter((p) => p.id !== user.id);
           setPersonas(results);


### PR DESCRIPTION
## Summary
- prevent chat persona search from running with an empty query
- clear previous search results when query is blank to avoid erroneous API calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def447790883279080cd43b3d0e93b