### PR TITLE
Refactor baja workflow with administrative review

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/application/SolicitudBajaAlumnoService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/application/SolicitudBajaAlumnoService.java
@@ -2,6 +2,7 @@ package edu.ecep.base_app.vidaescolar.application;
 
 import edu.ecep.base_app.shared.exception.NotFoundException;
 import edu.ecep.base_app.vidaescolar.domain.SolicitudBajaAlumno;
+import edu.ecep.base_app.vidaescolar.domain.enums.EstadoRevisionAdministrativa;
 import edu.ecep.base_app.vidaescolar.domain.enums.EstadoSolicitudBaja;
 import edu.ecep.base_app.vidaescolar.infrastructure.mapper.SolicitudBajaAlumnoMapper;
 import edu.ecep.base_app.vidaescolar.infrastructure.persistence.SolicitudBajaAlumnoRepository;
@@ -9,6 +10,7 @@ import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoCreateD
 import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoDTO;
 import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoDecisionDTO;
 import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoRechazoDTO;
+import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoRevisionAdministrativaDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +48,8 @@ public class SolicitudBajaAlumnoService {
     public void aprobar(Long id, SolicitudBajaAlumnoDecisionDTO dto) {
         SolicitudBajaAlumno solicitud = obtenerPendiente(id);
 
+        validarRevisionAdministrativaRealizada(solicitud);
+
         if (!StringUtils.hasText(solicitud.getMotivo())) {
             throw new IllegalStateException("La solicitud debe tener un motivo registrado antes de aprobarla");
         }
@@ -62,6 +66,8 @@ public class SolicitudBajaAlumnoService {
     public void rechazar(Long id, SolicitudBajaAlumnoRechazoDTO dto) {
         SolicitudBajaAlumno solicitud = obtenerPendiente(id);
 
+        validarRevisionAdministrativaRealizada(solicitud);
+
         if (!StringUtils.hasText(dto.getMotivoRechazo())) {
             throw new IllegalArgumentException("Debe indicar un motivo de rechazo");
         }
@@ -73,11 +79,52 @@ public class SolicitudBajaAlumnoService {
         solicitud.setFechaDecision(OffsetDateTime.now());
     }
 
-    private Long requirePersonaDecisor(Long personaDecisorId) {
-        if (personaDecisorId == null) {
-            throw new IllegalArgumentException("Debe indicar la persona que decide la solicitud");
+    @Transactional
+    public void registrarRevisionAdministrativa(
+            Long id, SolicitudBajaAlumnoRevisionAdministrativaDTO dto) {
+        SolicitudBajaAlumno solicitud = obtenerPendiente(id);
+
+        if (solicitud.getEstadoRevisionAdministrativa() != EstadoRevisionAdministrativa.PENDIENTE) {
+            throw new IllegalStateException("La solicitud ya fue revisada por administración");
         }
-        return personaDecisorId;
+
+        Long personaRevisoraId = requirePersonaRevisora(dto.getRevisadoPorPersonaId());
+
+        EstadoRevisionAdministrativa nuevoEstado = dto.getEstadoRevisionAdministrativa();
+        if (nuevoEstado == null) {
+            throw new IllegalArgumentException("Debe indicar el resultado de la revisión administrativa");
+        }
+
+        String observacion =
+                StringUtils.hasText(dto.getObservacionRevisionAdministrativa())
+                        ? dto.getObservacionRevisionAdministrativa().trim()
+                        : null;
+
+        if (nuevoEstado == EstadoRevisionAdministrativa.DEUDAS_INFORMADAS && !StringUtils.hasText(observacion)) {
+            throw new IllegalArgumentException(
+                    "Debe detallar las observaciones cuando se informan deudas");
+        }
+
+        solicitud.setEstadoRevisionAdministrativa(nuevoEstado);
+        solicitud.setObservacionRevisionAdministrativa(observacion);
+        solicitud.setRevisadoAdministrativamentePorPersonaId(personaRevisoraId);
+        solicitud.setFechaRevisionAdministrativa(OffsetDateTime.now());
+    }
+
+    private Long requirePersonaDecisor(Long personaDecisorId) {
+        return requirePersona(personaDecisorId, "Debe indicar la persona que decide la solicitud");
+    }
+
+    private Long requirePersonaRevisora(Long personaRevisoraId) {
+        return requirePersona(
+                personaRevisoraId, "Debe indicar la persona que revisa administrativamente la solicitud");
+    }
+
+    private Long requirePersona(Long personaId, String message) {
+        if (personaId == null) {
+            throw new IllegalArgumentException(message);
+        }
+        return personaId;
     }
 
     private SolicitudBajaAlumno obtenerPendiente(Long id) {
@@ -89,5 +136,12 @@ public class SolicitudBajaAlumnoService {
         }
 
         return solicitud;
+    }
+
+    private void validarRevisionAdministrativaRealizada(SolicitudBajaAlumno solicitud) {
+        if (solicitud.getEstadoRevisionAdministrativa() == EstadoRevisionAdministrativa.PENDIENTE) {
+            throw new IllegalStateException(
+                    "La solicitud debe contar con la revisión administrativa antes de tomar una decisión");
+        }
     }
 }

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/SolicitudBajaAlumno.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/SolicitudBajaAlumno.java
@@ -1,6 +1,7 @@
 package edu.ecep.base_app.vidaescolar.domain;
 
 import edu.ecep.base_app.shared.domain.BaseEntity;
+import edu.ecep.base_app.vidaescolar.domain.enums.EstadoRevisionAdministrativa;
 import edu.ecep.base_app.vidaescolar.domain.enums.EstadoSolicitudBaja;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -15,8 +16,22 @@ import java.time.OffsetDateTime;
 public class SolicitudBajaAlumno extends BaseEntity {
     @ManyToOne(optional=false, fetch= FetchType.LAZY) private Matricula matricula;
 
-    @Enumerated(EnumType.STRING) @Column(nullable=false)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable=false)
     private EstadoSolicitudBaja estado = EstadoSolicitudBaja.PENDIENTE;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado_revision_administrativa", nullable = false)
+    private EstadoRevisionAdministrativa estadoRevisionAdministrativa = EstadoRevisionAdministrativa.PENDIENTE;
+
+    @Column(name = "fecha_revision_administrativa")
+    private OffsetDateTime fechaRevisionAdministrativa;
+
+    @Column(name = "revisado_administrativamente_por_persona_id")
+    private Long revisadoAdministrativamentePorPersonaId;
+
+    @Column(name = "observacion_revision_administrativa")
+    private String observacionRevisionAdministrativa;
 
     private String motivo;
     private String motivoRechazo; // obligatorio si RECHAZADA

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/enums/EstadoRevisionAdministrativa.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/domain/enums/EstadoRevisionAdministrativa.java
@@ -1,0 +1,7 @@
+package edu.ecep.base_app.vidaescolar.domain.enums;
+
+public enum EstadoRevisionAdministrativa {
+    PENDIENTE,
+    CONFIRMADA,
+    DEUDAS_INFORMADAS
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/dto/SolicitudBajaAlumnoDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/dto/SolicitudBajaAlumnoDTO.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.vidaescolar.presentation.dto;
 
+import edu.ecep.base_app.vidaescolar.domain.enums.EstadoRevisionAdministrativa;
 import edu.ecep.base_app.vidaescolar.domain.enums.EstadoSolicitudBaja;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -18,8 +19,13 @@ public class SolicitudBajaAlumnoDTO {
     Long alumnoId;
     @NotNull
     EstadoSolicitudBaja estado;
+    @NotNull
+    EstadoRevisionAdministrativa estadoRevisionAdministrativa;
     String motivo;
     String motivoRechazo;
+    OffsetDateTime fechaRevisionAdministrativa;
+    Long revisadoAdministrativamentePorPersonaId;
+    String observacionRevisionAdministrativa;
     OffsetDateTime fechaDecision;
     Long decididoPorPersonaId;
     String alumnoNombre;

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/dto/SolicitudBajaAlumnoRevisionAdministrativaDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/dto/SolicitudBajaAlumnoRevisionAdministrativaDTO.java
@@ -1,0 +1,20 @@
+package edu.ecep.base_app.vidaescolar.presentation.dto;
+
+import edu.ecep.base_app.vidaescolar.domain.enums.EstadoRevisionAdministrativa;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SolicitudBajaAlumnoRevisionAdministrativaDTO {
+    @NotNull
+    private EstadoRevisionAdministrativa estadoRevisionAdministrativa;
+
+    @NotNull
+    private Long revisadoPorPersonaId;
+
+    private String observacionRevisionAdministrativa;
+}

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/rest/SolicitudBajaAlumnoController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/presentation/rest/SolicitudBajaAlumnoController.java
@@ -1,25 +1,68 @@
 package edu.ecep.base_app.vidaescolar.presentation.rest;
 
-
-import edu.ecep.base_app.vidaescolar.presentation.dto.*;
 import edu.ecep.base_app.vidaescolar.application.SolicitudBajaAlumnoService;
+import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoCreateDTO;
+import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoDTO;
+import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoDecisionDTO;
+import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoRechazoDTO;
+import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoRevisionAdministrativaDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import java.util.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-@RestController @RequestMapping("/api/bajas")
-@RequiredArgsConstructor @Validated
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/bajas")
+@RequiredArgsConstructor
+@Validated
 public class SolicitudBajaAlumnoController {
+
     private final SolicitudBajaAlumnoService service;
-    @GetMapping public List<SolicitudBajaAlumnoDTO> list(){ return service.findAll(); }
-    @GetMapping("/historial") public List<SolicitudBajaAlumnoDTO> historial(){ return service.findHistorial(); }
-    @PostMapping public ResponseEntity<Long> create(@RequestBody @Valid SolicitudBajaAlumnoCreateDTO dto){ return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED); }
-    @PostMapping("/{id}/aprobar") @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void aprobar(@PathVariable Long id, @RequestBody @Valid SolicitudBajaAlumnoDecisionDTO dto){ service.aprobar(id, dto); }
-    @PostMapping("/{id}/rechazar") @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void rechazar(@PathVariable Long id, @RequestBody @Valid SolicitudBajaAlumnoRechazoDTO dto){ service.rechazar(id, dto); }
+
+    @GetMapping
+    public List<SolicitudBajaAlumnoDTO> list() {
+        return service.findAll();
+    }
+
+    @GetMapping("/historial")
+    public List<SolicitudBajaAlumnoDTO> historial() {
+        return service.findHistorial();
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> create(@RequestBody @Valid SolicitudBajaAlumnoCreateDTO dto) {
+        return new ResponseEntity<>(service.create(dto), HttpStatus.CREATED);
+    }
+
+    @PostMapping("/{id}/revision-administrativa")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void registrarRevisionAdministrativa(
+            @PathVariable Long id,
+            @RequestBody @Valid SolicitudBajaAlumnoRevisionAdministrativaDTO dto) {
+        service.registrarRevisionAdministrativa(id, dto);
+    }
+
+    @PostMapping("/{id}/aprobar")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void aprobar(
+            @PathVariable Long id, @RequestBody @Valid SolicitudBajaAlumnoDecisionDTO dto) {
+        service.aprobar(id, dto);
+    }
+
+    @PostMapping("/{id}/rechazar")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void rechazar(
+            @PathVariable Long id, @RequestBody @Valid SolicitudBajaAlumnoRechazoDTO dto) {
+        service.rechazar(id, dto);
+    }
 }

--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -17,7 +17,6 @@ import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Step3 as HogarForm } from "@/app/postulacion/Step3";
 import { Step4 as SaludForm } from "@/app/postulacion/Step4";
 import type { PostulacionFormData } from "@/app/postulacion/types";
@@ -83,6 +82,7 @@ import type {
   SeccionDTO,
 } from "@/types/api-generated";
 import {
+  EstadoRevisionAdministrativa,
   EstadoSolicitudBaja,
   RolVinculo,
   SolicitudBajaAlumnoDTO,
@@ -160,8 +160,6 @@ export default function AlumnoPerfilPage() {
   const [reloadKey, setReloadKey] = useState(0);
   const [crearBajaOpen, setCrearBajaOpen] = useState(false);
   const [crearBajaMotivo, setCrearBajaMotivo] = useState("");
-  const [crearBajaConfirmacionDeuda, setCrearBajaConfirmacionDeuda] =
-    useState(false);
   const [crearBajaLoading, setCrearBajaLoading] = useState(false);
   const [solicitudesBaja, setSolicitudesBaja] = useState<
     SolicitudBajaAlumnoDTO[]
@@ -170,15 +168,56 @@ export default function AlumnoPerfilPage() {
     useState(false);
   const [solicitudesBajaError, setSolicitudesBajaError] =
     useState<string | null>(null);
+  const [processingDecisionSolicitudId, setProcessingDecisionSolicitudId] =
+    useState<number | null>(null);
 
   const [familiares, setFamiliares] = useState<FamiliarConVinculo[]>([]);
 
   const { periodoEscolarId: activePeriodId, getPeriodoNombre } = useActivePeriod();
-  const { hasRole } = useAuth();
+  const { hasRole, user } = useAuth();
   const { type: viewerScope } = useViewerScope();
   const canManageProfile = viewerScope === "staff";
   const canEditRoles =
     canManageProfile && (hasRole(UserRole.ADMIN) || hasRole(UserRole.DIRECTOR));
+  const personaActualId = useMemo(
+    () => user?.personaId ?? user?.id ?? null,
+    [user],
+  );
+  const puedeDecidirBaja =
+    viewerScope === "staff" && hasRole(UserRole.DIRECTOR);
+
+  const estadoSolicitudLabels: Record<EstadoSolicitudBaja, string> = {
+    [EstadoSolicitudBaja.PENDIENTE]: "Pendiente",
+    [EstadoSolicitudBaja.APROBADA]: "Aprobada",
+    [EstadoSolicitudBaja.RECHAZADA]: "Rechazada",
+  };
+
+  const estadoSolicitudVariant: Record<
+    EstadoSolicitudBaja,
+    "secondary" | "default" | "destructive"
+  > = {
+    [EstadoSolicitudBaja.PENDIENTE]: "secondary",
+    [EstadoSolicitudBaja.APROBADA]: "default",
+    [EstadoSolicitudBaja.RECHAZADA]: "destructive",
+  };
+
+  const revisionAdministrativaLabels: Record<
+    EstadoRevisionAdministrativa,
+    string
+  > = {
+    [EstadoRevisionAdministrativa.PENDIENTE]: "Pendiente",
+    [EstadoRevisionAdministrativa.CONFIRMADA]: "Sin deudas",
+    [EstadoRevisionAdministrativa.DEUDAS_INFORMADAS]: "Deudas informadas",
+  };
+
+  const revisionAdministrativaVariant: Record<
+    EstadoRevisionAdministrativa,
+    "outline" | "default" | "destructive"
+  > = {
+    [EstadoRevisionAdministrativa.PENDIENTE]: "outline",
+    [EstadoRevisionAdministrativa.CONFIRMADA]: "default",
+    [EstadoRevisionAdministrativa.DEUDAS_INFORMADAS]: "destructive",
+  };
 
   // helpers
   const toNombre = (p?: PersonaDTO | null) =>
@@ -223,6 +262,19 @@ export default function AlumnoPerfilPage() {
     if (start && !end) return `${start} – Actualidad`;
     if (!start && end) return `Hasta ${end}`;
     return "Sin fechas registradas";
+  };
+
+  const formatDateTime = (value?: string | null) => {
+    if (!value) return "—";
+    const parsed = parseDateValue(value);
+    if (!parsed) return value;
+    return parsed.toLocaleString("es-AR", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
   };
 
   const getTimeValue = (value?: string | null) => {
@@ -627,9 +679,43 @@ export default function AlumnoPerfilPage() {
     );
   }, [matriculaActual, solicitudesBaja]);
 
+  const pendingSolicitudRevisionEstado = pendingSolicitud
+    ? pendingSolicitud.estadoRevisionAdministrativa ??
+      EstadoRevisionAdministrativa.PENDIENTE
+    : null;
+
+  const pendingSolicitudTooltip = useMemo(() => {
+    if (!pendingSolicitud) return null;
+    const detalle = pendingSolicitud.observacionRevisionAdministrativa?.trim();
+    const estado =
+      pendingSolicitudRevisionEstado ?? EstadoRevisionAdministrativa.PENDIENTE;
+    if (estado === EstadoRevisionAdministrativa.PENDIENTE) {
+      return "Hay una solicitud de baja pendiente a la espera de revisión administrativa.";
+    }
+    if (estado === EstadoRevisionAdministrativa.CONFIRMADA) {
+      return "Administración confirmó la revisión. Dirección debe decidir si acepta o rechaza la baja.";
+    }
+    return `Administración informó deudas pendientes.${
+      detalle ? ` Detalle: ${detalle}` : ""
+    }`;
+  }, [pendingSolicitud, pendingSolicitudRevisionEstado]);
+
+  const pendingSolicitudBadgeClass = useMemo(() => {
+    if (!pendingSolicitudRevisionEstado) {
+      return "border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100";
+    }
+    switch (pendingSolicitudRevisionEstado) {
+      case EstadoRevisionAdministrativa.CONFIRMADA:
+        return "border-emerald-300 bg-emerald-50 text-emerald-900 hover:bg-emerald-100";
+      case EstadoRevisionAdministrativa.DEUDAS_INFORMADAS:
+        return "border-red-300 bg-red-50 text-red-900 hover:bg-red-100";
+      default:
+        return "border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100";
+    }
+  }, [pendingSolicitudRevisionEstado]);
+
   const resetCrearBajaForm = useCallback(() => {
     setCrearBajaMotivo("");
-    setCrearBajaConfirmacionDeuda(false);
     setCrearBajaLoading(false);
     setSolicitudesBajaError(null);
   }, []);
@@ -662,10 +748,6 @@ export default function AlumnoPerfilPage() {
       toast.error("El motivo de la baja es obligatorio");
       return;
     }
-    if (!crearBajaConfirmacionDeuda) {
-      toast.error("Confirmá que revisaste el estado de deudas del alumno");
-      return;
-    }
 
     setCrearBajaLoading(true);
     try {
@@ -685,13 +767,112 @@ export default function AlumnoPerfilPage() {
       setCrearBajaLoading(false);
     }
   }, [
-    crearBajaConfirmacionDeuda,
     crearBajaMotivo,
     fetchSolicitudesBaja,
     matriculaActual,
     pendingSolicitud,
     resetCrearBajaForm,
   ]);
+
+  const ensurePersonaActual = useCallback(
+    (message: string) => {
+      if (!personaActualId) {
+        toast.error(message);
+        return false;
+      }
+      return true;
+    },
+    [personaActualId],
+  );
+
+  const handleAceptarSolicitud = useCallback(
+    async (sol: SolicitudBajaAlumnoDTO) => {
+      if (
+        (sol.estadoRevisionAdministrativa ??
+          EstadoRevisionAdministrativa.PENDIENTE) ===
+        EstadoRevisionAdministrativa.PENDIENTE
+      ) {
+        toast.error(
+          "Administración debe completar la revisión antes de aceptar la baja",
+        );
+        return;
+      }
+      if (!ensurePersonaActual("No pudimos identificar a la persona que acepta la baja"))
+        return;
+      if (!window.confirm("¿Confirmás aceptar la baja del alumno?")) return;
+
+      setProcessingDecisionSolicitudId(sol.id ?? null);
+      try {
+        await vidaEscolar.solicitudesBaja.approve(sol.id!, {
+          decididoPorPersonaId: personaActualId!,
+        });
+        toast.success("Baja aceptada correctamente");
+        await fetchSolicitudesBaja();
+        setReloadKey((prev) => prev + 1);
+      } catch (error) {
+        logAlumnoError(error, "No se pudo aceptar la baja");
+        toast.error("No se pudo aceptar la baja");
+      } finally {
+        setProcessingDecisionSolicitudId(null);
+      }
+    },
+    [
+      ensurePersonaActual,
+      fetchSolicitudesBaja,
+      personaActualId,
+      setReloadKey,
+    ],
+  );
+
+  const handleRechazarSolicitud = useCallback(
+    async (sol: SolicitudBajaAlumnoDTO) => {
+      if (
+        (sol.estadoRevisionAdministrativa ??
+          EstadoRevisionAdministrativa.PENDIENTE) ===
+        EstadoRevisionAdministrativa.PENDIENTE
+      ) {
+        toast.error(
+          "Administración debe completar la revisión antes de rechazar la baja",
+        );
+        return;
+      }
+      if (!ensurePersonaActual("No pudimos identificar a la persona que rechaza la baja"))
+        return;
+
+      const reason = window.prompt(
+        "Motivo del rechazo",
+        sol.motivoRechazo ?? "",
+      );
+      if (reason == null) return;
+      const normalized = reason.trim();
+      if (!normalized) {
+        toast.error("El motivo de rechazo es obligatorio");
+        return;
+      }
+
+      setProcessingDecisionSolicitudId(sol.id ?? null);
+      try {
+        await vidaEscolar.solicitudesBaja.reject(sol.id!, {
+          decididoPorPersonaId: personaActualId!,
+          motivoRechazo: normalized,
+        });
+        toast.success("Solicitud rechazada");
+        await fetchSolicitudesBaja();
+        setReloadKey((prev) => prev + 1);
+      } catch (error) {
+        logAlumnoError(error, "No se pudo rechazar la baja");
+        toast.error("No se pudo rechazar la baja");
+      } finally {
+        setProcessingDecisionSolicitudId(null);
+      }
+    },
+    [
+      ensurePersonaActual,
+      fetchSolicitudesBaja,
+      personaActualId,
+      setReloadKey,
+    ],
+  );
 
   useEffect(() => {
     if (!editOpen) return;
@@ -1373,12 +1554,13 @@ export default function AlumnoPerfilPage() {
                   <TooltipProvider delayDuration={200}>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Badge className="border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-100">
+                        <Badge className={pendingSolicitudBadgeClass}>
                           Baja pendiente
                         </Badge>
                       </TooltipTrigger>
                       <TooltipContent side="bottom" className="max-w-xs text-xs leading-relaxed">
-                        Hay una solicitud de baja pendiente a la espera de revisión administrativa.
+                        {pendingSolicitudTooltip ??
+                          "Hay una solicitud de baja pendiente a la espera de revisión administrativa."}
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
@@ -1470,32 +1652,6 @@ export default function AlumnoPerfilPage() {
                             loadingSolicitudesBaja
                           }
                         />
-                      </div>
-                      <div className="flex items-start gap-3 rounded-md border border-border/60 p-3">
-                        <Checkbox
-                          id="crear-baja-deuda"
-                          checked={crearBajaConfirmacionDeuda}
-                          onCheckedChange={(checked) =>
-                            setCrearBajaConfirmacionDeuda(Boolean(checked))
-                          }
-                          disabled={
-                            crearBajaLoading ||
-                            !matriculaActual?.id ||
-                            loadingSolicitudesBaja
-                          }
-                        />
-                        <div className="space-y-1">
-                          <Label
-                            htmlFor="crear-baja-deuda"
-                            className="text-sm font-medium"
-                          >
-                            Confirmación administrativa
-                          </Label>
-                          <p className="text-xs text-muted-foreground">
-                            Confirmo que revisé el estado de deudas y autorizo la
-                            baja del alumno.
-                          </p>
-                        </div>
                       </div>
                     </div>
                     <DialogFooter className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
@@ -2331,11 +2487,156 @@ export default function AlumnoPerfilPage() {
                     </div>
                   )}
                 </div>
+            </CardContent>
+          </Card>
+
+          {canManageProfile && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle>Solicitudes de baja</CardTitle>
+                <CardDescription>
+                  Seguimiento del circuito de baja registrado para este alumno.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {loadingSolicitudesBaja ? (
+                  <LoadingState label="Cargando solicitudes…" />
+                ) : solicitudesBajaError ? (
+                  <div className="text-sm text-destructive">
+                    {solicitudesBajaError}
+                  </div>
+                ) : solicitudesBaja.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No hay solicitudes de baja registradas para este alumno.
+                  </p>
+                ) : (
+                  <div className="space-y-4">
+                    {solicitudesBaja.map((sol) => {
+                      const estado =
+                        sol.estado ?? EstadoSolicitudBaja.PENDIENTE;
+                      const revisionEstado =
+                        sol.estadoRevisionAdministrativa ??
+                        EstadoRevisionAdministrativa.PENDIENTE;
+                      const observacionRevision =
+                        sol.observacionRevisionAdministrativa?.trim() || null;
+                      const puedeResolver =
+                        puedeDecidirBaja &&
+                        estado === EstadoSolicitudBaja.PENDIENTE &&
+                        revisionEstado !== EstadoRevisionAdministrativa.PENDIENTE;
+
+                      return (
+                        <div
+                          key={sol.id}
+                          className="rounded-lg border border-border/60 p-4"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <Badge variant={estadoSolicitudVariant[estado]}>
+                                {estadoSolicitudLabels[estado]}
+                              </Badge>
+                              <Badge
+                                variant={
+                                  revisionAdministrativaVariant[revisionEstado]
+                                }
+                              >
+                                {revisionAdministrativaLabels[revisionEstado]}
+                              </Badge>
+                              <Badge variant="outline">Solicitud #{sol.id}</Badge>
+                            </div>
+                            {sol.matriculaId && (
+                              <div className="text-xs text-muted-foreground">
+                                Matrícula #{sol.matriculaId}
+                              </div>
+                            )}
+                          </div>
+
+                          <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+                            <div className="whitespace-pre-line">
+                              {sol.motivo?.trim() || "—"}
+                            </div>
+                            {observacionRevision && (
+                              <div className="rounded-md bg-muted/60 p-3 text-xs text-foreground">
+                                <span className="font-medium">
+                                  Detalle de administración:
+                                </span>{" "}
+                                <span className="whitespace-pre-line">
+                                  {observacionRevision}
+                                </span>
+                              </div>
+                            )}
+                            <div className="grid gap-2 text-xs sm:grid-cols-2">
+                              <div>
+                                <span className="text-muted-foreground">
+                                  Revisión administrativa:
+                                </span>{" "}
+                                {revisionEstado ===
+                                EstadoRevisionAdministrativa.PENDIENTE
+                                  ? "Pendiente"
+                                  : formatDateTime(
+                                      sol.fechaRevisionAdministrativa,
+                                    )}
+                              </div>
+                              <div>
+                                <span className="text-muted-foreground">
+                                  Decisión final:
+                                </span>{" "}
+                                {estado === EstadoSolicitudBaja.PENDIENTE
+                                  ? "Pendiente"
+                                  : formatDateTime(sol.fechaDecision)}
+                              </div>
+                              {sol.revisadoAdministrativamentePorPersonaId && (
+                                <div>
+                                  <span className="text-muted-foreground">
+                                    Revisó Adm.:
+                                  </span>{" "}
+                                  #{sol.revisadoAdministrativamentePorPersonaId}
+                                </div>
+                              )}
+                              {sol.decididoPorPersonaId && (
+                                <div>
+                                  <span className="text-muted-foreground">
+                                    Decidió Dirección:
+                                  </span>{" "}
+                                  #{sol.decididoPorPersonaId}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+
+                          {puedeResolver && (
+                            <div className="mt-4 flex flex-wrap gap-2">
+                              <Button
+                                size="sm"
+                                onClick={() => handleAceptarSolicitud(sol)}
+                                disabled={
+                                  processingDecisionSolicitudId === sol.id
+                                }
+                              >
+                                Aceptar baja
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="destructive"
+                                onClick={() => handleRechazarSolicitud(sol)}
+                                disabled={
+                                  processingDecisionSolicitudId === sol.id
+                                }
+                              >
+                                Rechazar
+                              </Button>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </CardContent>
             </Card>
+          )}
 
-            {/* Familia */}
-            <Card className="md:col-span-2">
+          {/* Familia */}
+          <Card className="md:col-span-2">
               <CardHeader className="pb-3">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>

--- a/frontend-ecep/src/services/api/modules/vidaescolar/matriculas.ts
+++ b/frontend-ecep/src/services/api/modules/vidaescolar/matriculas.ts
@@ -22,6 +22,10 @@ export const solicitudesBaja = {
   list: () => http.get<DTO.SolicitudBajaAlumnoDTO[]>("/api/bajas"),
   create: (body: DTO.SolicitudBajaAlumnoCreateDTO) =>
     http.post<number>("/api/bajas", body),
+  review: (
+    id: number,
+    body: DTO.SolicitudBajaAlumnoRevisionAdministrativaDTO,
+  ) => http.post<void>(`/api/bajas/${id}/revision-administrativa`, body),
   approve: (id: number, body: DTO.SolicitudBajaAlumnoDecisionDTO) =>
     http.post<void>(`/api/bajas/${id}/aprobar`, body),
   reject: (id: number, body: DTO.SolicitudBajaAlumnoRechazoDTO) =>

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -97,6 +97,12 @@ export enum EstadoSolicitudBaja {
   RECHAZADA = "RECHAZADA",
 }
 
+export enum EstadoRevisionAdministrativa {
+  PENDIENTE = "PENDIENTE",
+  CONFIRMADA = "CONFIRMADA",
+  DEUDAS_INFORMADAS = "DEUDAS_INFORMADAS",
+}
+
 export enum RolSeccion {
   MAESTRO_TITULAR = "MAESTRO_TITULAR",
   SUPLENTE = "SUPLENTE",
@@ -909,9 +915,13 @@ export interface SolicitudBajaAlumnoDTO {
   matriculaId?: number;
   alumnoId?: number;
   estado?: EstadoSolicitudBaja;
+  estadoRevisionAdministrativa?: EstadoRevisionAdministrativa;
   motivo?: string;
   motivoRechazo?: string;
+  fechaRevisionAdministrativa?: ISODateTime;
   fechaDecision?: ISODateTime;
+  revisadoAdministrativamentePorPersonaId?: number;
+  observacionRevisionAdministrativa?: string;
   decididoPorPersonaId?: number;
   alumnoNombre?: string;
   alumnoApellido?: string;
@@ -926,6 +936,12 @@ export interface SolicitudBajaAlumnoDecisionDTO {
 export interface SolicitudBajaAlumnoRechazoDTO
   extends SolicitudBajaAlumnoDecisionDTO {
   motivoRechazo: string;
+}
+
+export interface SolicitudBajaAlumnoRevisionAdministrativaDTO {
+  estadoRevisionAdministrativa: EstadoRevisionAdministrativa;
+  revisadoPorPersonaId: number;
+  observacionRevisionAdministrativa?: string;
 }
 
 export interface TrimestreCreateDTO {


### PR DESCRIPTION
## Summary
- introduce an administrative review state and endpoint for solicitudes de baja so that administración debe confirmar o informar deudas antes de la decisión final
- extend the shared API types and client helpers to enviar la nueva revisión administrativa
- update las vistas de bajas del dashboard y del perfil del alumno para eliminar la confirmación manual inicial, mostrar el resultado administrativo y permitir que Dirección resuelva la baja

## Testing
- npm run lint *(fails: Next.js CLI is not installed in the execution environment)*
- ./mvnw -q test *(fails: Maven distribution cannot be downloaded without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcfd316308327b2dba6be12d40954