### PR TITLE
Enhance alumno edit form with full aspirant data

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/alta/page.tsx
@@ -107,7 +107,7 @@ const emptyAlumno: AlumnoForm = {
 type AspiranteComplementoForm = Pick<
   PostulacionFormData,
   |
-    | "conectividadInternet"
+    "conectividadInternet"
     | "dispositivosDisponibles"
     | "idiomasHabladosHogar"
     | "enfermedadesAlergias"


### PR DESCRIPTION
## Summary
- fix the postulant complement union in the alta page so the form compiles again
- extend the alumno edit dialog to capture hogar and salud information plus additional personal fields
- surface the stored hogar, salud, and academic observations directly on the alumno profile cards

## Testing
- npm run lint *(fails: next: not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df006d059c8327b1ec53e349424ecc