### PR TITLE
Show alumnus history with egresados

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AlumnoHistorialService.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/application/AlumnoHistorialService.java
@@ -1,0 +1,213 @@
+package edu.ecep.base_app.identidad.application;
+
+import edu.ecep.base_app.identidad.domain.Alumno;
+import edu.ecep.base_app.identidad.domain.enums.EstadoHistorialAlumno;
+import edu.ecep.base_app.identidad.presentation.dto.AlumnoHistorialDTO;
+import edu.ecep.base_app.shared.domain.enums.NivelAcademico;
+import edu.ecep.base_app.vidaescolar.domain.Matricula;
+import edu.ecep.base_app.vidaescolar.domain.MatriculaSeccionHistorial;
+import edu.ecep.base_app.vidaescolar.domain.SolicitudBajaAlumno;
+import edu.ecep.base_app.vidaescolar.domain.enums.EstadoSolicitudBaja;
+import edu.ecep.base_app.vidaescolar.infrastructure.mapper.SolicitudBajaAlumnoMapper;
+import edu.ecep.base_app.vidaescolar.infrastructure.persistence.MatriculaSeccionHistorialRepository;
+import edu.ecep.base_app.vidaescolar.infrastructure.persistence.SolicitudBajaAlumnoRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class AlumnoHistorialService {
+
+    private static final String GRADO_FINAL_PRIMARIO = "6°";
+
+    private final SolicitudBajaAlumnoRepository solicitudBajaAlumnoRepository;
+    private final SolicitudBajaAlumnoMapper solicitudBajaAlumnoMapper;
+    private final MatriculaSeccionHistorialRepository historialRepository;
+
+    @Transactional(Transactional.TxType.SUPPORTS)
+    public List<AlumnoHistorialDTO> findHistorialCompleto() {
+        LocalDate hoy = LocalDate.now();
+        List<AlumnoHistorialDTO> resultado = new ArrayList<>();
+        Set<Long> alumnosProcesados = new HashSet<>();
+
+        // 1) Bajas aprobadas
+        List<SolicitudBajaAlumno> bajas =
+                solicitudBajaAlumnoRepository.findAllByEstadoOrderByFechaDecisionDesc(EstadoSolicitudBaja.APROBADA);
+        for (SolicitudBajaAlumno solicitud : bajas) {
+            AlumnoHistorialDTO dto = mapDesdeSolicitudBaja(solicitud);
+            resultado.add(dto);
+            if (dto.getAlumnoId() != null) {
+                alumnosProcesados.add(dto.getAlumnoId());
+            }
+        }
+
+        // 2) Egresados (terminados) de 6° grado
+        Map<Long, MatriculaSeccionHistorial> ultimoHistorialPorAlumno = new HashMap<>();
+        Map<Long, Boolean> matriculaTieneAsignacionVigente = new HashMap<>();
+
+        List<MatriculaSeccionHistorial> historialesFinales =
+                historialRepository.findByNivelAndGradoFinalizados(NivelAcademico.PRIMARIO, GRADO_FINAL_PRIMARIO);
+
+        for (MatriculaSeccionHistorial historial : historialesFinales) {
+            Matricula matricula = historial.getMatricula();
+            if (matricula == null) {
+                continue;
+            }
+            Alumno alumno = matricula.getAlumno();
+            if (alumno == null) {
+                continue;
+            }
+            Long alumnoId = alumno.getId();
+            if (alumnoId == null || alumnosProcesados.contains(alumnoId)) {
+                continue;
+            }
+
+            Long matriculaId = matricula.getId();
+            if (matriculaId == null) {
+                continue;
+            }
+
+            boolean tieneVigente = matriculaTieneAsignacionVigente.computeIfAbsent(
+                    matriculaId,
+                    id -> !historialRepository.findVigente(id, hoy).isEmpty());
+            if (tieneVigente) {
+                // Alumno aún tiene sección vigente: no se considera egresado
+                continue;
+            }
+
+            ultimoHistorialPorAlumno.merge(
+                    alumnoId,
+                    historial,
+                    (existente, candidato) ->
+                            fechaHistorial(candidato).isAfter(fechaHistorial(existente)) ? candidato : existente);
+        }
+
+        for (MatriculaSeccionHistorial historial : ultimoHistorialPorAlumno.values()) {
+            AlumnoHistorialDTO dto = mapDesdeHistorialFinal(historial);
+            resultado.add(dto);
+            if (dto.getAlumnoId() != null) {
+                alumnosProcesados.add(dto.getAlumnoId());
+            }
+        }
+
+        resultado.sort(Comparator
+                .comparing(AlumnoHistorialDTO::getFechaRegistro,
+                        Comparator.nullsLast(Comparator.reverseOrder()))
+                .thenComparing(AlumnoHistorialDTO::getAlumnoApellido, Comparator.nullsLast(String::compareToIgnoreCase))
+                .thenComparing(AlumnoHistorialDTO::getAlumnoNombre, Comparator.nullsLast(String::compareToIgnoreCase)));
+
+        return resultado;
+    }
+
+    private AlumnoHistorialDTO mapDesdeSolicitudBaja(SolicitudBajaAlumno solicitud) {
+        Matricula matricula = solicitud.getMatricula();
+        Alumno alumno = matricula != null ? matricula.getAlumno() : null;
+        var persona = alumno != null ? alumno.getPersona() : null;
+
+        AlumnoHistorialDTO dto = new AlumnoHistorialDTO();
+        dto.setAlumnoId(alumno != null ? alumno.getId() : null);
+        dto.setMatriculaId(matricula != null ? matricula.getId() : null);
+        dto.setSolicitudBajaId(solicitud.getId());
+        dto.setAlumnoNombre(persona != null ? persona.getNombre() : null);
+        dto.setAlumnoApellido(persona != null ? persona.getApellido() : null);
+        dto.setAlumnoDni(persona != null ? persona.getDni() : null);
+        dto.setEstado(EstadoHistorialAlumno.BAJA);
+        dto.setDetalle(normalize(solicitud.getMotivo()));
+        dto.setFechaRegistro(solicitud.getFechaDecision());
+        dto.setSeccionNombre(resolveSeccionNombre(matricula, solicitud.getFechaDecision()));
+        dto.setPeriodoEscolarAnio(
+                matricula != null && matricula.getPeriodoEscolar() != null
+                        ? matricula.getPeriodoEscolar().getAnio()
+                        : null);
+        dto.setSolicitudBaja(solicitudBajaAlumnoMapper.toDto(solicitud));
+        return dto;
+    }
+
+    private AlumnoHistorialDTO mapDesdeHistorialFinal(MatriculaSeccionHistorial historial) {
+        Matricula matricula = historial.getMatricula();
+        Alumno alumno = matricula != null ? matricula.getAlumno() : null;
+        var persona = alumno != null ? alumno.getPersona() : null;
+
+        LocalDate fecha = fechaHistorial(historial);
+        OffsetDateTime fechaRegistro = fecha != null
+                ? fecha.atStartOfDay(ZoneId.systemDefault()).toOffsetDateTime()
+                : null;
+
+        AlumnoHistorialDTO dto = new AlumnoHistorialDTO();
+        dto.setAlumnoId(alumno != null ? alumno.getId() : null);
+        dto.setMatriculaId(matricula != null ? matricula.getId() : null);
+        dto.setSolicitudBajaId(null);
+        dto.setAlumnoNombre(persona != null ? persona.getNombre() : null);
+        dto.setAlumnoApellido(persona != null ? persona.getApellido() : null);
+        dto.setAlumnoDni(persona != null ? persona.getDni() : null);
+        dto.setEstado(EstadoHistorialAlumno.TERMINADO);
+        dto.setDetalle("Finalizó " + buildSeccionNombre(historial));
+        dto.setFechaRegistro(fechaRegistro);
+        dto.setSeccionNombre(buildSeccionNombre(historial));
+        dto.setPeriodoEscolarAnio(
+                matricula != null && matricula.getPeriodoEscolar() != null
+                        ? matricula.getPeriodoEscolar().getAnio()
+                        : null);
+        dto.setSolicitudBaja(null);
+        return dto;
+    }
+
+    private LocalDate fechaHistorial(MatriculaSeccionHistorial historial) {
+        LocalDate hasta = historial.getHasta();
+        if (hasta != null) {
+            return hasta;
+        }
+        return historial.getDesde();
+    }
+
+    private String buildSeccionNombre(MatriculaSeccionHistorial historial) {
+        if (historial == null || historial.getSeccion() == null) {
+            return null;
+        }
+        var seccion = historial.getSeccion();
+        StringBuilder sb = new StringBuilder();
+        if (seccion.getGradoSala() != null) {
+            sb.append(seccion.getGradoSala());
+        }
+        if (seccion.getDivision() != null && !seccion.getDivision().isBlank()) {
+            if (sb.length() > 0) {
+                sb.append(" ");
+            }
+            sb.append(seccion.getDivision());
+        }
+        return sb.length() == 0 ? null : sb.toString();
+    }
+
+    private String resolveSeccionNombre(Matricula matricula, OffsetDateTime fechaDecision) {
+        if (matricula == null || matricula.getId() == null) {
+            return null;
+        }
+        LocalDate fecha = fechaDecision != null ? fechaDecision.toLocalDate() : LocalDate.now();
+        List<MatriculaSeccionHistorial> vigentes = historialRepository.findVigente(matricula.getId(), fecha);
+        if (vigentes.isEmpty()) {
+            return null;
+        }
+        return buildSeccionNombre(vigentes.get(0));
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}
+

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/enums/EstadoHistorialAlumno.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/domain/enums/EstadoHistorialAlumno.java
@@ -1,0 +1,7 @@
+package edu.ecep.base_app.identidad.domain.enums;
+
+public enum EstadoHistorialAlumno {
+    BAJA,
+    TERMINADO
+}
+

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoHistorialDTO.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/dto/AlumnoHistorialDTO.java
@@ -1,0 +1,30 @@
+package edu.ecep.base_app.identidad.presentation.dto;
+
+import edu.ecep.base_app.identidad.domain.enums.EstadoHistorialAlumno;
+import edu.ecep.base_app.vidaescolar.presentation.dto.SolicitudBajaAlumnoDTO;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlumnoHistorialDTO {
+    Long alumnoId;
+    Long matriculaId;
+    Long solicitudBajaId;
+    String alumnoNombre;
+    String alumnoApellido;
+    String alumnoDni;
+    @NotNull
+    EstadoHistorialAlumno estado;
+    String detalle;
+    OffsetDateTime fechaRegistro;
+    String seccionNombre;
+    Integer periodoEscolarAnio;
+    SolicitudBajaAlumnoDTO solicitudBaja;
+}
+

--- a/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/AlumnoController.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/identidad/presentation/rest/AlumnoController.java
@@ -1,7 +1,9 @@
 package edu.ecep.base_app.identidad.presentation.rest;
 
+import edu.ecep.base_app.identidad.application.AlumnoHistorialService;
 import edu.ecep.base_app.identidad.application.AlumnoService;
 import edu.ecep.base_app.identidad.presentation.dto.AlumnoDTO;
+import edu.ecep.base_app.identidad.presentation.dto.AlumnoHistorialDTO;
 import edu.ecep.base_app.shared.web.PageResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -28,10 +30,16 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class AlumnoController {
     private final AlumnoService service;
+    private final AlumnoHistorialService historialService;
 
     @GetMapping
     public List<AlumnoDTO> list() {
         return service.findAll();
+    }
+
+    @GetMapping("/historial")
+    public List<AlumnoHistorialDTO> historial() {
+        return historialService.findHistorialCompleto();
     }
 
     @GetMapping("/paginated")

--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/infrastructure/persistence/MatriculaSeccionHistorialRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/infrastructure/persistence/MatriculaSeccionHistorialRepository.java
@@ -1,5 +1,6 @@
 package edu.ecep.base_app.vidaescolar.infrastructure.persistence;
 
+import edu.ecep.base_app.shared.domain.enums.NivelAcademico;
 import edu.ecep.base_app.vidaescolar.domain.MatriculaSeccionHistorial;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -32,4 +33,21 @@ public interface MatriculaSeccionHistorialRepository extends JpaRepository<Matri
          """)
     List<MatriculaSeccionHistorial> findActivosBySeccionOnDate(@Param("seccionId") Long seccionId,
                                                                @Param("fecha") LocalDate fecha);
+
+    @Query("""
+            select h
+            from MatriculaSeccionHistorial h
+            join fetch h.matricula m
+            join fetch m.alumno a
+            join fetch a.persona p
+            join fetch h.seccion s
+            where h.activo = true
+              and m.activo = true
+              and s.nivel = :nivel
+              and s.gradoSala = :gradoSala
+              and h.hasta is not null
+            """)
+    List<MatriculaSeccionHistorial> findByNivelAndGradoFinalizados(
+            @Param("nivel") NivelAcademico nivel,
+            @Param("gradoSala") String gradoSala);
 }

--- a/frontend-ecep/src/app/dashboard/alumnos/page.tsx
+++ b/frontend-ecep/src/app/dashboard/alumnos/page.tsx
@@ -134,13 +134,13 @@ export default function AlumnosIndexPage() {
   const [errorSolicitudesBaja, setErrorSolicitudesBaja] = useState<string | null>(
     null,
   );
-  const [historialBajas, setHistorialBajas] = useState<
-    DTO.SolicitudBajaAlumnoDTO[]
+  const [historialAlumnos, setHistorialAlumnos] = useState<
+    DTO.AlumnoHistorialDTO[]
   >([]);
-  const [loadingHistorialBajas, setLoadingHistorialBajas] = useState(false);
-  const [errorHistorialBajas, setErrorHistorialBajas] = useState<string | null>(
-    null,
-  );
+  const [loadingHistorialAlumnos, setLoadingHistorialAlumnos] = useState(false);
+  const [errorHistorialAlumnos, setErrorHistorialAlumnos] = useState<
+    string | null
+  >(null);
   const [processingSolicitudId, setProcessingSolicitudId] = useState<number | null>(
     null,
   );
@@ -232,17 +232,19 @@ export default function AlumnosIndexPage() {
     }
   }, []);
 
-  const fetchHistorialBajas = useCallback(async () => {
-    setLoadingHistorialBajas(true);
-    setErrorHistorialBajas(null);
+  const fetchHistorialAlumnos = useCallback(async () => {
+    setLoadingHistorialAlumnos(true);
+    setErrorHistorialAlumnos(null);
     try {
-      const { data } = await vidaEscolar.solicitudesBaja.historial();
-      setHistorialBajas(data ?? []);
+      const { data } = await identidad.alumnos.historial();
+      setHistorialAlumnos(data ?? []);
     } catch (error) {
       console.error(error);
-      setErrorHistorialBajas("No se pudo cargar el historial de bajas");
+      setErrorHistorialAlumnos(
+        "No se pudo cargar el historial de alumnos egresados",
+      );
     } finally {
-      setLoadingHistorialBajas(false);
+      setLoadingHistorialAlumnos(false);
     }
   }, []);
 
@@ -256,11 +258,15 @@ export default function AlumnosIndexPage() {
 
   useEffect(() => {
     if (canViewAspirantesHistorial || canManageBajas) {
-      fetchHistorialBajas();
+      fetchHistorialAlumnos();
     } else {
-      setHistorialBajas([]);
+      setHistorialAlumnos([]);
     }
-  }, [canManageBajas, canViewAspirantesHistorial, fetchHistorialBajas]);
+  }, [
+    canManageBajas,
+    canViewAspirantesHistorial,
+    fetchHistorialAlumnos,
+  ]);
 
   const loadMatriculas = useCallback(
     async (signal?: { cancelled: boolean }) => {
@@ -348,6 +354,19 @@ export default function AlumnosIndexPage() {
     [DTO.EstadoSolicitudBaja.PENDIENTE]: "secondary",
     [DTO.EstadoSolicitudBaja.APROBADA]: "default",
     [DTO.EstadoSolicitudBaja.RECHAZADA]: "destructive",
+  };
+
+  const historialEstadoLabels: Record<DTO.EstadoHistorialAlumno, string> = {
+    [DTO.EstadoHistorialAlumno.BAJA]: "Baja",
+    [DTO.EstadoHistorialAlumno.TERMINADO]: "Finalización",
+  };
+
+  const historialEstadoVariant: Record<
+    DTO.EstadoHistorialAlumno,
+    "default" | "secondary" | "destructive"
+  > = {
+    [DTO.EstadoHistorialAlumno.BAJA]: "destructive",
+    [DTO.EstadoHistorialAlumno.TERMINADO]: "secondary",
   };
 
   const revisionLabels: Record<DTO.EstadoRevisionAdministrativa, string> = {
@@ -448,7 +467,7 @@ export default function AlumnosIndexPage() {
         decididoPorPersonaId: personaActualId!,
       });
       toast.success("Baja aceptada correctamente");
-      await Promise.all([fetchSolicitudesBaja(), fetchHistorialBajas()]);
+      await Promise.all([fetchSolicitudesBaja(), fetchHistorialAlumnos()]);
     } catch (error) {
       console.error(error);
       toast.error("No se pudo aceptar la baja");
@@ -487,7 +506,7 @@ export default function AlumnosIndexPage() {
         motivoRechazo: normalized,
       });
       toast.success("Solicitud rechazada");
-      await Promise.all([fetchSolicitudesBaja(), fetchHistorialBajas()]);
+      await Promise.all([fetchSolicitudesBaja(), fetchHistorialAlumnos()]);
     } catch (error) {
       console.error(error);
       toast.error("No se pudo rechazar la solicitud");
@@ -588,7 +607,7 @@ export default function AlumnosIndexPage() {
       toast.success("Solicitud de baja registrada correctamente");
       resetCrearBajaForm();
       setCrearBajaOpen(false);
-      await Promise.all([fetchSolicitudesBaja(), fetchHistorialBajas()]);
+      await Promise.all([fetchSolicitudesBaja(), fetchHistorialAlumnos()]);
     } catch (error) {
       console.error(error);
       toast.error("No se pudo registrar la solicitud de baja");
@@ -1303,29 +1322,30 @@ export default function AlumnosIndexPage() {
                 <Card>
                   <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div>
-                      <CardTitle>Historial de bajas</CardTitle>
+                      <CardTitle>Historial de alumnos</CardTitle>
                       <CardDescription>
-                        Registro de bajas aceptadas con detalle de motivos y fechas.
+                        Registro de estudiantes que egresaron o finalizaron su
+                        paso por la institución.
                       </CardDescription>
                     </div>
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={fetchHistorialBajas}
+                      onClick={fetchHistorialAlumnos}
                     >
                       <TimerReset className="mr-2 h-4 w-4" /> Actualizar
                     </Button>
                   </CardHeader>
                   <CardContent>
-                    {loadingHistorialBajas ? (
+                    {loadingHistorialAlumnos ? (
                       <LoadingState label="Cargando historial…" />
-                    ) : errorHistorialBajas ? (
+                    ) : errorHistorialAlumnos ? (
                       <div className="text-sm text-red-600">
-                        {errorHistorialBajas}
+                        {errorHistorialAlumnos}
                       </div>
-                    ) : historialBajas.length === 0 ? (
+                    ) : historialAlumnos.length === 0 ? (
                       <div className="py-8 text-center text-sm text-muted-foreground">
-                        Todavía no hay bajas confirmadas.
+                        Todavía no hay alumnos en el historial.
                       </div>
                     ) : (
                       <div className="overflow-x-auto">
@@ -1333,23 +1353,40 @@ export default function AlumnosIndexPage() {
                           <thead>
                             <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
                               <th className="py-2 pr-4 font-medium">Alumno</th>
-                              <th className="py-2 pr-4 font-medium">Motivo</th>
-                              <th className="py-2 pr-4 font-medium">Fecha decisión</th>
-                              <th className="py-2 pr-4 font-medium">Descarga</th>
+                              <th className="py-2 pr-4 font-medium">Detalle</th>
+                              <th className="py-2 pr-4 font-medium">Última sección</th>
+                              <th className="py-2 pr-4 font-medium">Periodo</th>
+                              <th className="py-2 pr-4 font-medium">Fecha</th>
+                              <th className="py-2 pr-4 font-medium">Acciones</th>
                             </tr>
                           </thead>
                           <tbody>
-                            {historialBajas.map((sol) => {
+                            {historialAlumnos.map((entry) => {
                               const estado =
-                                sol.estado ?? DTO.EstadoSolicitudBaja.APROBADA;
+                                entry.estado ??
+                                DTO.EstadoHistorialAlumno.TERMINADO;
                               const nombre =
-                                [sol.alumnoApellido, sol.alumnoNombre]
+                                [entry.alumnoApellido, entry.alumnoNombre]
                                   .filter(Boolean)
                                   .join(", ") ||
                                 "Alumno sin datos";
+                              const dniLabel = entry.alumnoDni
+                                ? `DNI ${entry.alumnoDni}`
+                                : "Sin documento";
+                              const detalle = entry.detalle ?? "—";
+                              const seccion = entry.seccionNombre ?? "—";
+                              const periodo = entry.periodoEscolarAnio
+                                ? `Período ${entry.periodoEscolarAnio}`
+                                : "—";
+                              const key =
+                                entry.solicitudBajaId != null
+                                  ? `baja-${entry.solicitudBajaId}`
+                                  : `terminado-${entry.alumnoId ?? ""}-${
+                                      entry.matriculaId ?? ""
+                                    }-${entry.fechaRegistro ?? ""}`;
                               return (
                                 <tr
-                                  key={sol.id}
+                                  key={key}
                                   className="border-t border-border/60 align-top"
                                 >
                                   <td className="py-3 pr-4">
@@ -1357,29 +1394,43 @@ export default function AlumnosIndexPage() {
                                       {nombre}
                                     </div>
                                     <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                                      <span>
-                                        {sol.alumnoDni ? `DNI ${sol.alumnoDni}` : "Sin documento"}
-                                      </span>
-                                      <Badge variant={estadoVariant[estado]}>
-                                        {estadoLabels[estado]}
+                                      <span>{dniLabel}</span>
+                                      <Badge variant={historialEstadoVariant[estado]}>
+                                        {historialEstadoLabels[estado]}
                                       </Badge>
                                     </div>
                                   </td>
                                   <td className="py-3 pr-4 max-w-md text-sm text-muted-foreground whitespace-pre-line">
-                                    {sol.motivo || "—"}
+                                    {detalle}
                                   </td>
                                   <td className="py-3 pr-4 text-sm text-muted-foreground">
-                                    {formatDateTime(sol.fechaDecision)}
+                                    {seccion}
                                   </td>
                                   <td className="py-3 pr-4">
-                                    <Button
-                                      size="sm"
-                                      variant="outline"
-                                      onClick={() => handleDownloadSolicitud(sol)}
-                                    >
-                                      <Download className="mr-2 h-3 w-3" />
-                                      Descargar
-                                    </Button>
+                                    {periodo}
+                                  </td>
+                                  <td className="py-3 pr-4 text-sm text-muted-foreground">
+                                    {formatDateTime(entry.fechaRegistro)}
+                                  </td>
+                                  <td className="py-3 pr-4">
+                                    {entry.solicitudBaja ? (
+                                      <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() =>
+                                          handleDownloadSolicitud(
+                                            entry.solicitudBaja!,
+                                          )
+                                        }
+                                      >
+                                        <Download className="mr-2 h-3 w-3" />
+                                        Descargar
+                                      </Button>
+                                    ) : (
+                                      <span className="text-xs text-muted-foreground">
+                                        —
+                                      </span>
+                                    )}
                                   </td>
                                 </tr>
                               );

--- a/frontend-ecep/src/services/api/modules/identidad/personas.ts
+++ b/frontend-ecep/src/services/api/modules/identidad/personas.ts
@@ -4,6 +4,7 @@ import type { SpringPage } from "@/types/pagination";
 
 export const alumnos = {
   list: () => http.get<DTO.AlumnoDTO[]>("/api/alumnos"),
+  historial: () => http.get<DTO.AlumnoHistorialDTO[]>("/api/alumnos/historial"),
   listPaged: (params?: {
     page?: number;
     size?: number;

--- a/frontend-ecep/src/types/api-generated.ts
+++ b/frontend-ecep/src/types/api-generated.ts
@@ -103,6 +103,11 @@ export enum EstadoRevisionAdministrativa {
   DEUDAS_INFORMADAS = "DEUDAS_INFORMADAS",
 }
 
+export enum EstadoHistorialAlumno {
+  BAJA = "BAJA",
+  TERMINADO = "TERMINADO",
+}
+
 export enum RolSeccion {
   MAESTRO_TITULAR = "MAESTRO_TITULAR",
   SUPLENTE = "SUPLENTE",
@@ -202,6 +207,21 @@ export interface AlumnoDTO {
   seccionActualId?: number;
   seccionActualNombre?: string;
   seccionActualTurno?: string;
+}
+
+export interface AlumnoHistorialDTO {
+  alumnoId?: number;
+  matriculaId?: number;
+  solicitudBajaId?: number;
+  alumnoNombre?: string;
+  alumnoApellido?: string;
+  alumnoDni?: string;
+  estado: EstadoHistorialAlumno;
+  detalle?: string;
+  fechaRegistro?: ISODateTime;
+  seccionNombre?: string;
+  periodoEscolarAnio?: number;
+  solicitudBaja?: SolicitudBajaAlumnoDTO | null;
 }
 
 export interface AlumnoFamiliarCreateDTO {


### PR DESCRIPTION
## Summary
- add a dedicated alumno historial service and expose `/api/alumnos/historial`
- mark alumnos that finished sexto grado as terminados while keeping bajas information available
- update the alumnos dashboard tab and API client to show the combined historial

## Testing
- ./mvnw -q -DskipTests compile *(fails: repository download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfda55dcb88327a7f3dc3d4d47a6e5