### PR TITLE
Add baja request workflow to student profile

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -34,13 +34,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Download,
-  Search,
-  TimerReset,
-  UserPlus,
-  UserMinus,
-} from "lucide-react";
+import { Download, Search, TimerReset, UserPlus } from "lucide-react";
 import { useScopedIndex } from "@/hooks/scope/useScopedIndex";
 import FamilyView from "./_components/FamilyView";
 import AspirantesTab from "./_components/AspirantesTabs";
@@ -972,9 +966,6 @@ export default function AlumnosIndexPage() {
                         onClick={fetchSolicitudesBaja}
                       >
                         <TimerReset className="mr-2 h-4 w-4" /> Actualizar
-                      </Button>
-                      <Button size="sm" onClick={() => setCrearBajaOpen(true)}>
-                        <UserMinus className="mr-2 h-4 w-4" /> Nueva baja
                       </Button>
                     </div>
                   </CardHeader>


### PR DESCRIPTION
## Summary
- add a staff-only baja request dialog to the student profile, including debt confirmation, progress state, and pending request detection
- surface pending baja state in the profile header and document the action via tooltip messaging for Dirección
- remove the manual baja creation button from the bajas tab in the alumnos dashboard list

## Testing
- pnpm lint *(fails: next binary missing because dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df0381dfd08327b614b8cfb7bdd367