### PR TITLE
Limit active students list to current enrollments

### DIFF
--- a/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/infrastructure/persistence/MatriculaSeccionHistorialRepository.java
+++ b/backend-ecep/src/main/java/edu/ecep/base_app/vidaescolar/infrastructure/persistence/MatriculaSeccionHistorialRepository.java
@@ -16,6 +16,9 @@ public interface MatriculaSeccionHistorialRepository extends JpaRepository<Matri
         select h from MatriculaSeccionHistorial h
         join fetch h.seccion s
         where h.matricula.id = :matriculaId
+          and h.activo = true
+          and h.matricula.activo = true
+          and s.activo = true
           and h.desde <= :fecha
           and (h.hasta is null or h.hasta >= :fecha)
     """)


### PR DESCRIPTION
## Summary
- restrict the paginated alumno query to enrollments that belong to the currently active school period and have an active section assignment
- ignore inactive matriculas, sections, or historical records when resolving the current section for each alumno
- ensure matricula-section lookups only return active records for the current period

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00e8c56e48327bf9f065b294276b9