### PR TITLE
Add migration for estado revision column on bajas alumnos

### DIFF
--- a/backend-ecep/src/main/resources/db/migration/V20250220__add_estado_revision_administrativa_to_bajas_alumnos.sql
+++ b/backend-ecep/src/main/resources/db/migration/V20250220__add_estado_revision_administrativa_to_bajas_alumnos.sql
@@ -1,0 +1,7 @@
+ALTER TABLE bajas_alumnos
+    ADD COLUMN IF NOT EXISTS estado_revision_administrativa VARCHAR(50) NOT NULL DEFAULT 'PENDIENTE';
+
+-- Ensure existing rows have a valid value when the column already existed but allowed nulls
+UPDATE bajas_alumnos
+SET estado_revision_administrativa = 'PENDIENTE'
+WHERE estado_revision_administrativa IS NULL;


### PR DESCRIPTION
## Summary
- add a Flyway migration that ensures the `estado_revision_administrativa` column exists on `bajas_alumnos`
- default existing and future rows to `PENDIENTE` so the enum can be read without errors

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to fetch dependencies from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd9fb396c83278b23d57f6cae4d0e