### PR TITLE
Fix hydration issues in dashboard layout

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -80,9 +80,21 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     }
   }, [loading, user, rolesNormalized, selectedRole, setSelectedRole, router]);
 
-  if (user && rolesNormalized.length > 1 && !selectedRole) return null;
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-muted dark:bg-background">
+        <span className="text-sm text-muted-foreground">Cargando panel...</span>
+      </div>
+    );
+  }
 
-  const displayName = user?.nombreCompleto || user?.email || "Usuario";
+  if (!user) {
+    return null;
+  }
+
+  if (rolesNormalized.length > 1 && !selectedRole) return null;
+
+  const displayName = user.nombreCompleto || user.email || "Usuario";
 
   const handleChangeRole = (r: UserRole) => {
     if (currentRole === r) return;


### PR DESCRIPTION
## Summary
- add a loading fallback to the dashboard layout so it does not render menu content until authentication finishes
- avoid rendering the layout when there is no authenticated user available, preventing mismatches between server and client output

## Testing
- pnpm lint *(fails: missing local node_modules / Next.js binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc11d9d8883279968f93d62a3ac56