### PR TITLE
Adjust attendance jornada progress bar colors

### DIFF
--- a/frontend-ecep/src/app/dashboard/asistencia/_components/DetalleDiaDialog.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/_components/DetalleDiaDialog.tsx
@@ -156,7 +156,11 @@ export default function DetalleDiaDialog({
                   Porcentaje: <b>{porcentaje}%</b>
                 </span>
               </div>
-              <Progress value={porcentaje} className="h-2 mt-2" />
+              <Progress
+                value={porcentaje}
+                className="h-2 mt-2 bg-destructive"
+                indicatorClassName="bg-emerald-500"
+              />
             </div>
 
             <div className="space-y-2">

--- a/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/asistencia/seccion/[id]/page.tsx
@@ -718,7 +718,8 @@ export default function SeccionHistorialPage() {
                                             </div>
                                             <Progress
                                               value={selectedResumenPercent}
-                                              className="h-2"
+                                              className="h-2 bg-destructive"
+                                              indicatorClassName="bg-emerald-500"
                                             />
                                           </div>
                                         </div>
@@ -786,7 +787,8 @@ export default function SeccionHistorialPage() {
                                   </div>
                                   <Progress
                                     value={Math.round(r.porcentaje)}
-                                    className="h-2"
+                                    className="h-2 bg-destructive"
+                                    indicatorClassName="bg-emerald-500"
                                   />
                                 </div>
                               ))

--- a/frontend-ecep/src/components/ui/progress.tsx
+++ b/frontend-ecep/src/components/ui/progress.tsx
@@ -5,10 +5,15 @@ import * as ProgressPrimitive from '@radix-ui/react-progress';
 
 import { cn } from '@/lib/utils';
 
+interface ProgressProps
+  extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  indicatorClassName?: string;
+}
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  ProgressProps
+>(({ className, value, indicatorClassName, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +23,10 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn(
+        'h-full w-full flex-1 bg-primary transition-all',
+        indicatorClassName
+      )}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
## Summary
- extend the shared Progress component to accept custom indicator classes so attendance views can override colors
- apply the jornada attendance progress bars to use the emerald present fill over a destructive background matching the present/absent icon palette

## Testing
- npm run lint *(fails: `next` command not found because dependencies are not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc4bbdc588327b94e365c9020b5f4