### PR TITLE
Fix alumno bajas fetch params and missing checkbox import

### DIFF
--- a/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/[id]/page.tsx
@@ -17,6 +17,7 @@ import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Step3 as HogarForm } from "@/app/postulacion/Step3";
 import { Step4 as SaludForm } from "@/app/postulacion/Step4";
 import type { PostulacionFormData } from "@/app/postulacion/types";
@@ -634,7 +635,9 @@ export default function AlumnoPerfilPage() {
     setLoadingSolicitudesBaja(true);
     setSolicitudesBajaError(null);
     try {
-      const { data } = await vidaEscolar.solicitudesBaja.list();
+      const safeAlumnoId = Number.isFinite(alumnoId) ? alumnoId : undefined;
+      const params = safeAlumnoId ? { alumnoId: safeAlumnoId } : undefined;
+      const { data } = await vidaEscolar.solicitudesBaja.list(params);
       const all = (data ?? []) as SolicitudBajaAlumnoDTO[];
       const filtered = all.filter((sol) => {
         const id = sol.matriculaId ?? null;
@@ -649,7 +652,7 @@ export default function AlumnoPerfilPage() {
     } finally {
       setLoadingSolicitudesBaja(false);
     }
-  }, [canManageProfile, matriculaIds]);
+  }, [alumnoId, canManageProfile, matriculaIds]);
 
   useEffect(() => {
     if (!canManageProfile) {

--- a/frontend-ecep/src/services/api/modules/vidaescolar/matriculas.ts
+++ b/frontend-ecep/src/services/api/modules/vidaescolar/matriculas.ts
@@ -18,8 +18,14 @@ export const matriculaSeccionHistorial = {
     http.put<void>(`/api/matriculas/historial/${id}`, body),
 };
 
+type SolicitudesBajaListParams = {
+  alumnoId?: number;
+  matriculaId?: number | number[];
+};
+
 export const solicitudesBaja = {
-  list: () => http.get<DTO.SolicitudBajaAlumnoDTO[]>("/api/bajas"),
+  list: (params?: SolicitudesBajaListParams) =>
+    http.get<DTO.SolicitudBajaAlumnoDTO[]>("/api/bajas", { params }),
   create: (body: DTO.SolicitudBajaAlumnoCreateDTO) =>
     http.post<number>("/api/bajas", body),
   review: (


### PR DESCRIPTION
## Summary
- add optional query parameters to the solicitudes de baja API client
- ensure the alumno detail page fetches bajas filtered by the current alumno and import the Checkbox component

## Testing
- pnpm lint *(fails: next binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd5bd58c083278ad344b6dba1de9f