### PR TITLE
Associate boletin subjects with teachers and observations

### DIFF
--- a/frontend-ecep/src/app/dashboard/reportes/_components/BoletinesReport.tsx
+++ b/frontend-ecep/src/app/dashboard/reportes/_components/BoletinesReport.tsx
@@ -52,6 +52,7 @@ export type BoletinesReportProps = {
       name: string;
       teacher: string | null;
       grade: string;
+      observations: string | null;
     }[];
   }[];
 };
@@ -389,11 +390,14 @@ function BoletinSubjectsDetail({
                 <div className="divide-y">
                   {trimester.subjects.map((subject) => {
                     const displayTeacher = sanitizeTeacherName(subject.teacher);
+                    const hasObservations = Boolean(
+                      subject.observations && subject.observations.trim(),
+                    );
 
                     return (
                       <div
                         key={subject.id}
-                        className="flex items-start justify-between gap-3 px-4 py-3"
+                        className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-start sm:justify-between"
                       >
                         <div className="space-y-1">
                           <p className="text-sm font-semibold text-foreground">
@@ -404,8 +408,13 @@ function BoletinSubjectsDetail({
                               Docente: {displayTeacher}
                             </p>
                           )}
+                          {hasObservations && (
+                            <p className="text-xs text-muted-foreground whitespace-pre-line">
+                              Observaciones: {subject.observations?.trim()}
+                            </p>
+                          )}
                         </div>
-                        <span className="rounded-md bg-muted px-2 py-1 text-sm font-semibold text-foreground whitespace-nowrap">
+                        <span className="self-start whitespace-nowrap rounded-md bg-muted px-2 py-1 text-sm font-semibold text-foreground sm:self-center">
                           {subject.grade ?? "—"}
                         </span>
                       </div>

--- a/frontend-ecep/src/app/dashboard/reportes/types.ts
+++ b/frontend-ecep/src/app/dashboard/reportes/types.ts
@@ -9,6 +9,7 @@ export type BoletinSubjectGrade = {
 export type BoletinSubject = {
   id: string;
   name: string;
+  teacherIds?: number[];
   teacher?: string | null;
   grades: BoletinSubjectGrade[];
 };

--- a/frontend-ecep/src/lib/pdf/report-helpers.ts
+++ b/frontend-ecep/src/lib/pdf/report-helpers.ts
@@ -29,6 +29,7 @@ export type BoletinReportTrimester = {
     name: string;
     teacher?: string | null;
     grade: string;
+    observations?: string | null;
   }[];
 };
 
@@ -225,6 +226,13 @@ const getTrimesterCardHeight = (
       );
       total += teacherLines.length * (lineHeight - 0.5);
     }
+    if (subject.observations) {
+      const observationLines = doc.splitTextToSize(
+        `Observaciones: ${subject.observations}`,
+        subjectTextWidth,
+      );
+      total += observationLines.length * (lineHeight - 0.5);
+    }
     total += lineHeight; // space for grade baseline
     if (index < trimester.subjects.length - 1) {
       total += 6;
@@ -357,6 +365,20 @@ const renderTrimesterCardsSection = (
           subjectTextWidth,
         );
         teacherLines.forEach((line) => {
+          doc.text(line, cardX + cardPaddingX, textCursorY);
+          textCursorY += lineHeight - 0.5;
+        });
+      }
+
+      if (subject.observations) {
+        doc.setFont("helvetica", "normal");
+        doc.setFontSize(9);
+        doc.setTextColor(100, 116, 139);
+        const observationLines = doc.splitTextToSize(
+          `Observaciones: ${subject.observations}`,
+          subjectTextWidth,
+        );
+        observationLines.forEach((line) => {
           doc.text(line, cardX + cardPaddingX, textCursorY);
           textCursorY += lineHeight - 0.5;
         });


### PR DESCRIPTION
## Summary
- fetch teacher assignments for secciones-materias, store the docentes asociados on each boletín subject, and refresh names once employee data is available
- surface teacher names and trimester observations in the boletín detail view
- include the new teacher and observation details when exporting boletines to PDF

## Testing
- npm run lint *(fails: `next: not found` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df090dc47c8327882e6309ebc41cef