### PR TITLE
Ensure DashboardLayout hooks run consistently

### DIFF
--- a/frontend-ecep/src/app/dashboard/layout.tsx
+++ b/frontend-ecep/src/app/dashboard/layout.tsx
@@ -80,46 +80,6 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     }
   }, [loading, user, rolesNormalized, selectedRole, setSelectedRole, router]);
 
-  if (loading) {
-    return (
-      <div className="flex h-screen items-center justify-center bg-muted dark:bg-background">
-        <span className="text-sm text-muted-foreground">Cargando panel...</span>
-      </div>
-    );
-  }
-
-  if (!user) {
-    return null;
-  }
-
-  if (rolesNormalized.length > 1 && !selectedRole) return null;
-
-  const displayName = user.nombreCompleto || user.email || "Usuario";
-
-  const handleChangeRole = (r: UserRole) => {
-    if (currentRole === r) return;
-
-    setSelectedRole(r);
-
-    // Siempre mandamos al usuario al inicio del dashboard para evitar rutas
-    // incompatibles con el nuevo rol seleccionado.
-    router.replace("/dashboard");
-  };
-
-  const handleLogout = async (e?: React.FormEvent) => {
-    e?.preventDefault();
-    logout();
-  };
-
-  const handleNavigationToggle = () => {
-    if (isDesktop) {
-      setIsCollapsed((prev) => !prev);
-      return;
-    }
-
-    setSidebarOpen((prev) => !prev);
-  };
-
   // ⭐ Agrupación dinámica por `group` preservando orden
   const groupedMenu = useMemo(() => {
     const map = new Map<string, MenuItem[]>();
@@ -159,6 +119,46 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
       mediaQuery.removeListener(listener);
     };
   }, []);
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-muted dark:bg-background">
+        <span className="text-sm text-muted-foreground">Cargando panel...</span>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  if (rolesNormalized.length > 1 && !selectedRole) return null;
+
+  const displayName = user.nombreCompleto || user.email || "Usuario";
+
+  const handleChangeRole = (r: UserRole) => {
+    if (currentRole === r) return;
+
+    setSelectedRole(r);
+
+    // Siempre mandamos al usuario al inicio del dashboard para evitar rutas
+    // incompatibles con el nuevo rol seleccionado.
+    router.replace("/dashboard");
+  };
+
+  const handleLogout = async (e?: React.FormEvent) => {
+    e?.preventDefault();
+    logout();
+  };
+
+  const handleNavigationToggle = () => {
+    if (isDesktop) {
+      setIsCollapsed((prev) => !prev);
+      return;
+    }
+
+    setSidebarOpen((prev) => !prev);
+  };
 
   const isNavCollapsed = isDesktop && isCollapsed;
   const isNavigationOpen = isDesktop ? !isNavCollapsed : sidebarOpen;


### PR DESCRIPTION
## Summary
- move grouped menu memoization and media query effect before early returns so all hooks run in a stable order
- keep loading and auth guards after hooks to avoid React hook order warnings

## Testing
- `npm run lint` *(fails: `next` executable not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc56fd8088327805731964f86719f